### PR TITLE
Fix wrong name for yaml package in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 transformers
 rich
 loguru
-yaml
+pyyaml
 openai


### PR DESCRIPTION
As of now, yaml package  in requirements.txt is called "yaml" (probably it was auto-collected from the includes?).
This breaks `pip install -r requirements.txt` part of the instruction, as pip package for yaml is called "pyyaml".

This PR changes "yaml" to "pyyaml" in requirements.txt.