### PR TITLE
Add the generated specs for linux-6.7

### DIFF
--- a/generated-specs/specs-6.7/correct-driver-spec/_ctl_fops#drivers_md_dm-ioctl.c:2152.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/_ctl_fops#drivers_md_dm-ioctl.c:2152.json
@@ -1,0 +1,130 @@
+{
+  "open": {
+    "filename": "/dev/mapper/control",
+    "fd_name": "fd_dm_ctl",
+    "spec": "openat$KGPT_dm_ctl(fd const[AT_FDCWD], file ptr[in, string[\"/dev/mapper/control\"]], flags const[O_RDWR], mode const[0]) fd_dm_ctl"
+  },
+  "resources": {
+    "fd_dm_ctl": {
+      "type": "fd",
+      "spec": "resource fd_dm_ctl[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/md/dm-ioctl.c:2152",
+  "ioctls": {
+    "DM_VERSION_CMD": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "DM_DEV_CREATE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "DM_DEV_REMOVE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "DM_DEV_SUSPEND": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "DM_DEV_STATUS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "DM_TABLE_CLEAR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "DM_DEV_ARM_POLL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "DM_DEV_RENAME": {
+      "arg": "ptr[in, dm_ioctl]",
+      "arg_name_in_usage": "param",
+      "arg_inference": null
+    },
+    "DM_DEV_WAIT": {
+      "arg": "ptr[in, dm_ioctl]",
+      "arg_name_in_usage": "param",
+      "arg_inference": null
+    },
+    "DM_TABLE_LOAD": {
+      "arg": "ptr[in, dm_ioctl]",
+      "arg_name_in_usage": "param",
+      "arg_inference": null
+    },
+    "DM_TABLE_DEPS": {
+      "arg": "ptr[in, dm_ioctl]",
+      "arg_name_in_usage": "param",
+      "arg_inference": null
+    },
+    "DM_TABLE_STATUS": {
+      "arg": "ptr[in, dm_ioctl]",
+      "arg_name_in_usage": "param",
+      "arg_inference": null
+    },
+    "DM_LIST_VERSIONS": {
+      "arg": "ptr[in,out, dm_ioctl]",
+      "arg_name_in_usage": "param",
+      "arg_inference": null
+    },
+    "DM_TARGET_MSG": {
+      "arg": "ptr[in, dm_ioctl]",
+      "arg_name_in_usage": "param",
+      "arg_inference": null
+    },
+    "DM_DEV_SET_GEOMETRY": {
+      "arg": "ptr[in, dm_ioctl]",
+      "arg_name_in_usage": "param",
+      "arg_inference": null
+    },
+    "DM_GET_TARGET_VERSION": {
+      "arg": "ptr[inout, dm_ioctl]",
+      "arg_name_in_usage": "param",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "dm_ioctl": "dm_ioctl {\n\tversion\tarray[int32, 3]\n\tdata_size\tint32\n\tdata_start\tint32\n\ttarget_count\tint32\n\topen_count\tint32\n\tflags\tint32\n\tevent_nr\tint32\n\tpadding\tint32\n\tdev\tint64\n\tname\tarray[int8, DM_NAME_LEN]\n\tuuid\tarray[int8, DM_UUID_LEN]\n\tdata\tarray[int8, 7]\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_dm_ctl": "openat$KGPT_dm_ctl(fd const[AT_FDCWD], file ptr[in, string[\"/dev/mapper/control\"]], flags const[O_RDWR], mode const[0]) fd_dm_ctl",
+    "ioctl$KGPT_DM_VERSION_CMD": "ioctl$KGPT_DM_VERSION_CMD(fd fd_dm_ctl, cmd const[DM_VERSION_CMD], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_DM_DEV_CREATE": "ioctl$KGPT_DM_DEV_CREATE(fd fd_dm_ctl, cmd const[DM_DEV_CREATE], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_DM_DEV_REMOVE": "ioctl$KGPT_DM_DEV_REMOVE(fd fd_dm_ctl, cmd const[DM_DEV_REMOVE], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_DM_DEV_SUSPEND": "ioctl$KGPT_DM_DEV_SUSPEND(fd fd_dm_ctl, cmd const[DM_DEV_SUSPEND], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_DM_DEV_STATUS": "ioctl$KGPT_DM_DEV_STATUS(fd fd_dm_ctl, cmd const[DM_DEV_STATUS], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_DM_TABLE_CLEAR": "ioctl$KGPT_DM_TABLE_CLEAR(fd fd_dm_ctl, cmd const[DM_TABLE_CLEAR], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_DM_DEV_ARM_POLL": "ioctl$KGPT_DM_DEV_ARM_POLL(fd fd_dm_ctl, cmd const[DM_DEV_ARM_POLL], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_DM_DEV_RENAME": "ioctl$KGPT_DM_DEV_RENAME(fd fd_dm_ctl, cmd const[DM_DEV_RENAME], arg ptr[in, dm_ioctl])",
+    "ioctl$KGPT_DM_DEV_WAIT": "ioctl$KGPT_DM_DEV_WAIT(fd fd_dm_ctl, cmd const[DM_DEV_WAIT], arg ptr[in, dm_ioctl])",
+    "ioctl$KGPT_DM_TABLE_LOAD": "ioctl$KGPT_DM_TABLE_LOAD(fd fd_dm_ctl, cmd const[DM_TABLE_LOAD], arg ptr[in, dm_ioctl])",
+    "ioctl$KGPT_DM_TABLE_DEPS": "ioctl$KGPT_DM_TABLE_DEPS(fd fd_dm_ctl, cmd const[DM_TABLE_DEPS], arg ptr[in, dm_ioctl])",
+    "ioctl$KGPT_DM_TABLE_STATUS": "ioctl$KGPT_DM_TABLE_STATUS(fd fd_dm_ctl, cmd const[DM_TABLE_STATUS], arg ptr[in, dm_ioctl])",
+    "ioctl$KGPT_DM_LIST_VERSIONS": "ioctl$KGPT_DM_LIST_VERSIONS(fd fd_dm_ctl, cmd const[DM_LIST_VERSIONS], arg ptr[inout, dm_ioctl])",
+    "ioctl$KGPT_DM_TARGET_MSG": "ioctl$KGPT_DM_TARGET_MSG(fd fd_dm_ctl, cmd const[DM_TARGET_MSG], arg ptr[in, dm_ioctl])",
+    "ioctl$KGPT_DM_DEV_SET_GEOMETRY": "ioctl$KGPT_DM_DEV_SET_GEOMETRY(fd fd_dm_ctl, cmd const[DM_DEV_SET_GEOMETRY], arg ptr[in, dm_ioctl])",
+    "ioctl$KGPT_DM_GET_TARGET_VERSION": "ioctl$KGPT_DM_GET_TARGET_VERSION(fd fd_dm_ctl, cmd const[DM_GET_TARGET_VERSION], arg ptr[inout, dm_ioctl])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_dm_ctl"
+  ],
+  "includes": [
+    "uapi/linux/dm-ioctl.h",
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/adv7842_core_ops#drivers_media_i2c_adv7842.c:3283.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/adv7842_core_ops#drivers_media_i2c_adv7842.c:3283.json
@@ -1,0 +1,36 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_adv7842",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_adv7842"
+  },
+  "resources": {
+    "fd_adv7842": {
+      "type": "fd",
+      "spec": "resource fd_adv7842[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/i2c/adv7842.c:3283",
+  "ioctls": {
+    "ADV7842_CMD_RAM_TEST": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_adv7842",
+    "ioctl$KGPT_ADV7842_CMD_RAM_TEST": "ioctl$KGPT_ADV7842_CMD_RAM_TEST(fd fd_adv7842, cmd const[ADV7842_CMD_RAM_TEST], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "media/i2c/adv7842.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/amdgpu_debugfs_gprwave_fops#drivers_gpu_drm_amd_amdgpu_amdgpu_debugfs.c:1507.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/amdgpu_debugfs_gprwave_fops#drivers_gpu_drm_amd_amdgpu_amdgpu_debugfs.c:1507.json
@@ -1,0 +1,40 @@
+{
+  "open": {
+    "filename": "/sys/kernel/debug/dri/#/amdgpu_gprwave",
+    "fd_name": "fd_amdgpu_gprwave",
+    "spec": "openat$KGPT_amdgpu_gprwave(fd const[AT_FDCWD], file ptr[in, string[\"/sys/kernel/debug/dri/#/amdgpu_gprwave\"]], flags flags[open_flags], mode const[0]) fd_amdgpu_gprwave"
+  },
+  "resources": {
+    "fd_amdgpu_gprwave": {
+      "type": "fd",
+      "spec": "resource fd_amdgpu_gprwave[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/gpu/drm/amd/amdgpu/amdgpu_debugfs.c:1507",
+  "ioctls": {
+    "AMDGPU_DEBUGFS_GPRWAVE_IOC_SET_STATE": {
+      "arg": "ptr[in, amdgpu_debugfs_gprwave_iocdata]",
+      "arg_name_in_usage": "data",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "amdgpu_debugfs_gprwave_iocdata": "amdgpu_debugfs_gprwave_iocdata {\n\tgpr_or_wave\tint32\n\tse\tint32\n\tsh\tint32\n\tcu\tint32\n\twave\tint32\n\tsimd\tint32\n\txcc_id\tint32\n\tgpr\tamdgpu_debugfs_gprwave_iocdata_gpr\n}",
+    "amdgpu_debugfs_gprwave_iocdata_gpr": "amdgpu_debugfs_gprwave_iocdata_gpr {\n\tthread\tint32\n\tvpgr_or_sgpr\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_amdgpu_gprwave": "openat$KGPT_amdgpu_gprwave(fd const[AT_FDCWD], file ptr[in, string[\"/sys/kernel/debug/dri/#/amdgpu_gprwave\"]], flags flags[open_flags], mode const[0]) fd_amdgpu_gprwave",
+    "ioctl$KGPT_AMDGPU_DEBUGFS_GPRWAVE_IOC_SET_STATE": "ioctl$KGPT_AMDGPU_DEBUGFS_GPRWAVE_IOC_SET_STATE(fd fd_amdgpu_gprwave, cmd const[AMDGPU_DEBUGFS_GPRWAVE_IOC_SET_STATE], arg ptr[in, amdgpu_debugfs_gprwave_iocdata])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_amdgpu_gprwave"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "drivers/gpu/drm/amd/amdgpu/amdgpu_umr.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/amdgpu_debugfs_regs2_fops#drivers_gpu_drm_amd_amdgpu_amdgpu_debugfs.c:1497.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/amdgpu_debugfs_regs2_fops#drivers_gpu_drm_amd_amdgpu_amdgpu_debugfs.c:1497.json
@@ -1,0 +1,49 @@
+{
+  "open": {
+    "filename": "/sys/kernel/debug/dri/#/amdgpu_regs2",
+    "fd_name": "fd_amdgpu_regs2",
+    "spec": "syz_open_dev$KGPT_amdgpu_regs2(dev ptr[in, string[\"/sys/kernel/debug/dri/#/amdgpu_regs2\"]], id proc[0, 1], flags flags[open_flags]) fd_amdgpu_regs2"
+  },
+  "resources": {
+    "fd_amdgpu_regs2": {
+      "type": "fd",
+      "spec": "resource fd_amdgpu_regs2[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/gpu/drm/amd/amdgpu/amdgpu_debugfs.c:1497",
+  "ioctls": {
+    "AMDGPU_DEBUGFS_REGS2_IOC_SET_STATE_V2": {
+      "arg": "ptr[in, amdgpu_debugfs_regs2_iocdata_v2]",
+      "arg_name_in_usage": "data",
+      "arg_inference": null
+    },
+    "AMDGPU_DEBUGFS_REGS2_IOC_SET_STATE": {
+      "arg": "ptr[in, amdgpu_debugfs_regs2_iocdata]",
+      "arg_name_in_usage": "data",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "amdgpu_debugfs_regs2_iocdata_v2": "amdgpu_debugfs_regs2_iocdata_v2 {\n\tuse_srbm\tint32\n\tuse_grbm\tint32\n\tpg_lock\tint32\n\tgrbm\tamdgpu_debugfs_regs2_iocdata_v2_grbm\n\tsrbm\tamdgpu_debugfs_regs2_iocdata_v2_srbm\n\txcc_id\tint32\n}",
+    "amdgpu_debugfs_regs2_iocdata": "amdgpu_debugfs_regs2_iocdata {\n\tuse_srbm\tint32\n\tuse_grbm\tint32\n\tpg_lock\tint32\n\tgrbm\tamdgpu_debugfs_regs2_iocdata_grbm\n\tsrbm\tamdgpu_debugfs_regs2_iocdata_srbm\n}",
+    "amdgpu_debugfs_regs2_iocdata_v2_grbm": "amdgpu_debugfs_regs2_iocdata_v2_grbm {\n\tse\tint32\n\tsh\tint32\n\tinstance\tint32\n}",
+    "amdgpu_debugfs_regs2_iocdata_v2_srbm": "amdgpu_debugfs_regs2_iocdata_v2_srbm {\n\tme\tint32\n\tpipe\tint32\n\tqueue\tint32\n\tvmid\tint32\n}",
+    "amdgpu_debugfs_regs2_iocdata_grbm": "amdgpu_debugfs_regs2_iocdata_grbm {\n\tse\tint32\n\tsh\tint32\n\tinstance\tint32\n}",
+    "amdgpu_debugfs_regs2_iocdata_srbm": "amdgpu_debugfs_regs2_iocdata_srbm {\n\tme\tint32\n\tpipe\tint32\n\tqueue\tint32\n\tvmid\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_amdgpu_regs2": "syz_open_dev$KGPT_amdgpu_regs2(dev ptr[in, string[\"/sys/kernel/debug/dri/#/amdgpu_regs2\"]], id proc[0, 1], flags flags[open_flags]) fd_amdgpu_regs2",
+    "ioctl$KGPT_AMDGPU_DEBUGFS_REGS2_IOC_SET_STATE_V2": "ioctl$KGPT_AMDGPU_DEBUGFS_REGS2_IOC_SET_STATE_V2(fd fd_amdgpu_regs2, cmd const[AMDGPU_DEBUGFS_REGS2_IOC_SET_STATE_V2], arg ptr[in, amdgpu_debugfs_regs2_iocdata_v2])",
+    "ioctl$KGPT_AMDGPU_DEBUGFS_REGS2_IOC_SET_STATE": "ioctl$KGPT_AMDGPU_DEBUGFS_REGS2_IOC_SET_STATE(fd fd_amdgpu_regs2, cmd const[AMDGPU_DEBUGFS_REGS2_IOC_SET_STATE], arg ptr[in, amdgpu_debugfs_regs2_iocdata])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_amdgpu_regs2"
+  ],
+  "includes": [
+    "drivers/gpu/drm/amd/amdgpu/amdgpu_umr.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/aoe_bdops#drivers_block_aoe_aoeblk.c:315.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/aoe_bdops#drivers_block_aoe_aoeblk.c:315.json
@@ -1,0 +1,44 @@
+{
+  "open": {
+    "filename": "/dev/etherd/e#.#",
+    "fd_name": "fd_aoe",
+    "spec": "syz_open_dev$KGPT_aoe(dev ptr[in, string[\"/dev/etherd/e#.#\"]], id proc[0, 1], flags flags[open_flags]) fd_aoe"
+  },
+  "resources": {
+    "fd_aoe": {
+      "type": "fd",
+      "spec": "resource fd_aoe[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/block/aoe/aoeblk.c:315",
+  "ioctls": {
+    "HDIO_GET_IDENTITY": {
+      "arg": "ptr[out, hd_driveid]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "hd_driveid": "type hd_driveid ptr[in, array[int8]]"
+  },
+  "existing_ioctls": {
+    "SG_IO": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_aoe": "syz_open_dev$KGPT_aoe(dev ptr[in, string[\"/dev/etherd/e#.#\"]], id proc[0, 1], flags flags[open_flags]) fd_aoe",
+    "ioctl$KGPT_HDIO_GET_IDENTITY": "ioctl$KGPT_HDIO_GET_IDENTITY(fd fd_aoe, cmd const[HDIO_GET_IDENTITY], arg ptr[out, hd_driveid])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_aoe"
+  ],
+  "includes": [
+    "uapi/linux/hdreg.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/async_ops#drivers_net_ppp_ppp_async.c:109.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/async_ops#drivers_net_ppp_ppp_async.c:109.json
@@ -1,0 +1,135 @@
+{
+  "open": {
+    "filename": "/dev/pts/#",
+    "fd_name": "fd_ppp_async",
+    "spec": "syz_open_dev$KGPT_ppp_async(dev ptr[in, string[\"/dev/pts/#\"]], id proc[0, 1], flags flags[open_flags]) fd_ppp_async"
+  },
+  "resources": {
+    "fd_ppp_async": {
+      "type": "fd",
+      "spec": "resource fd_ppp_async[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/ppp/ppp_async.c:109",
+  "ioctls": {
+    "PPPIOCGASYNCMAP": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "PPPIOCSASYNCMAP": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "PPPIOCGRASYNCMAP": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "PPPIOCSRASYNCMAP": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "PPPIOCGXASYNCMAP": {
+      "arg": "ptr[out, array[int32, 8]]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "PPPIOCSXASYNCMAP": {
+      "arg": "ptr[in, array[int32, 8]]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "PPPIOCGFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (put_user(val, p))"
+        ]
+      }
+    },
+    "PPPIOCSFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (get_user(val, p))"
+        ]
+      }
+    },
+    "PPPIOCGMRU": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (put_user(ap->mru, p))"
+        ]
+      }
+    },
+    "PPPIOCSMRU": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (get_user(val, p))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_ppp_async": "syz_open_dev$KGPT_ppp_async(dev ptr[in, string[\"/dev/pts/#\"]], id proc[0, 1], flags flags[open_flags]) fd_ppp_async",
+    "ioctl$KGPT_PPPIOCGASYNCMAP": "ioctl$KGPT_PPPIOCGASYNCMAP(fd fd_ppp_async, cmd const[PPPIOCGASYNCMAP], arg ptr[out, int32])",
+    "ioctl$KGPT_PPPIOCSASYNCMAP": "ioctl$KGPT_PPPIOCSASYNCMAP(fd fd_ppp_async, cmd const[PPPIOCSASYNCMAP], arg ptr[in, int32])",
+    "ioctl$KGPT_PPPIOCGRASYNCMAP": "ioctl$KGPT_PPPIOCGRASYNCMAP(fd fd_ppp_async, cmd const[PPPIOCGRASYNCMAP], arg ptr[out, int32])",
+    "ioctl$KGPT_PPPIOCSRASYNCMAP": "ioctl$KGPT_PPPIOCSRASYNCMAP(fd fd_ppp_async, cmd const[PPPIOCSRASYNCMAP], arg ptr[in, int32])",
+    "ioctl$KGPT_PPPIOCGXASYNCMAP": "ioctl$KGPT_PPPIOCGXASYNCMAP(fd fd_ppp_async, cmd const[PPPIOCGXASYNCMAP], arg ptr[out, array[int32, 8]])",
+    "ioctl$KGPT_PPPIOCSXASYNCMAP": "ioctl$KGPT_PPPIOCSXASYNCMAP(fd fd_ppp_async, cmd const[PPPIOCSXASYNCMAP], arg ptr[in, array[int32, 8]])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_ppp_async"
+  ],
+  "includes": [
+    "uapi/linux/ppp-ioctl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ax_ldisc#drivers_net_hamradio_mkiss.c:938.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ax_ldisc#drivers_net_hamradio_mkiss.c:938.json
@@ -1,0 +1,69 @@
+{
+  "open": {
+    "filename": "/dev/ptmx",
+    "fd_name": "fd_mkiss",
+    "spec": "openat$KGPT_mkiss(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ptmx\"]], flags flags[open_flags], mode const[0]) fd_mkiss"
+  },
+  "resources": {
+    "fd_mkiss": {
+      "type": "fd",
+      "spec": "resource fd_mkiss[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/hamradio/mkiss.c:938",
+  "ioctls": {
+    "SIOCGIFNAME": {
+      "arg": "ptr[out, string]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SIOCGIFENCAP": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SIOCSIFENCAP": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "SIOCSIFHWADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "__dev_addr_set"
+        ],
+        "type": [],
+        "usage": [
+          "if (copy_from_user(&addr, (void __user *) arg, AX25_ADDR_LEN))",
+          "netif_tx_lock_bh(dev);",
+          "__dev_addr_set(dev, addr, AX25_ADDR_LEN);",
+          "netif_tx_unlock_bh(dev);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_mkiss": "openat$KGPT_mkiss(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ptmx\"]], flags flags[open_flags], mode const[0]) fd_mkiss",
+    "ioctl$KGPT_SIOCGIFNAME": "ioctl$KGPT_SIOCGIFNAME(fd fd_mkiss, cmd const[SIOCGIFNAME], arg ptr[out, string])",
+    "ioctl$KGPT_SIOCGIFENCAP": "ioctl$KGPT_SIOCGIFENCAP(fd fd_mkiss, cmd const[SIOCGIFENCAP], arg ptr[out, int32])",
+    "ioctl$KGPT_SIOCSIFENCAP": "ioctl$KGPT_SIOCSIFENCAP(fd fd_mkiss, cmd const[SIOCSIFENCAP], arg intptr)"
+  },
+  "init_syscalls": [
+    "openat$KGPT_mkiss"
+  ],
+  "includes": [
+    "uapi/linux/sockios.h",
+    "uapi/linux/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/bt_bmc_fops#drivers_char_ipmi_bt-bmc.c:338.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/bt_bmc_fops#drivers_char_ipmi_bt-bmc.c:338.json
@@ -1,0 +1,37 @@
+{
+  "open": {
+    "filename": "/dev/",
+    "fd_name": "fd_bt_bmc",
+    "spec": "openat$KGPT_bt_bmc(fd const[AT_FDCWD], file ptr[in, string[\"/dev/bt-bmc\"]], flags flags[open_flags], mode const[0]) fd_bt_bmc"
+  },
+  "resources": {
+    "fd_bt_bmc": {
+      "type": "fd",
+      "spec": "resource fd_bt_bmc[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/char/ipmi/bt-bmc.c:338",
+  "ioctls": {
+    "BT_BMC_IOCTL_SMS_ATN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_bt_bmc": "openat$KGPT_bt_bmc(fd const[AT_FDCWD], file ptr[in, string[\"/dev/bt-bmc\"]], flags flags[open_flags], mode const[0]) fd_bt_bmc",
+    "ioctl$KGPT_BT_BMC_IOCTL_SMS_ATN": "ioctl$KGPT_BT_BMC_IOCTL_SMS_ATN(fd fd_bt_bmc, cmd const[BT_BMC_IOCTL_SMS_ATN], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_bt_bmc"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/bt-bmc.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/capi_fops#drivers_isdn_capi_capi.c:1022.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/capi_fops#drivers_isdn_capi_capi.c:1022.json
@@ -1,0 +1,226 @@
+{
+  "open": {
+    "filename": "/dev/capi20",
+    "fd_name": "fd_capi",
+    "spec": "openat$KGPT_capi(fd const[AT_FDCWD], file ptr[in, string[\"/dev/capi20\"]], flags flags[open_flags], mode const[0]) fd_capi"
+  },
+  "resources": {
+    "fd_capi": {
+      "type": "fd",
+      "spec": "resource fd_capi[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/isdn/capi/capi.c:1022",
+  "ioctls": {
+    "CAPI_GET_VERSION": {
+      "arg": "ptr[inout, capi_version]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "capi_version": "capi_version {\n\tmajorversion\tint32\n\tminorversion\tint32\n\tmajormanuversion\tint32\n\tminormanuversion\tint32\n}"
+  },
+  "existing_ioctls": {
+    "CAPI_REGISTER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "capi_register_params"
+        ],
+        "usage": [
+          "if (copy_from_user(&cdev->ap.rparam, argp, sizeof(struct capi_register_params)))"
+        ]
+      }
+    },
+    "CAPI_GET_SERIAL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "capi20_get_serial"
+        ],
+        "type": [
+          "capi_serial"
+        ],
+        "usage": [
+          "if (copy_from_user(&data.contr, argp, sizeof(data.contr)))",
+          "cdev->errcode = capi20_get_serial(data.contr, data.serial);",
+          "if (copy_to_user(argp, data.serial, sizeof(data.serial)))"
+        ]
+      }
+    },
+    "CAPI_GET_PROFILE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "capi20_get_profile"
+        ],
+        "type": [
+          "capi_profile"
+        ],
+        "usage": [
+          "if (copy_from_user(&data.contr, argp, sizeof(data.contr)))",
+          "cdev->errcode = capi20_get_profile(data.contr, &data.profile);",
+          "retval = copy_to_user(argp, &data.profile, sizeof(data.profile));"
+        ]
+      }
+    },
+    "CAPI_GET_MANUFACTURER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "capi20_get_manufacturer"
+        ],
+        "type": [
+          "capi_manufacturer"
+        ],
+        "usage": [
+          "if (copy_from_user(&data.contr, argp, sizeof(data.contr)))",
+          "cdev->errcode = capi20_get_manufacturer(data.contr, data.manufacturer);",
+          "if (copy_to_user(argp, data.manufacturer, sizeof(data.manufacturer)))"
+        ]
+      }
+    },
+    "CAPI_GET_ERRCODE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CAPI_INSTALLED": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CAPI_MANUFACTURER_CMD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "capi20_manufacturer"
+        ],
+        "type": [
+          "capi_manufacturer_cmd"
+        ],
+        "usage": [
+          "if (copy_from_user(&mcmd, argp, sizeof(mcmd)))",
+          "return capi20_manufacturer(mcmd.cmd, mcmd.data);"
+        ]
+      }
+    },
+    "CAPI_SET_FLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "unsigned"
+        ],
+        "usage": [
+          "if (copy_from_user(&userflags, argp, sizeof(userflags)))",
+          "cdev->userflags |= userflags;"
+        ]
+      }
+    },
+    "CAPI_CLR_FLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "unsigned"
+        ],
+        "usage": [
+          "if (copy_from_user(&userflags, argp, sizeof(userflags)))",
+          "cdev->userflags &= ~userflags;"
+        ]
+      }
+    },
+    "CAPI_GET_FLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "unsigned"
+        ],
+        "usage": [
+          "if (copy_to_user(argp, &cdev->userflags, sizeof(cdev->userflags)))"
+        ]
+      }
+    },
+    "CAPI_NCCI_OPENCOUNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "capincci_find",
+          "capincci_minor_opencount"
+        ],
+        "type": [
+          "unsigned"
+        ],
+        "usage": [
+          "if (copy_from_user(&ncci, argp, sizeof(ncci)))",
+          "nccip = capincci_find(cdev, (u32)ncci);",
+          "count = capincci_minor_opencount(nccip);"
+        ]
+      }
+    },
+    "CAPI_NCCI_GETUNIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "capincci_find"
+        ],
+        "type": [
+          "unsigned"
+        ],
+        "usage": [
+          "if (copy_from_user(&ncci, argp, sizeof(ncci)))",
+          "nccip = capincci_find(cdev, (u32)ncci);",
+          "unit = mp->minor;"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_capi": "openat$KGPT_capi(fd const[AT_FDCWD], file ptr[in, string[\"/dev/capi20\"]], flags flags[open_flags], mode const[0]) fd_capi",
+    "ioctl$KGPT_CAPI_GET_VERSION": "ioctl$KGPT_CAPI_GET_VERSION(fd fd_capi, cmd const[CAPI_GET_VERSION], arg ptr[inout, capi_version])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_capi"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/capi.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ccdc_v4l2_core_ops#drivers_media_platform_ti_omap3isp_ispccdc.c:2488.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ccdc_v4l2_core_ops#drivers_media_platform_ti_omap3isp_ispccdc.c:2488.json
@@ -1,0 +1,50 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_ccdc",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_ccdc"
+  },
+  "resources": {
+    "fd_ccdc": {
+      "type": "fd",
+      "spec": "resource fd_ccdc[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/platform/ti/omap3isp/ispccdc.c:2488",
+  "ioctls": {
+    "VIDIOC_OMAP3ISP_CCDC_CFG": {
+      "arg": "ptr[in, omap3isp_ccdc_update_config]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "omap3isp_ccdc_update_config": "omap3isp_ccdc_update_config {\n\tupdate\tint16\n\tflag\tint16\n\talawip\tflags[omap3isp_alaw_ipwidth, int32]\n\tbclamp\tptr[in, omap3isp_ccdc_bclamp]\n\tblcomp\tptr[in, omap3isp_ccdc_blcomp]\n\tfpc\tptr[in, omap3isp_ccdc_fpc]\n\tlsc_cfg\tptr[in, omap3isp_ccdc_lsc_config]\n\tcull\tptr[in, omap3isp_ccdc_culling]\n\tlsc\tptr[in, array[int8]]\n}",
+    "omap3isp_alaw_ipwidth": "omap3isp_alaw_ipwidth = ISPCCDC_ALAW_IP_WIDTH_10BIT, ISPCCDC_ALAW_IP_WIDTH_11BIT, ISPCCDC_ALAW_IP_WIDTH_12BIT, ISPCCDC_ALAW_IP_WIDTH_13BIT, ISPCCDC_ALAW_IP_WIDTH_14BIT, ISPCCDC_ALAW_IP_WIDTH_15BIT",
+    "omap3isp_ccdc_bclamp": "omap3isp_ccdc_bclamp {\n\tobgain\tint8\n\tobstpixel\tint8\n\toblines\tint8\n\toblen\tint8\n\tdcsubval\tint16\n}",
+    "omap3isp_ccdc_blcomp": "omap3isp_ccdc_blcomp {\n\tb_mg\tint8\n\tgb_g\tint8\n\tgr_cy\tint8\n\tr_ye\tint8\n}",
+    "omap3isp_ccdc_fpc": "omap3isp_ccdc_fpc {\n\tfpnum\tint16\n\tfpcaddr\tint32\n}",
+    "omap3isp_ccdc_lsc_config": "omap3isp_ccdc_lsc_config {\n\toffset\tint16\n\tgain_mode_n\tint8\n\tgain_mode_m\tint8\n\tgain_format\tint8\n\tfmtsph\tint16\n\tfmtlnh\tint16\n\tfmtslv\tint16\n\tfmtlnv\tint16\n\tinitial_x\tint8\n\tinitial_y\tint8\n\tsize\tint32\n}",
+    "omap3isp_ccdc_culling": "omap3isp_ccdc_culling {\n\tv_pattern\tint8\n\th_odd\tint16\n\th_even\tint16\n}",
+    "ISPCCDC_ALAW_IP_WIDTH_10BIT": "define ISPCCDC_ALAW_IP_WIDTH_10BIT 0",
+    "ISPCCDC_ALAW_IP_WIDTH_11BIT": "define ISPCCDC_ALAW_IP_WIDTH_11BIT 1",
+    "ISPCCDC_ALAW_IP_WIDTH_12BIT": "define ISPCCDC_ALAW_IP_WIDTH_12BIT 2",
+    "ISPCCDC_ALAW_IP_WIDTH_13BIT": "define ISPCCDC_ALAW_IP_WIDTH_13BIT 3",
+    "ISPCCDC_ALAW_IP_WIDTH_14BIT": "define ISPCCDC_ALAW_IP_WIDTH_14BIT 4",
+    "ISPCCDC_ALAW_IP_WIDTH_15BIT": "define ISPCCDC_ALAW_IP_WIDTH_15BIT 5"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_ccdc",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_CCDC_CFG": "ioctl$KGPT_VIDIOC_OMAP3ISP_CCDC_CFG(fd fd_ccdc, cmd const[VIDIOC_OMAP3ISP_CCDC_CFG], arg ptr[in, omap3isp_ccdc_update_config])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "uapi/linux/omap3isp.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/cec_devnode_fops#drivers_media_cec_core_cec-api.c:691.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/cec_devnode_fops#drivers_media_cec_core_cec-api.c:691.json
@@ -1,0 +1,108 @@
+{
+  "open": {
+    "filename": "/dev/cec#",
+    "fd_name": "fd_cec",
+    "spec": "syz_open_dev$KGPT_cec(dev ptr[in, string[\"/dev/cec#\"]], id proc[0, CEC_NUM_DEVICES], flags flags[open_flags]) fd_cec"
+  },
+  "resources": {
+    "fd_cec": {
+      "type": "fd",
+      "spec": "resource fd_cec[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/cec/core/cec-api.c:691",
+  "ioctls": {
+    "CEC_ADAP_G_CAPS": {
+      "arg": "ptr[out, cec_caps]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "CEC_ADAP_G_PHYS_ADDR": {
+      "arg": "ptr[out, int16]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "CEC_ADAP_S_PHYS_ADDR": {
+      "arg": "ptr[in, int16]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "CEC_ADAP_G_LOG_ADDRS": {
+      "arg": "ptr[out, cec_log_addrs]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "CEC_ADAP_S_LOG_ADDRS": {
+      "arg": "ptr[inout, cec_log_addrs]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "CEC_ADAP_G_CONNECTOR_INFO": {
+      "arg": "ptr[out, cec_connector_info]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "CEC_TRANSMIT": {
+      "arg": "ptr[inout, cec_msg]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "CEC_RECEIVE": {
+      "arg": "ptr[inout, cec_msg]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "CEC_DQEVENT": {
+      "arg": "ptr[out, cec_event]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "CEC_G_MODE": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "CEC_S_MODE": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "cec_caps": "cec_caps {\n\tdriver\tarray[int8, 32]\n\tname\tarray[int8, 32]\n\tavailable_log_addrs\tint32\n\tcapabilities\tint32\n\tversion\tint32\n}",
+    "cec_log_addrs": "cec_log_addrs {\n\tlog_addr\tarray[int8, CEC_MAX_LOG_ADDRS]\n\tlog_addr_mask\tint16\n\tcec_version\tint8\n\tnum_log_addrs\tint8\n\tvendor_id\tint32\n\tflags\tint32\n\tosd_name\tarray[int8, 15]\n\tprimary_device_type\tarray[int8, CEC_MAX_LOG_ADDRS]\n\tlog_addr_type\tarray[int8, CEC_MAX_LOG_ADDRS]\n\tall_device_types\tarray[int8, CEC_MAX_LOG_ADDRS]\n\tfeatures\tarray[array[int8, 12], CEC_MAX_LOG_ADDRS]\n}",
+    "cec_connector_info": "cec_connector_info {\n\ttype\tint32\n\tu\tcec_connector_info_union\n}",
+    "cec_msg": "cec_msg {\n\ttx_ts\tint64\n\trx_ts\tint64\n\tlen\tint32\n\ttimeout\tint32\n\tsequence\tint32\n\tflags\tint32\n\tmsg\tarray[int8, CEC_MAX_MSG_SIZE]\n\treply\tint8\n\trx_status\tint8\n\ttx_status\tint8\n\ttx_arb_lost_cnt\tint8\n\ttx_nack_cnt\tint8\n\ttx_low_drive_cnt\tint8\n\ttx_error_cnt\tint8\n}",
+    "cec_event": "cec_event {\n\tts\tint64\n\tevent\tint32\n\tflags\tint32\n\tunion\tcec_event_union\n}",
+    "CEC_MAX_NUM_DEVICES": "define CEC_MAX_NUM_DEVICES 8",
+    "cec_connector_info_union": "cec_connector_info_union [\n\tdrm\tcec_drm_connector_info\n\traw\tarray[int32, 16]\n]",
+    "cec_event_union": "cec_event_union [\n\tstate_change\tcec_event_state_change\n\tlost_msgs\tcec_event_lost_msgs\n\traw\tarray[int32, 16]\n]",
+    "cec_drm_connector_info": "cec_drm_connector_info {\n\tcard_no\tint32\n\tconnector_id\tint32\n}",
+    "cec_event_state_change": "cec_event_state_change {\n\tphys_addr\tint16\n\tlog_addr_mask\tint16\n\thave_conn_info\tint16\n}",
+    "cec_event_lost_msgs": "cec_event_lost_msgs {\n\tlost_msgs\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_cec": "syz_open_dev$KGPT_cec(dev ptr[in, string[\"/dev/cec#\"]], id proc[0, CEC_MAX_NUM_DEVICES], flags flags[open_flags]) fd_cec",
+    "ioctl$KGPT_CEC_ADAP_G_CAPS": "ioctl$KGPT_CEC_ADAP_G_CAPS(fd fd_cec, cmd const[CEC_ADAP_G_CAPS], arg ptr[out, cec_caps])",
+    "ioctl$KGPT_CEC_ADAP_G_PHYS_ADDR": "ioctl$KGPT_CEC_ADAP_G_PHYS_ADDR(fd fd_cec, cmd const[CEC_ADAP_G_PHYS_ADDR], arg ptr[out, int16])",
+    "ioctl$KGPT_CEC_ADAP_S_PHYS_ADDR": "ioctl$KGPT_CEC_ADAP_S_PHYS_ADDR(fd fd_cec, cmd const[CEC_ADAP_S_PHYS_ADDR], arg ptr[in, int16])",
+    "ioctl$KGPT_CEC_ADAP_G_LOG_ADDRS": "ioctl$KGPT_CEC_ADAP_G_LOG_ADDRS(fd fd_cec, cmd const[CEC_ADAP_G_LOG_ADDRS], arg ptr[out, cec_log_addrs])",
+    "ioctl$KGPT_CEC_ADAP_S_LOG_ADDRS": "ioctl$KGPT_CEC_ADAP_S_LOG_ADDRS(fd fd_cec, cmd const[CEC_ADAP_S_LOG_ADDRS], arg ptr[inout, cec_log_addrs])",
+    "ioctl$KGPT_CEC_ADAP_G_CONNECTOR_INFO": "ioctl$KGPT_CEC_ADAP_G_CONNECTOR_INFO(fd fd_cec, cmd const[CEC_ADAP_G_CONNECTOR_INFO], arg ptr[out, cec_connector_info])",
+    "ioctl$KGPT_CEC_TRANSMIT": "ioctl$KGPT_CEC_TRANSMIT(fd fd_cec, cmd const[CEC_TRANSMIT], arg ptr[inout, cec_msg])",
+    "ioctl$KGPT_CEC_RECEIVE": "ioctl$KGPT_CEC_RECEIVE(fd fd_cec, cmd const[CEC_RECEIVE], arg ptr[inout, cec_msg])",
+    "ioctl$KGPT_CEC_DQEVENT": "ioctl$KGPT_CEC_DQEVENT(fd fd_cec, cmd const[CEC_DQEVENT], arg ptr[out, cec_event])",
+    "ioctl$KGPT_CEC_G_MODE": "ioctl$KGPT_CEC_G_MODE(fd fd_cec, cmd const[CEC_G_MODE], arg ptr[out, int32])",
+    "ioctl$KGPT_CEC_S_MODE": "ioctl$KGPT_CEC_S_MODE(fd fd_cec, cmd const[CEC_S_MODE], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_cec"
+  ],
+  "includes": [
+    "uapi/linux/cec.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/changer_fops#drivers_scsi_ch.c:985.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/changer_fops#drivers_scsi_ch.c:985.json
@@ -1,0 +1,344 @@
+{
+  "open": {
+    "filename": "/dev/ch#",
+    "fd_name": "fd_ch",
+    "spec": "syz_open_dev$KGPT_ch(dev ptr[in, string[\"/dev/ch#\"]], id proc[0, 1], flags flags[open_flags]) fd_ch"
+  },
+  "resources": {
+    "fd_ch": {
+      "type": "fd",
+      "spec": "resource fd_ch[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/scsi/ch.c:985",
+  "ioctls": {
+    "CHIOINITELEM": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CHIOGPARAMS": {
+      "arg": "ptr[out, changer_params]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "CHIOGVPARAMS": {
+      "arg": "ptr[out, changer_vendor_params]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "CHIOPOSITION": {
+      "arg": "ptr[in, changer_position]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "CHIOMOVE": {
+      "arg": "ptr[in, changer_move]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "CHIOEXCHANGE": {
+      "arg": "ptr[in, changer_exchange]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "CHIOGSTATUS": {
+      "arg": "ptr[in, changer_element_status]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "CHIOGSTATUS32": {
+      "arg": "ptr[in, changer_element_status32]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "CHIOGELEM": {
+      "arg": "ptr[in, changer_get_element]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "CHIOSVOLTAG": {
+      "arg": "ptr[in, changer_set_voltag]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "changer_params": "changer_params {\n\tcp_curpicker\tint32\n\tcp_npickers\tint32\n\tcp_nslots\tint32\n\tcp_nportals\tint32\n\tcp_ndrives\tint32\n}",
+    "changer_vendor_params": "changer_vendor_params {\n\tcvp_n1\tint32\n\tcvp_label1\tarray[int8, 16]\n\tcvp_n2\tint32\n\tcvp_label2\tarray[int8, 16]\n\tcvp_n3\tint32\n\tcvp_label3\tarray[int8, 16]\n\tcvp_n4\tint32\n\tcvp_label4\tarray[int8, 16]\n\treserved\tarray[int32, 8]\n}",
+    "changer_position": "changer_position {\n\tcp_type\tint32\n\tcp_unit\tint32\n\tcp_flags\tint32\n}",
+    "changer_move": "changer_move {\n\tcm_fromtype\tint32\n\tcm_fromunit\tint32\n\tcm_totype\tint32\n\tcm_tounit\tint32\n\tcm_flags\tint32\n}",
+    "changer_exchange": "changer_exchange {\n\tce_srctype\tint32\n\tce_srcunit\tint32\n\tce_fdsttype\tint32\n\tce_fdstunit\tint32\n\tce_sdsttype\tint32\n\tce_sdstunit\tint32\n\tce_flags\tint32\n}",
+    "changer_element_status": "changer_element_status {\n\tces_type\tint32\n\tces_data\tptr[in, array[int8]]\n}",
+    "changer_get_element": "changer_get_element {\n\tcge_type\tint32\n\tcge_unit\tint32\n\tcge_status\tint32\n\tcge_errno\tint32\n\tcge_srctype\tint32\n\tcge_srcunit\tint32\n\tcge_id\tint32\n\tcge_lun\tint32\n\tcge_pvoltag\tarray[int8, 36]\n\tcge_avoltag\tarray[int8, 36]\n\tcge_flags\tint32\n}",
+    "changer_set_voltag": "changer_set_voltag {\n\tcsv_type\tint32\n\tcsv_unit\tint32\n\tcsv_voltag\tarray[int8, 36]\n\tcsv_flags\tint32\n}"
+  },
+  "existing_ioctls": {
+    "SCSI_IOCTL_SEND_COMMAND": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_scsi_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_scsi_ioctl(q, open_for_write, arg);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_TEST_UNIT_READY": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_BENCHMARK_COMMAND": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_SYNC": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_START_UNIT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_STOP_UNIT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_VERSION_NUM": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_get_version"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_get_version(arg);"
+        ]
+      }
+    },
+    "SG_SET_TIMEOUT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_set_timeout"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_set_timeout(sdev, arg);"
+        ]
+      }
+    },
+    "SG_GET_TIMEOUT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_RESERVED_SIZE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_get_reserved_size"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_get_reserved_size(sdev, arg);"
+        ]
+      }
+    },
+    "SG_SET_RESERVED_SIZE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_set_reserved_size"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_set_reserved_size(sdev, arg);"
+        ]
+      }
+    },
+    "SG_EMULATED_HOST": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_emulated_host"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_emulated_host(q, arg);"
+        ]
+      }
+    },
+    "SG_IO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl_sg_io"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_ioctl_sg_io(sdev, open_for_write, arg);"
+        ]
+      }
+    },
+    "CDROM_SEND_PACKET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_cdrom_send_packet"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_cdrom_send_packet(sdev, open_for_write, arg);"
+        ]
+      }
+    },
+    "CDROMCLOSETRAY": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CDROMEJECT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_GET_IDLUN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_get_idlun"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_get_idlun(sdev, arg);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_GET_BUS_NUMBER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "return put_user(sdev->host->host_no, (int __user *)arg);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_PROBE_HOST": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "ioctl_probe"
+        ],
+        "type": [],
+        "usage": [
+          "return ioctl_probe(sdev->host, arg);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_DOORLOCK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_DOORUNLOCK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_GET_PCI": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl_get_pci"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_ioctl_get_pci(sdev, arg);"
+        ]
+      }
+    },
+    "SG_SCSI_RESET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl_reset"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_ioctl_reset(sdev, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_ch": "syz_open_dev$KGPT_ch(dev ptr[in, string[\"/dev/ch#\"]], id proc[0, 1], flags flags[open_flags]) fd_ch",
+    "ioctl$KGPT_CHIOINITELEM": "ioctl$KGPT_CHIOINITELEM(fd fd_ch, cmd const[CHIOINITELEM], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_CHIOGPARAMS": "ioctl$KGPT_CHIOGPARAMS(fd fd_ch, cmd const[CHIOGPARAMS], arg ptr[out, changer_params])",
+    "ioctl$KGPT_CHIOGVPARAMS": "ioctl$KGPT_CHIOGVPARAMS(fd fd_ch, cmd const[CHIOGVPARAMS], arg ptr[out, changer_vendor_params])",
+    "ioctl$KGPT_CHIOPOSITION": "ioctl$KGPT_CHIOPOSITION(fd fd_ch, cmd const[CHIOPOSITION], arg ptr[in, changer_position])",
+    "ioctl$KGPT_CHIOMOVE": "ioctl$KGPT_CHIOMOVE(fd fd_ch, cmd const[CHIOMOVE], arg ptr[in, changer_move])",
+    "ioctl$KGPT_CHIOEXCHANGE": "ioctl$KGPT_CHIOEXCHANGE(fd fd_ch, cmd const[CHIOEXCHANGE], arg ptr[in, changer_exchange])",
+    "ioctl$KGPT_CHIOGSTATUS": "ioctl$KGPT_CHIOGSTATUS(fd fd_ch, cmd const[CHIOGSTATUS], arg ptr[in, changer_element_status])",
+    "ioctl$KGPT_CHIOGELEM": "ioctl$KGPT_CHIOGELEM(fd fd_ch, cmd const[CHIOGELEM], arg ptr[in, changer_get_element])",
+    "ioctl$KGPT_CHIOSVOLTAG": "ioctl$KGPT_CHIOSVOLTAG(fd fd_ch, cmd const[CHIOSVOLTAG], arg ptr[in, changer_set_voltag])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_ch"
+  ],
+  "includes": [
+    "uapi/linux/chio.h"
+  ],
+  "unused_types": {
+    "changer_element_status32": "changer_element_status32 {\n\tces_type\tint32\n\tces_data\tintptr\n}"
+  },
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/con_ops#drivers_tty_vt_vt.c:3499.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/con_ops#drivers_tty_vt_vt.c:3499.json
@@ -1,0 +1,242 @@
+{
+  "open": {
+    "filename": "/dev/tty#",
+    "fd_name": "fd_tty",
+    "spec": "syz_open_dev$KGPT_tty(dev ptr[in, string[\"/dev/tty#\"]], id proc[0, 1], flags flags[open_flags]) fd_tty"
+  },
+  "resources": {
+    "fd_tty": {
+      "type": "fd",
+      "spec": "resource fd_tty[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/tty/vt/vt.c:3499",
+  "ioctls": {
+    "VT_LOCKSWITCH": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VT_UNLOCKSWITCH": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VT_SETACTIVATE": {
+      "arg": "ptr[in, vt_setactivate]",
+      "arg_name_in_usage": "sa",
+      "arg_inference": null
+    },
+    "VT_GETHIFONTMASK": {
+      "arg": "ptr[out, int16]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VT_WAITEVENT": {
+      "arg": "ptr[in, vt_event]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "vt_event_wait_ioctl"
+        ],
+        "type": [
+          "vt_event"
+        ],
+        "usage": [
+          "return vt_event_wait_ioctl((struct vt_event __user *)arg);"
+        ]
+      }
+    }
+  },
+  "types": {
+    "vt_setactivate": "vt_setactivate {\n\tconsole\tint32\n\tmode\tvt_mode\n}",
+    "vt_event": "vt_event {\n\tevent\tflags[vt_event_flags, int32]\n\toldev\tint32\n\tnewev\tint32\n\tpad\tarray[int32, 4]\n}",
+    "vt_event_flags": "vt_event_flags = VT_EVENT_SWITCH, VT_EVENT_BLANK, VT_EVENT_UNBLANK, VT_EVENT_RESIZE, VT_MAX_EVENT"
+  },
+  "existing_ioctls": {
+    "TIOCLINUX": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tioclinux"
+        ],
+        "type": [],
+        "usage": [
+          "return tioclinux(tty, arg);"
+        ]
+      }
+    },
+    "VT_SETMODE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "up"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "vt_mode"
+        ],
+        "usage": [
+          "struct vt_mode tmp;",
+          "if (copy_from_user(&tmp, up, sizeof(struct vt_mode)))"
+        ]
+      }
+    },
+    "VT_GETMODE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "up"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "vt_mode"
+        ],
+        "usage": [
+          "struct vt_mode tmp;",
+          "int rc;",
+          "rc = copy_to_user(up, &tmp, sizeof(struct vt_mode));"
+        ]
+      }
+    },
+    "VT_GETSTATE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "vtstat"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "vt_stat"
+        ],
+        "usage": [
+          "struct vt_stat __user *vtstat = up;",
+          "if (put_user(fg_console + 1, &vtstat->v_active))"
+        ]
+      }
+    },
+    "VT_OPENQRY": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VT_ACTIVATE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_console"
+        ],
+        "type": [],
+        "usage": [
+          "set_console(arg);"
+        ]
+      }
+    },
+    "VT_WAITACTIVE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "vt_waitactive"
+        ],
+        "type": [],
+        "usage": [
+          "return vt_waitactive(arg);"
+        ]
+      }
+    },
+    "VT_RELDISP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "vt_reldisp"
+        ],
+        "type": [],
+        "usage": [
+          "ret = vt_reldisp(vc, arg);"
+        ]
+      }
+    },
+    "VT_DISALLOCATE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "vt_disallocate",
+          "vt_disallocate_all"
+        ],
+        "type": [],
+        "usage": [
+          "arg = array_index_nospec(arg - 1, MAX_NR_CONSOLES);",
+          "return vt_disallocate(arg);",
+          "vt_disallocate_all();"
+        ]
+      }
+    },
+    "VT_RESIZE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "vtsizes"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "vt_sizes"
+        ],
+        "usage": [
+          "struct vt_sizes __user *vtsizes = up;",
+          "ushort ll,cc;",
+          "if (get_user(ll, &vtsizes->v_rows) ||",
+          "get_user(cc, &vtsizes->v_cols))"
+        ]
+      }
+    },
+    "VT_RESIZEX": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "up"
+      ],
+      "arg_inference": {
+        "function": [
+          "vt_resizex"
+        ],
+        "type": [],
+        "usage": [
+          "return vt_resizex(vc, up);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_tty": "syz_open_dev$KGPT_tty(dev ptr[in, string[\"/dev/tty#\"]], id proc[0, 1], flags flags[open_flags]) fd_tty",
+    "ioctl$KGPT_VT_LOCKSWITCH": "ioctl$KGPT_VT_LOCKSWITCH(fd fd_tty, cmd const[VT_LOCKSWITCH], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VT_UNLOCKSWITCH": "ioctl$KGPT_VT_UNLOCKSWITCH(fd fd_tty, cmd const[VT_UNLOCKSWITCH], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VT_SETACTIVATE": "ioctl$KGPT_VT_SETACTIVATE(fd fd_tty, cmd const[VT_SETACTIVATE], arg ptr[in, vt_setactivate])",
+    "ioctl$KGPT_VT_GETHIFONTMASK": "ioctl$KGPT_VT_GETHIFONTMASK(fd fd_tty, cmd const[VT_GETHIFONTMASK], arg ptr[out, int16])",
+    "ioctl$KGPT_VT_WAITEVENT": "ioctl$KGPT_VT_WAITEVENT(fd fd_tty, cmd const[VT_WAITEVENT], arg ptr[in, vt_event])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_tty"
+  ],
+  "includes": [
+    "uapi/linux/vt.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "vt_mode": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/console_fops#drivers_tty_tty_io.c:479.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/console_fops#drivers_tty_tty_io.c:479.json
@@ -1,0 +1,390 @@
+{
+  "open": {
+    "filename": "/dev/console",
+    "fd_name": "fd_console",
+    "spec": "openat$KGPT_console(fd const[AT_FDCWD], file ptr[in, string[\"/dev/console\"]], flags flags[open_flags], mode const[0]) fd_console"
+  },
+  "resources": {
+    "fd_console": {
+      "type": "fd",
+      "spec": "resource fd_console[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/tty/tty_io.c:479",
+  "ioctls": {
+    "TIOCGEXCL": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "TIOCSTI": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocsti"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocsti(tty, p);"
+        ]
+      }
+    },
+    "TIOCGWINSZ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocgwinsz"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocgwinsz(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSWINSZ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocswinsz"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocswinsz(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCCONS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCEXCL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCNXCL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCGETD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocgetd"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocgetd(tty, p);"
+        ]
+      }
+    },
+    "TIOCSETD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocsetd"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocsetd(tty, p);"
+        ]
+      }
+    },
+    "TIOCVHANGUP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCGDEV": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "unsigned int"
+        ],
+        "usage": [
+          "unsigned int ret = new_encode_dev(tty_devnum(real_tty));\nreturn put_user(ret, (unsigned int __user *)p);"
+        ]
+      }
+    },
+    "TIOCSBRK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCCBRK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TCSBRK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "send_break"
+        ],
+        "type": [],
+        "usage": [
+          "if (!arg)\nreturn send_break(tty, 250);"
+        ]
+      }
+    },
+    "TCSBRKP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "send_break"
+        ],
+        "type": [],
+        "usage": [
+          "return send_break(tty, arg ? arg*100 : 250);"
+        ]
+      }
+    },
+    "TIOCMGET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocmget"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocmget(tty, p);"
+        ]
+      }
+    },
+    "TIOCMSET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocmset"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocmset(tty, cmd, p);"
+        ]
+      }
+    },
+    "TIOCMBIC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocmset"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocmset(tty, cmd, p);"
+        ]
+      }
+    },
+    "TIOCMBIS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocmset"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocmset(tty, cmd, p);"
+        ]
+      }
+    },
+    "TIOCGICOUNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocgicount"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocgicount(tty, p);"
+        ]
+      }
+    },
+    "TCFLSH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_buffer_flush"
+        ],
+        "type": [],
+        "usage": [
+          "switch (arg) {\ncase TCIFLUSH:\ncase TCIOFLUSH:\ntty_buffer_flush(tty, NULL);\nbreak;\n}"
+        ]
+      }
+    },
+    "TIOCSSERIAL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocsserial"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocsserial(tty, p);"
+        ]
+      }
+    },
+    "TIOCGSERIAL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocgserial"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocgserial(tty, p);"
+        ]
+      }
+    },
+    "TIOCGPTPEER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "ptm_open_peer"
+        ],
+        "type": [],
+        "usage": [
+          "return ptm_open_peer(file, tty, (int)arg);"
+        ]
+      }
+    },
+    "TIOCNOTTY": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCSCTTY": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocsctty"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocsctty(real_tty, file, arg);"
+        ]
+      }
+    },
+    "TIOCGPGRP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocgpgrp"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocgpgrp(tty, real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSPGRP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocspgrp"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocspgrp(tty, real_tty, p);"
+        ]
+      }
+    },
+    "TIOCGSID": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocgsid"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocgsid(tty, real_tty, p);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_console": "openat$KGPT_console(fd const[AT_FDCWD], file ptr[in, string[\"/dev/console\"]], flags flags[open_flags], mode const[0]) fd_console",
+    "ioctl$KGPT_TIOCGEXCL": "ioctl$KGPT_TIOCGEXCL(fd fd_console, cmd const[TIOCGEXCL], arg ptr[out, int32])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_console"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/def_blk_fops#block_fops.c:838.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/def_blk_fops#block_fops.c:838.json
@@ -1,0 +1,567 @@
+{
+  "open": {
+    "filename": "/dev/#",
+    "fd_name": "fd_blk",
+    "spec": "syz_open_dev$KGPT_blk(dev ptr[in, string[\"/dev/#\"]], id proc[0, 1], flags flags[open_flags]) fd_blk"
+  },
+  "resources": {
+    "fd_blk": {
+      "type": "fd",
+      "spec": "resource fd_blk[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/block/fops.c:838",
+  "ioctls": {
+    "BLKDISCARDZEROES": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "BLKFRAGET": {
+      "arg": "ptr[out, int64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "BLKGETDISKSEQ": {
+      "arg": "ptr[out, int64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "BLKOPENZONE": {
+      "arg": "ptr[in, blk_zone_range]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "BLKCLOSEZONE": {
+      "arg": "ptr[in, blk_zone_range]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "BLKFINISHZONE": {
+      "arg": "ptr[in, blk_zone_range]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "BLKGETZONESZ": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "BLKGETNRZONES": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "BLKSSZGET": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "BLKRASET": {
+      "arg": "int64",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "HDIO_GETGEO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_getgeo"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_getgeo(bdev, argp);"
+        ]
+      }
+    },
+    "BLKPG": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkpg_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return blkpg_ioctl(bdev, argp);"
+        ]
+      }
+    },
+    "BLKRAGET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_long"
+        ],
+        "type": [],
+        "usage": [
+          "return put_long(argp, (bdev->bd_disk->bdi->ra_pages * PAGE_SIZE) / 512);"
+        ]
+      }
+    },
+    "BLKGETSIZE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_ulong"
+        ],
+        "type": [],
+        "usage": [
+          "return put_ulong(argp, bdev_nr_sectors(bdev));"
+        ]
+      }
+    },
+    "BLKBSZGET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_int"
+        ],
+        "type": [],
+        "usage": [
+          "return put_int(argp, block_size(bdev));"
+        ]
+      }
+    },
+    "BLKBSZSET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_bszset"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_bszset(bdev, mode, argp);"
+        ]
+      }
+    },
+    "BLKGETSIZE64": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_u64"
+        ],
+        "type": [],
+        "usage": [
+          "return put_u64(argp, bdev_nr_bytes(bdev));"
+        ]
+      }
+    },
+    "BLKTRACESETUP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blk_trace_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return blk_trace_ioctl(bdev, cmd, argp);"
+        ]
+      }
+    },
+    "BLKFLSBUF": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "BLKROSET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_roset"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_roset(bdev, cmd, arg);"
+        ]
+      }
+    },
+    "BLKDISCARD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "blk_ioctl_discard"
+        ],
+        "type": [],
+        "usage": [
+          "return blk_ioctl_discard(bdev, mode, arg);"
+        ]
+      }
+    },
+    "BLKSECDISCARD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blk_ioctl_secure_erase"
+        ],
+        "type": [],
+        "usage": [
+          "return blk_ioctl_secure_erase(bdev, mode, argp);"
+        ]
+      }
+    },
+    "BLKZEROOUT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "blk_ioctl_zeroout"
+        ],
+        "type": [],
+        "usage": [
+          "return blk_ioctl_zeroout(bdev, mode, arg);"
+        ]
+      }
+    },
+    "BLKREPORTZONE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_report_zones_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_report_zones_ioctl(bdev, cmd, arg);"
+        ]
+      }
+    },
+    "BLKRESETZONE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_zone_mgmt_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_zone_mgmt_ioctl(bdev, mode, cmd, arg);"
+        ]
+      }
+    },
+    "BLKROGET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_int"
+        ],
+        "type": [],
+        "usage": [
+          "return put_int(argp, bdev_read_only(bdev) != 0);"
+        ]
+      }
+    },
+    "BLKPBSZGET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_uint"
+        ],
+        "type": [],
+        "usage": [
+          "return put_uint(argp, bdev_physical_block_size(bdev));"
+        ]
+      }
+    },
+    "BLKIOMIN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_uint"
+        ],
+        "type": [],
+        "usage": [
+          "return put_uint(argp, bdev_io_min(bdev));"
+        ]
+      }
+    },
+    "BLKIOOPT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_uint"
+        ],
+        "type": [],
+        "usage": [
+          "return put_uint(argp, bdev_io_opt(bdev));"
+        ]
+      }
+    },
+    "BLKALIGNOFF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_int"
+        ],
+        "type": [],
+        "usage": [
+          "return put_int(argp, bdev_alignment_offset(bdev));"
+        ]
+      }
+    },
+    "BLKSECTGET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_ushort"
+        ],
+        "type": [],
+        "usage": [
+          "unsigned int max_sectors;\nmax_sectors = min_t(unsigned int, USHRT_MAX,\n\t\t\t\tqueue_max_sectors(bdev_get_queue(bdev)));\nreturn put_ushort(argp, max_sectors);"
+        ]
+      }
+    },
+    "BLKROTATIONAL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_ushort"
+        ],
+        "type": [],
+        "usage": [
+          "return put_ushort(argp, !bdev_nonrot(bdev));"
+        ]
+      }
+    },
+    "BLKFRASET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "bdev->bd_disk->bdi->ra_pages = (arg * 512) / PAGE_SIZE;\nreturn 0;"
+        ]
+      }
+    },
+    "BLKRRPART": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "BLKTRACESTART": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blk_trace_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return blk_trace_ioctl(bdev, cmd, argp);"
+        ]
+      }
+    },
+    "BLKTRACESTOP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blk_trace_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return blk_trace_ioctl(bdev, cmd, argp);"
+        ]
+      }
+    },
+    "BLKTRACETEARDOWN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blk_trace_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return blk_trace_ioctl(bdev, cmd, argp);"
+        ]
+      }
+    },
+    "IOC_PR_REGISTER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_pr_register"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_pr_register(bdev, mode, argp);"
+        ]
+      }
+    },
+    "IOC_PR_RESERVE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_pr_reserve"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_pr_reserve(bdev, mode, argp);"
+        ]
+      }
+    },
+    "IOC_PR_RELEASE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_pr_release"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_pr_release(bdev, mode, argp);"
+        ]
+      }
+    },
+    "IOC_PR_PREEMPT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_pr_preempt"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_pr_preempt(bdev, mode, argp, false);"
+        ]
+      }
+    },
+    "IOC_PR_PREEMPT_ABORT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_pr_preempt"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_pr_preempt(bdev, mode, argp, true);"
+        ]
+      }
+    },
+    "IOC_PR_CLEAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "blkdev_pr_clear"
+        ],
+        "type": [],
+        "usage": [
+          "return blkdev_pr_clear(bdev, mode, argp);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_blk": "syz_open_dev$KGPT_blk(dev ptr[in, string[\"/dev/#\"]], id proc[0, 1], flags flags[open_flags]) fd_blk",
+    "ioctl$KGPT_BLKDISCARDZEROES": "ioctl$KGPT_BLKDISCARDZEROES(fd fd_blk, cmd const[BLKDISCARDZEROES], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_BLKFRAGET": "ioctl$KGPT_BLKFRAGET(fd fd_blk, cmd const[BLKFRAGET], arg ptr[out, int64])",
+    "ioctl$KGPT_BLKGETDISKSEQ": "ioctl$KGPT_BLKGETDISKSEQ(fd fd_blk, cmd const[BLKGETDISKSEQ], arg ptr[out, int64])",
+    "ioctl$KGPT_BLKOPENZONE": "ioctl$KGPT_BLKOPENZONE(fd fd_blk, cmd const[BLKOPENZONE], arg ptr[in, blk_zone_range])",
+    "ioctl$KGPT_BLKCLOSEZONE": "ioctl$KGPT_BLKCLOSEZONE(fd fd_blk, cmd const[BLKCLOSEZONE], arg ptr[in, blk_zone_range])",
+    "ioctl$KGPT_BLKFINISHZONE": "ioctl$KGPT_BLKFINISHZONE(fd fd_blk, cmd const[BLKFINISHZONE], arg ptr[in, blk_zone_range])",
+    "ioctl$KGPT_BLKGETZONESZ": "ioctl$KGPT_BLKGETZONESZ(fd fd_blk, cmd const[BLKGETZONESZ], arg ptr[out, int32])",
+    "ioctl$KGPT_BLKGETNRZONES": "ioctl$KGPT_BLKGETNRZONES(fd fd_blk, cmd const[BLKGETNRZONES], arg ptr[out, int32])",
+    "ioctl$KGPT_BLKSSZGET": "ioctl$KGPT_BLKSSZGET(fd fd_blk, cmd const[BLKSSZGET], arg ptr[out, int32])",
+    "ioctl$KGPT_BLKRASET": "ioctl$KGPT_BLKRASET(fd fd_blk, cmd const[BLKRASET], arg int64)"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_blk"
+  ],
+  "includes": [
+    "uapi/linux/blkzoned.h",
+    "uapi/linux/fs.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "blk_zone_range": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/dst_ca_fops#drivers_media_pci_bt8xx_dst_ca.c:639.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/dst_ca_fops#drivers_media_pci_bt8xx_dst_ca.c:639.json
@@ -1,0 +1,89 @@
+{
+  "open": {
+    "filename": "/dev/dvb/adapter#/ca#",
+    "fd_name": "fd_dst_ca",
+    "spec": "syz_open_dev$KGPT_dvb_ca(dev ptr[in, string[\"/dev/dvb/adapter#/ca#\"]], id proc[0, 1], flags flags[open_flags]) fd_dst_ca"
+  },
+  "resources": {
+    "fd_dst_ca": {
+      "type": "fd",
+      "spec": "resource fd_dst_ca[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/pci/bt8xx/dst_ca.c:639",
+  "ioctls": {
+    "CA_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CA_SEND_MSG": {
+      "arg": "ptr[in, ca_msg]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "ca_send_message"
+        ],
+        "type": [
+          "ca_msg"
+        ],
+        "usage": [
+          "result = ca_send_message(state, p_ca_message, arg);"
+        ]
+      }
+    },
+    "CA_GET_MSG": {
+      "arg": "ptr[inout, ca_msg]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "CA_GET_SLOT_INFO": {
+      "arg": "ptr[out, ca_slot_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "CA_GET_CAP": {
+      "arg": "ptr[out, ca_caps]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "CA_GET_DESCR_INFO": {
+      "arg": "ptr[in, ca_msg]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "ca_msg": "ca_msg {\n\tindex\tint32\n\ttype\tint32\n\tlength\tint32\n\tmsg\tarray[int8, 256]\n}",
+    "ca_caps": "ca_caps {\n\tslot_num\tint32\n\tslot_type\tint32\n\tdescr_num\tint32\n\tdescr_type\tint32\n}",
+    "ca_slot_info": "ca_slot_info {\n\tnum\tint32\n\ttype\tflags[ca_slot_info_type, int32]\n\tflags\tflags[ca_slot_info_flags, int32]\n}",
+    "ca_slot_info_type": "ca_slot_info_type = CA_CI, CA_CI_LINK, CA_CI_PHYS, CA_DESCR, CA_SC",
+    "ca_slot_info_flags": "ca_slot_info_flags = CA_CI_MODULE_PRESENT, CA_CI_MODULE_READY",
+    "CA_CI": "define CA_CI 1",
+    "CA_CI_LINK": "define CA_CI_LINK 2",
+    "CA_CI_PHYS": "define CA_CI_PHYS 4",
+    "CA_DESCR": "define CA_DESCR 8",
+    "CA_SC": "define CA_SC 128",
+    "CA_CI_MODULE_PRESENT": "define CA_CI_MODULE_PRESENT 1",
+    "CA_CI_MODULE_READY": "define CA_CI_MODULE_READY 2"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_dvb_ca": "syz_open_dev$KGPT_dvb_ca(dev ptr[in, string[\"/dev/dvb/adapter#/ca#\"]], id proc[0, 1], flags flags[open_flags]) fd_dst_ca",
+    "ioctl$KGPT_CA_RESET": "ioctl$KGPT_CA_RESET(fd fd_dst_ca, cmd const[CA_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_CA_SEND_MSG": "ioctl$KGPT_CA_SEND_MSG(fd fd_dst_ca, cmd const[CA_SEND_MSG], arg ptr[in, ca_msg])",
+    "ioctl$KGPT_CA_GET_MSG": "ioctl$KGPT_CA_GET_MSG(fd fd_dst_ca, cmd const[CA_GET_MSG], arg ptr[inout, ca_msg])",
+    "ioctl$KGPT_CA_GET_SLOT_INFO": "ioctl$KGPT_CA_GET_SLOT_INFO(fd fd_dst_ca, cmd const[CA_GET_SLOT_INFO], arg ptr[out, ca_slot_info])",
+    "ioctl$KGPT_CA_GET_CAP": "ioctl$KGPT_CA_GET_CAP(fd fd_dst_ca, cmd const[CA_GET_CAP], arg ptr[out, ca_caps])",
+    "ioctl$KGPT_CA_GET_DESCR_INFO": "ioctl$KGPT_CA_GET_DESCR_INFO(fd fd_dst_ca, cmd const[CA_GET_DESCR_INFO], arg ptr[in, ca_msg])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_dvb_ca"
+  ],
+  "includes": [
+    "uapi/linux/dvb/ca.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/dvb_ca_fops#drivers_media_dvb-core_dvb_ca_en50221.c:1835.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/dvb_ca_fops#drivers_media_dvb-core_dvb_ca_en50221.c:1835.json
@@ -1,0 +1,60 @@
+{
+  "open": {
+    "filename": "/dev/dvb/adapter#/ca#",
+    "fd_name": "fd_dvb_ca",
+    "spec": "syz_open_dev$KGPT_dvb_ca(dev ptr[in, string[\"/dev/dvb/adapter#/ca#\"]], id proc[0, 1], flags flags[open_flags]) fd_dvb_ca"
+  },
+  "resources": {
+    "fd_dvb_ca": {
+      "type": "fd",
+      "spec": "resource fd_dvb_ca[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/dvb-core/dvb_ca_en50221.c:1835",
+  "ioctls": {
+    "CA_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CA_GET_CAP": {
+      "arg": "ptr[out, ca_caps]",
+      "arg_name_in_usage": "caps",
+      "arg_inference": null
+    },
+    "CA_GET_SLOT_INFO": {
+      "arg": "ptr[inout, ca_slot_info]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "ca_caps": "ca_caps {\n\tslot_num\tint32\n\tslot_type\tint32\n\tdescr_num\tint32\n\tdescr_type\tint32\n}",
+    "ca_slot_info": "ca_slot_info {\n\tnum\tint32\n\ttype\tflags[ca_slot_info_type, int32]\n\tflags\tflags[ca_slot_info_flags, int32]\n}",
+    "ca_slot_info_type": "ca_slot_info_type = CA_CI, CA_CI_LINK, CA_CI_PHYS, CA_DESCR, CA_SC",
+    "ca_slot_info_flags": "ca_slot_info_flags = CA_CI_MODULE_PRESENT, CA_CI_MODULE_READY",
+    "CA_CI": "define CA_CI 1",
+    "CA_CI_LINK": "define CA_CI_LINK 2",
+    "CA_CI_PHYS": "define CA_CI_PHYS 4",
+    "CA_DESCR": "define CA_DESCR 8",
+    "CA_SC": "define CA_SC 128",
+    "CA_CI_MODULE_PRESENT": "define CA_CI_MODULE_PRESENT 1",
+    "CA_CI_MODULE_READY": "define CA_CI_MODULE_READY 2"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_dvb_ca": "syz_open_dev$KGPT_dvb_ca(dev ptr[in, string[\"/dev/dvb/adapter#/ca#\"]], id proc[0, 1], flags flags[open_flags]) fd_dvb_ca",
+    "ioctl$KGPT_CA_RESET": "ioctl$KGPT_CA_RESET(fd fd_dvb_ca, cmd const[CA_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_CA_GET_CAP": "ioctl$KGPT_CA_GET_CAP(fd fd_dvb_ca, cmd const[CA_GET_CAP], arg ptr[out, ca_caps])",
+    "ioctl$KGPT_CA_GET_SLOT_INFO": "ioctl$KGPT_CA_GET_SLOT_INFO(fd fd_dvb_ca, cmd const[CA_GET_SLOT_INFO], arg ptr[inout, ca_slot_info])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_dvb_ca"
+  ],
+  "includes": [
+    "uapi/linux/dvb/ca.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/dvb_demux_fops#drivers_media_dvb-core_dmxdev.c:1259.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/dvb_demux_fops#drivers_media_dvb-core_dmxdev.c:1259.json
@@ -1,0 +1,154 @@
+{
+  "open": {
+    "filename": "/dev/dvb/adapter#/demux#",
+    "fd_name": "fd_dvb_demux",
+    "spec": "syz_open_dev$KGPT_dvb_demux(dev ptr[in, string[\"/dev/dvb/adapter#/demux#\"]], id proc[0, 1], flags flags[open_flags]) fd_dvb_demux"
+  },
+  "resources": {
+    "fd_dvb_demux": {
+      "type": "fd",
+      "spec": "resource fd_dvb_demux[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/dvb-core/dmxdev.c:1259",
+  "ioctls": {
+    "DMX_START": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "DMX_STOP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "DMX_SET_FILTER": {
+      "arg": "ptr[in, dmx_sct_filter_params]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_SET_PES_FILTER": {
+      "arg": "ptr[in, dmx_pes_filter_params]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_SET_BUFFER_SIZE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "DMX_GET_PES_PIDS": {
+      "arg": "ptr[out, dmx_pes_pid]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "DMX_GET_STC": {
+      "arg": "ptr[inout, dmx_stc]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "DMX_ADD_PID": {
+      "arg": "intptr",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_REMOVE_PID": {
+      "arg": "ptr[in, int16]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_REQBUFS": {
+      "arg": "ptr[in, dmx_requestbuffers]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_QUERYBUF": {
+      "arg": "ptr[in,out, dmx_buffer]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_EXPBUF": {
+      "arg": "ptr[in, dmx_exportbuffer]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_QBUF": {
+      "arg": "ptr[in, dmx_buffer]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_DQBUF": {
+      "arg": "ptr[inout, dmx_buffer]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "dmx_sct_filter_params": "dmx_sct_filter_params {\n\tpid\tint16\n\tfilter\tdmx_filter\n\ttimeout\tint32\n\tflags\tflags[dmx_sct_filter_params_flags, int32]\n}",
+    "dmx_pes_pid": "type dmx_pes_pid ptr[in, array[int8]]",
+    "dmx_stc": "dmx_stc {\n\tnum\tint32\n\tbase\tint32\n\tstc\tint64\n}",
+    "dmx_requestbuffers": "dmx_requestbuffers {\n\tcount\tint32\n\tsize\tint32\n}",
+    "dmx_buffer": "dmx_buffer {\n\tindex\tint32\n\tbytesused\tint32\n\toffset\tint32\n\tlength\tint32\n\tflags\tint32\n\tcount\tint32\n}",
+    "dmx_exportbuffer": "dmx_exportbuffer {\n\tindex\tint32\n\tflags\tint32\n\tfd\tint32\n}",
+    "dmx_pes_filter_params": "dmx_pes_filter_params {\n\tpid\tint16\n\tinput\tflags[dmx_input, int32]\n\toutput\tflags[dmx_output, int32]\n\tpes_type\tflags[dmx_ts_pes, int32]\n\tflags\tint32\n}",
+    "dmx_sct_filter_params_flags": "dmx_sct_filter_params_flags = DMX_CHECK_CRC, DMX_ONESHOT, DMX_IMMEDIATE_START",
+    "dmx_filter": "dmx_filter {\n\tfilter\tarray[int8, DMX_FILTER_SIZE]\n\tmask\tarray[int8, DMX_FILTER_SIZE]\n\tmode\tarray[int8, DMX_FILTER_SIZE]\n}",
+    "dmx_input": "dmx_input = DMX_IN_FRONTEND, DMX_IN_DVR",
+    "dmx_output": "dmx_output = DMX_OUT_DECODER, DMX_OUT_TAP, DMX_OUT_TS_TAP, DMX_OUT_TSDEMUX_TAP",
+    "dmx_ts_pes": "dmx_ts_pes = DMX_PES_AUDIO0, DMX_PES_VIDEO0, DMX_PES_TELETEXT0, DMX_PES_SUBTITLE0, DMX_PES_PCR0, DMX_PES_AUDIO1, DMX_PES_VIDEO1, DMX_PES_TELETEXT1, DMX_PES_SUBTITLE1, DMX_PES_PCR1, DMX_PES_AUDIO2, DMX_PES_VIDEO2, DMX_PES_TELETEXT2, DMX_PES_SUBTITLE2, DMX_PES_PCR2, DMX_PES_AUDIO3, DMX_PES_VIDEO3, DMX_PES_TELETEXT3, DMX_PES_SUBTITLE3, DMX_PES_PCR3, DMX_PES_OTHER",
+    "DMX_IN_FRONTEND": "define DMX_IN_FRONTEND 0",
+    "DMX_IN_DVR": "define DMX_IN_DVR 1",
+    "DMX_OUT_DECODER": "define DMX_OUT_DECODER 0",
+    "DMX_OUT_TAP": "define DMX_OUT_TAP 1",
+    "DMX_OUT_TS_TAP": "define DMX_OUT_TS_TAP 2",
+    "DMX_OUT_TSDEMUX_TAP": "define DMX_OUT_TSDEMUX_TAP 3",
+    "DMX_PES_AUDIO0": "define DMX_PES_AUDIO0 0",
+    "DMX_PES_VIDEO0": "define DMX_PES_VIDEO0 1",
+    "DMX_PES_TELETEXT0": "define DMX_PES_TELETEXT0 2",
+    "DMX_PES_SUBTITLE0": "define DMX_PES_SUBTITLE0 3",
+    "DMX_PES_PCR0": "define DMX_PES_PCR0 4",
+    "DMX_PES_AUDIO1": "define DMX_PES_AUDIO1 5",
+    "DMX_PES_VIDEO1": "define DMX_PES_VIDEO1 6",
+    "DMX_PES_TELETEXT1": "define DMX_PES_TELETEXT1 7",
+    "DMX_PES_SUBTITLE1": "define DMX_PES_SUBTITLE1 8",
+    "DMX_PES_PCR1": "define DMX_PES_PCR1 9",
+    "DMX_PES_AUDIO2": "define DMX_PES_AUDIO2 10",
+    "DMX_PES_VIDEO2": "define DMX_PES_VIDEO2 11",
+    "DMX_PES_TELETEXT2": "define DMX_PES_TELETEXT2 12",
+    "DMX_PES_SUBTITLE2": "define DMX_PES_SUBTITLE2 13",
+    "DMX_PES_PCR2": "define DMX_PES_PCR2 14",
+    "DMX_PES_AUDIO3": "define DMX_PES_AUDIO3 15",
+    "DMX_PES_VIDEO3": "define DMX_PES_VIDEO3 16",
+    "DMX_PES_TELETEXT3": "define DMX_PES_TELETEXT3 17",
+    "DMX_PES_SUBTITLE3": "define DMX_PES_SUBTITLE3 18",
+    "DMX_PES_PCR3": "define DMX_PES_PCR3 19",
+    "DMX_PES_OTHER": "define DMX_PES_OTHER 20"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_dvb_demux": "syz_open_dev$KGPT_dvb_demux(dev ptr[in, string[\"/dev/dvb/adapter#/demux#\"]], id proc[0, 1], flags flags[open_flags]) fd_dvb_demux",
+    "ioctl$KGPT_DMX_START": "ioctl$KGPT_DMX_START(fd fd_dvb_demux, cmd const[DMX_START], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_DMX_STOP": "ioctl$KGPT_DMX_STOP(fd fd_dvb_demux, cmd const[DMX_STOP], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_DMX_SET_FILTER": "ioctl$KGPT_DMX_SET_FILTER(fd fd_dvb_demux, cmd const[DMX_SET_FILTER], arg ptr[in, dmx_sct_filter_params])",
+    "ioctl$KGPT_DMX_SET_PES_FILTER": "ioctl$KGPT_DMX_SET_PES_FILTER(fd fd_dvb_demux, cmd const[DMX_SET_PES_FILTER], arg ptr[in, dmx_pes_filter_params])",
+    "ioctl$KGPT_DMX_SET_BUFFER_SIZE": "ioctl$KGPT_DMX_SET_BUFFER_SIZE(fd fd_dvb_demux, cmd const[DMX_SET_BUFFER_SIZE], arg intptr)",
+    "ioctl$KGPT_DMX_GET_PES_PIDS": "ioctl$KGPT_DMX_GET_PES_PIDS(fd fd_dvb_demux, cmd const[DMX_GET_PES_PIDS], arg ptr[out, dmx_pes_pid])",
+    "ioctl$KGPT_DMX_GET_STC": "ioctl$KGPT_DMX_GET_STC(fd fd_dvb_demux, cmd const[DMX_GET_STC], arg ptr[inout, dmx_stc])",
+    "ioctl$KGPT_DMX_ADD_PID": "ioctl$KGPT_DMX_ADD_PID(fd fd_dvb_demux, cmd const[DMX_ADD_PID], arg intptr)",
+    "ioctl$KGPT_DMX_REMOVE_PID": "ioctl$KGPT_DMX_REMOVE_PID(fd fd_dvb_demux, cmd const[DMX_REMOVE_PID], arg ptr[in, int16])",
+    "ioctl$KGPT_DMX_REQBUFS": "ioctl$KGPT_DMX_REQBUFS(fd fd_dvb_demux, cmd const[DMX_REQBUFS], arg ptr[in, dmx_requestbuffers])",
+    "ioctl$KGPT_DMX_QUERYBUF": "ioctl$KGPT_DMX_QUERYBUF(fd fd_dvb_demux, cmd const[DMX_QUERYBUF], arg ptr[inout, dmx_buffer])",
+    "ioctl$KGPT_DMX_EXPBUF": "ioctl$KGPT_DMX_EXPBUF(fd fd_dvb_demux, cmd const[DMX_EXPBUF], arg ptr[in, dmx_exportbuffer])",
+    "ioctl$KGPT_DMX_QBUF": "ioctl$KGPT_DMX_QBUF(fd fd_dvb_demux, cmd const[DMX_QBUF], arg ptr[in, dmx_buffer])",
+    "ioctl$KGPT_DMX_DQBUF": "ioctl$KGPT_DMX_DQBUF(fd fd_dvb_demux, cmd const[DMX_DQBUF], arg ptr[inout, dmx_buffer])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_dvb_demux"
+  ],
+  "includes": [
+    "uapi/linux/dvb/dmx.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/dvb_dvr_fops#drivers_media_dvb-core_dmxdev.c:1386.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/dvb_dvr_fops#drivers_media_dvb-core_dmxdev.c:1386.json
@@ -1,0 +1,80 @@
+{
+  "open": {
+    "filename": "/dev/dvb/adapter#/dvr#",
+    "fd_name": "fd_dvb_dvr",
+    "spec": "syz_open_dev$KGPT_dvb_dvr(dev ptr[in, string[\"/dev/dvb/adapter#/dvr#\"]], id proc[0, 1], flags flags[open_flags]) fd_dvb_dvr"
+  },
+  "resources": {
+    "fd_dvb_dvr": {
+      "type": "fd",
+      "spec": "resource fd_dvb_dvr[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/dvb-core/dmxdev.c:1386",
+  "ioctls": {
+    "DMX_SET_BUFFER_SIZE": {
+      "arg": "intN",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "dvb_dvr_set_buffer_size"
+        ],
+        "type": [
+          "unsigned long"
+        ],
+        "usage": [
+          "ret = dvb_dvr_set_buffer_size(dmxdev, arg);"
+        ]
+      }
+    },
+    "DMX_REQBUFS": {
+      "arg": "ptr[in, dmx_requestbuffers]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_QUERYBUF": {
+      "arg": "ptr[inout, dmx_buffer]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_EXPBUF": {
+      "arg": "ptr[in, dmx_exportbuffer]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_QBUF": {
+      "arg": "ptr[in, dmx_buffer]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "DMX_DQBUF": {
+      "arg": "ptr[inout, dmx_buffer]",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "dmx_requestbuffers": "dmx_requestbuffers {\n\tcount\tint32\n\tsize\tint32\n}",
+    "dmx_buffer": "dmx_buffer {\n\tindex\tint32\n\tbytesused\tint32\n\toffset\tint32\n\tlength\tint32\n\tflags\tint32\n\tcount\tint32\n}",
+    "dmx_exportbuffer": "dmx_exportbuffer {\n\tindex\tint32\n\tflags\tint32\n\tfd\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_dvb_dvr": "syz_open_dev$KGPT_dvb_dvr(dev ptr[in, string[\"/dev/dvb/adapter#/dvr#\"]], id proc[0, 1], flags flags[open_flags]) fd_dvb_dvr",
+    "ioctl$KGPT_DMX_SET_BUFFER_SIZE": "ioctl$KGPT_DMX_SET_BUFFER_SIZE(fd fd_dvb_dvr, cmd const[DMX_SET_BUFFER_SIZE], arg intptr)",
+    "ioctl$KGPT_DMX_REQBUFS": "ioctl$KGPT_DMX_REQBUFS(fd fd_dvb_dvr, cmd const[DMX_REQBUFS], arg ptr[in, dmx_requestbuffers])",
+    "ioctl$KGPT_DMX_QUERYBUF": "ioctl$KGPT_DMX_QUERYBUF(fd fd_dvb_dvr, cmd const[DMX_QUERYBUF], arg ptr[inout, dmx_buffer])",
+    "ioctl$KGPT_DMX_EXPBUF": "ioctl$KGPT_DMX_EXPBUF(fd fd_dvb_dvr, cmd const[DMX_EXPBUF], arg ptr[in, dmx_exportbuffer])",
+    "ioctl$KGPT_DMX_QBUF": "ioctl$KGPT_DMX_QBUF(fd fd_dvb_dvr, cmd const[DMX_QBUF], arg ptr[in, dmx_buffer])",
+    "ioctl$KGPT_DMX_DQBUF": "ioctl$KGPT_DMX_DQBUF(fd fd_dvb_dvr, cmd const[DMX_DQBUF], arg ptr[inout, dmx_buffer])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_dvb_dvr"
+  ],
+  "includes": [
+    "uapi/linux/dvb/dmx.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/dvb_net_fops#drivers_media_dvb-core_dvb_net.c:1608.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/dvb_net_fops#drivers_media_dvb-core_dvb_net.c:1608.json
@@ -1,0 +1,64 @@
+{
+  "open": {
+    "filename": "/dev/dvb/adapter#/net#",
+    "fd_name": "fd_dvb_net",
+    "spec": "syz_open_dev$KGPT_dvb_net(dev ptr[in, string[\"/dev/dvb/adapter#/net#\"]], id proc[0, 1], flags flags[open_flags]) fd_dvb_net"
+  },
+  "resources": {
+    "fd_dvb_net": {
+      "type": "fd",
+      "spec": "resource fd_dvb_net[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/dvb-core/dvb_net.c:1608",
+  "ioctls": {
+    "NET_ADD_IF": {
+      "arg": "ptr[in, dvb_net_if]",
+      "arg_name_in_usage": "dvbnetif",
+      "arg_inference": null
+    },
+    "NET_GET_IF": {
+      "arg": "ptr[in, dvb_net_if]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "NET_REMOVE_IF": {
+      "arg": "intptr",
+      "arg_name_in_usage": "parg",
+      "arg_inference": null
+    },
+    "__NET_ADD_IF_OLD": {
+      "arg": "ptr[in, __dvb_net_if_old]",
+      "arg_name_in_usage": "dvbnetif",
+      "arg_inference": null
+    },
+    "__NET_GET_IF_OLD": {
+      "arg": "ptr[in, __dvb_net_if_old]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "dvb_net_if": "dvb_net_if {\n\tpid\tint16\n\tif_num\tint16\n\tfeedtype\tdvb_net_feedtype\n}",
+    "__dvb_net_if_old": "__dvb_net_if_old {\n\tpid\tint16\n\tif_num\tint16\n}",
+    "dvb_net_feedtype": "type dvb_net_feedtype ptr[in, array[int8]]"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_dvb_net": "syz_open_dev$KGPT_dvb_net(dev ptr[in, string[\"/dev/dvb/adapter#/net#\"]], id proc[0, 1], flags flags[open_flags]) fd_dvb_net",
+    "ioctl$KGPT_NET_ADD_IF": "ioctl$KGPT_NET_ADD_IF(fd fd_dvb_net, cmd const[NET_ADD_IF], arg ptr[in, dvb_net_if])",
+    "ioctl$KGPT_NET_GET_IF": "ioctl$KGPT_NET_GET_IF(fd fd_dvb_net, cmd const[NET_GET_IF], arg ptr[in, dvb_net_if])",
+    "ioctl$KGPT_NET_REMOVE_IF": "ioctl$KGPT_NET_REMOVE_IF(fd fd_dvb_net, cmd const[NET_REMOVE_IF], arg intptr)",
+    "ioctl$KGPT___NET_ADD_IF_OLD": "ioctl$KGPT___NET_ADD_IF_OLD(fd fd_dvb_net, cmd const[__NET_ADD_IF_OLD], arg ptr[in, __dvb_net_if_old])",
+    "ioctl$KGPT___NET_GET_IF_OLD": "ioctl$KGPT___NET_GET_IF_OLD(fd fd_dvb_net, cmd const[__NET_GET_IF_OLD], arg ptr[in, __dvb_net_if_old])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_dvb_net"
+  ],
+  "includes": [
+    "uapi/linux/dvb/net.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/evdev_fops#drivers_input_evdev.c:1292.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/evdev_fops#drivers_input_evdev.c:1292.json
@@ -1,0 +1,304 @@
+{
+  "open": {
+    "filename": "/dev/input/event#",
+    "fd_name": "fd_evdev",
+    "spec": "syz_open_dev$KGPT_evdev(dev ptr[in, string[\"/dev/input/event#\"]], id proc[0, 1], flags flags[open_flags]) fd_evdev"
+  },
+  "resources": {
+    "fd_evdev": {
+      "type": "fd",
+      "spec": "resource fd_evdev[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/input/evdev.c:1292",
+  "ioctls": {
+    "EVIOCGPROP": {
+      "arg": "ptr[out, array[int8]]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "EVIOCGMTSLOTS": {
+      "arg": "ptr[in, eviocg_mtslots]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "EVIOCGKEY": {
+      "arg": "ptr[out, array[int8]]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "EVIOCGLED": {
+      "arg": "ptr[out, array[int32]]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "EVIOCGSND": {
+      "arg": "ptr[out, array[int32]]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "EVIOCGSW": {
+      "arg": "ptr[out, array[int32]]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "EVIOCGNAME": {
+      "arg": "ptr[out, array[int8]]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "EVIOCGPHYS": {
+      "arg": "ptr[out, array[int8]]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "EVIOCGUNIQ": {
+      "arg": "ptr[out, array[int8]]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "EVIOCGABS": {
+      "arg": "ptr[out, input_absinfo]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "EVIOCSABS": {
+      "arg": "ptr[in, input_absinfo]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "EVIOCGVERSION": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [
+        "ip"
+      ],
+      "arg_inference": null
+    },
+    "EVIOCGID": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": null
+    },
+    "EVIOCGREP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [
+        "ip"
+      ],
+      "arg_inference": null
+    },
+    "EVIOCSREP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "ip"
+      ],
+      "arg_inference": {
+        "function": [
+          "input_inject_event"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(u, ip))\n\t\t\treturn -EFAULT;",
+          "if (get_user(v, ip + 1))\n\t\t\treturn -EFAULT;",
+          "input_inject_event(&evdev->handle, EV_REP, REP_DELAY, u);",
+          "input_inject_event(&evdev->handle, EV_REP, REP_PERIOD, v);"
+        ]
+      }
+    },
+    "EVIOCRMFF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "input_ff_erase"
+        ],
+        "type": [],
+        "usage": [
+          "return input_ff_erase(dev, (int)(unsigned long) p, file);"
+        ]
+      }
+    },
+    "EVIOCGEFFECTS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [
+        "ip"
+      ],
+      "arg_inference": null
+    },
+    "EVIOCGRAB": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "evdev_grab",
+          "evdev_ungrab"
+        ],
+        "type": [],
+        "usage": [
+          "if (p)\n\t\t\treturn evdev_grab(evdev, client);",
+          "else\n\t\t\treturn evdev_ungrab(evdev, client);"
+        ]
+      }
+    },
+    "EVIOCREVOKE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": null
+    },
+    "EVIOCGMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "evdev_get_mask"
+        ],
+        "type": [
+          "input_mask"
+        ],
+        "usage": [
+          "if (copy_from_user(&mask, p, sizeof(mask)))\n\t\t\treturn -EFAULT;",
+          "codes_ptr = (void __user *)(unsigned long)mask.codes_ptr;",
+          "return evdev_get_mask(client, mask.type, codes_ptr, mask.codes_size, compat_mode);"
+        ]
+      }
+    },
+    "EVIOCSMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "evdev_set_mask"
+        ],
+        "type": [
+          "input_mask"
+        ],
+        "usage": [
+          "if (copy_from_user(&mask, p, sizeof(mask)))\n\t\t\treturn -EFAULT;",
+          "codes_ptr = (const void __user *)(unsigned long)mask.codes_ptr;",
+          "return evdev_set_mask(client, mask.type, codes_ptr, mask.codes_size, compat_mode);"
+        ]
+      }
+    },
+    "EVIOCSCLOCKID": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "evdev_set_clk_type"
+        ],
+        "type": [],
+        "usage": [
+          "if (copy_from_user(&i, p, sizeof(unsigned int)))\n\t\t\treturn -EFAULT;",
+          "return evdev_set_clk_type(client, i);"
+        ]
+      }
+    },
+    "EVIOCGKEYCODE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "evdev_handle_get_keycode"
+        ],
+        "type": [],
+        "usage": [
+          "return evdev_handle_get_keycode(dev, p);"
+        ]
+      }
+    },
+    "EVIOCSKEYCODE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "evdev_handle_set_keycode"
+        ],
+        "type": [],
+        "usage": [
+          "return evdev_handle_set_keycode(dev, p);"
+        ]
+      }
+    },
+    "EVIOCGKEYCODE_V2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "evdev_handle_get_keycode_v2"
+        ],
+        "type": [],
+        "usage": [
+          "return evdev_handle_get_keycode_v2(dev, p);"
+        ]
+      }
+    },
+    "EVIOCSKEYCODE_V2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "evdev_handle_set_keycode_v2"
+        ],
+        "type": [],
+        "usage": [
+          "return evdev_handle_set_keycode_v2(dev, p);"
+        ]
+      }
+    },
+    "EVIOCSFF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "input_ff_upload"
+        ],
+        "type": [
+          "ff_effect"
+        ],
+        "usage": [
+          "if (input_ff_effect_from_user(p, size, &effect))\n\t\t\treturn -EFAULT;",
+          "error = input_ff_upload(dev, &effect, file);",
+          "if (put_user(effect.id, &(((struct ff_effect __user *)p)->id)))\n\t\t\treturn -EFAULT;"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_evdev": "syz_open_dev$KGPT_evdev(dev ptr[in, string[\"/dev/input/event#\"]], id proc[0, 1], flags flags[open_flags]) fd_evdev"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_evdev"
+  ],
+  "includes": [],
+  "unused_types": {
+    "eviocg_mtslots": "type eviocg_mtslots ptr[in, array[int8]]"
+  },
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/fb_fops#drivers_video_fbdev_core_fb_chrdev.c:448.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/fb_fops#drivers_video_fbdev_core_fb_chrdev.c:448.json
@@ -1,0 +1,198 @@
+{
+  "open": {
+    "filename": "/dev/fb#",
+    "fd_name": "fd_fb",
+    "spec": "syz_open_dev$KGPT_fb(dev ptr[in, string[\"/dev/fb#\"]], id proc[0, 1], flags flags[open_flags]) fd_fb"
+  },
+  "resources": {
+    "fd_fb": {
+      "type": "fd",
+      "spec": "resource fd_fb[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/video/fbdev/core/fb_chrdev.c:448",
+  "ioctls": {
+    "FBIO_CURSOR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "FBIOGET_VSCREENINFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_to_user"
+        ],
+        "type": [
+          "fb_var_screeninfo"
+        ],
+        "usage": [
+          "ret = copy_to_user(argp, &var, sizeof(var)) ? -EFAULT : 0;"
+        ]
+      }
+    },
+    "FBIOPUT_VSCREENINFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "fb_set_var",
+          "copy_to_user"
+        ],
+        "type": [
+          "fb_var_screeninfo"
+        ],
+        "usage": [
+          "if (copy_from_user(&var, argp, sizeof(var)))",
+          "ret = fb_set_var(info, &var);",
+          "if (!ret && copy_to_user(argp, &var, sizeof(var)))"
+        ]
+      }
+    },
+    "FBIOGET_FSCREENINFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_to_user"
+        ],
+        "type": [
+          "fb_fix_screeninfo"
+        ],
+        "usage": [
+          "ret = copy_to_user(argp, &fix, sizeof(fix)) ? -EFAULT : 0;"
+        ]
+      }
+    },
+    "FBIOPUTCMAP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "fb_set_user_cmap"
+        ],
+        "type": [
+          "fb_cmap_user"
+        ],
+        "usage": [
+          "if (copy_from_user(&cmap, argp, sizeof(cmap)))",
+          "ret = fb_set_user_cmap(&cmap, info);"
+        ]
+      }
+    },
+    "FBIOGETCMAP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "fb_cmap_to_user"
+        ],
+        "type": [
+          "fb_cmap_user"
+        ],
+        "usage": [
+          "if (copy_from_user(&cmap, argp, sizeof(cmap)))",
+          "ret = fb_cmap_to_user(&cmap_from, &cmap);"
+        ]
+      }
+    },
+    "FBIOPAN_DISPLAY": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "fb_pan_display",
+          "copy_to_user"
+        ],
+        "type": [
+          "fb_var_screeninfo"
+        ],
+        "usage": [
+          "if (copy_from_user(&var, argp, sizeof(var)))",
+          "ret = fb_pan_display(info, &var);",
+          "if (ret == 0 && copy_to_user(argp, &var, sizeof(var)))"
+        ]
+      }
+    },
+    "FBIOGET_CON2FBMAP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "fbcon_get_con2fb_map_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "ret = fbcon_get_con2fb_map_ioctl(argp);"
+        ]
+      }
+    },
+    "FBIOPUT_CON2FBMAP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "fbcon_set_con2fb_map_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "ret = fbcon_set_con2fb_map_ioctl(argp);"
+        ]
+      }
+    },
+    "FBIOBLANK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "fb_blank",
+          "fbcon_fb_blanked"
+        ],
+        "type": [],
+        "usage": [
+          "if (arg > FB_BLANK_POWERDOWN)",
+          "ret = fb_blank(info, arg);",
+          "fbcon_fb_blanked(info, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_fb": "syz_open_dev$KGPT_fb(dev ptr[in, string[\"/dev/fb#\"]], id proc[0, 1], flags flags[open_flags]) fd_fb"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_fb"
+  ],
+  "includes": [
+    "uapi/linux/fb.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/fops#drivers_gpu_drm_i915_i915_perf.c:3757.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/fops#drivers_gpu_drm_i915_i915_perf.c:3757.json
@@ -1,0 +1,48 @@
+{
+  "open": {
+    "filename": "/dev/dri/card#",
+    "fd_name": "fd_i915_perf",
+    "spec": "syz_open_dev$KGPT_i915_perf(dev ptr[in, string[\"/dev/dri/card#\"]], id proc[0, 1], flags flags[open_flags]) fd_i915_perf"
+  },
+  "resources": {
+    "fd_i915_perf": {
+      "type": "fd",
+      "spec": "resource fd_i915_perf[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/gpu/drm/i915/i915_perf.c:3757",
+  "ioctls": {
+    "I915_PERF_IOCTL_ENABLE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "I915_PERF_IOCTL_DISABLE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "I915_PERF_IOCTL_CONFIG": {
+      "arg": "int64",
+      "arg_name_in_usage": "metrics_set",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_i915_perf": "syz_open_dev$KGPT_i915_perf(dev ptr[in, string[\"/dev/dri/card#\"]], id proc[0, 1], flags flags[open_flags]) fd_i915_perf",
+    "ioctl$KGPT_I915_PERF_IOCTL_ENABLE": "ioctl$KGPT_I915_PERF_IOCTL_ENABLE(fd fd_i915_perf, cmd const[I915_PERF_IOCTL_ENABLE], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_I915_PERF_IOCTL_DISABLE": "ioctl$KGPT_I915_PERF_IOCTL_DISABLE(fd fd_i915_perf, cmd const[I915_PERF_IOCTL_DISABLE], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_I915_PERF_IOCTL_CONFIG": "ioctl$KGPT_I915_PERF_IOCTL_CONFIG(fd fd_i915_perf, cmd const[I915_PERF_IOCTL_CONFIG], arg int64)"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_i915_perf"
+  ],
+  "includes": [
+    "uapi/drm/i915_drm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/fsl_mc_uapi_dev_fops#drivers_bus_fsl-mc_fsl-mc-uapi.c:566.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/fsl_mc_uapi_dev_fops#drivers_bus_fsl-mc_fsl-mc-uapi.c:566.json
@@ -1,0 +1,41 @@
+{
+  "open": {
+    "filename": "/dev/fsl-mc",
+    "fd_name": "fd_fsl_mc",
+    "spec": "openat$KGPT_mc(fd const[AT_FDCWD], file ptr[in, string[\"/dev/fsl-mc\"]], flags flags[open_flags], mode const[0]) fd_fsl_mc"
+  },
+  "resources": {
+    "fd_fsl_mc": {
+      "type": "fd",
+      "spec": "resource fd_fsl_mc[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/bus/fsl-mc/fsl-mc-uapi.c:566",
+  "ioctls": {
+    "FSL_MC_SEND_MC_COMMAND": {
+      "arg": "ptr[inout, fsl_mc_command]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "fsl_mc_command": "fsl_mc_command {\n\theader\tint64\n\tparams\tarray[int64, MC_CMD_NUM_OF_PARAMS]\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_mc": "openat$KGPT_mc(fd const[AT_FDCWD], file ptr[in, string[\"/dev/fsl-mc\"]], flags flags[open_flags], mode const[0]) fd_fsl_mc",
+    "ioctl$KGPT_FSL_MC_SEND_MC_COMMAND": "ioctl$KGPT_FSL_MC_SEND_MC_COMMAND(fd fd_fsl_mc, cmd const[FSL_MC_SEND_MC_COMMAND], arg ptr[inout, fsl_mc_command])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_mc"
+  ],
+  "includes": [
+    "uapi/linux/fsl_mc.h",
+    "uapi/linux/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "MC_CMD_NUM_OF_PARAMS": "UNFOUND_MACRO"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/gc2235_core_ops#drivers_staging_media_atomisp_i2c_atomisp-gc2235.c:760.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/gc2235_core_ops#drivers_staging_media_atomisp_i2c_atomisp-gc2235.c:760.json
@@ -1,0 +1,38 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_gc2235",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_gc2235"
+  },
+  "resources": {
+    "fd_gc2235": {
+      "type": "fd",
+      "spec": "resource fd_gc2235[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/staging/media/atomisp/i2c/atomisp-gc2235.c:760",
+  "ioctls": {
+    "ATOMISP_IOC_S_EXPOSURE": {
+      "arg": "ptr[in, atomisp_exposure]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "atomisp_exposure": "atomisp_exposure {\n\tintegration_time\tarray[int32, 8]\n\tshutter_speed\tarray[int32, 8]\n\tgain\tarray[int32, 4]\n\taperture\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_gc2235",
+    "ioctl$KGPT_ATOMISP_IOC_S_EXPOSURE": "ioctl$KGPT_ATOMISP_IOC_S_EXPOSURE(fd fd_gc2235, cmd const[ATOMISP_IOC_S_EXPOSURE], arg ptr[in, atomisp_exposure])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "drivers/staging/media/atomisp/include/linux/atomisp.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/gpio_fileops#drivers_gpio_gpiolib-cdev.c:2780.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/gpio_fileops#drivers_gpio_gpiolib-cdev.c:2780.json
@@ -1,0 +1,94 @@
+{
+  "open": {
+    "filename": "/dev/gpiochip#",
+    "fd_name": "fd_gpio",
+    "spec": "syz_open_dev$KGPT_gpiochip(dev ptr[in, string[\"/dev/gpiochip#\"]], id proc[0, 1], flags flags[open_flags]) fd_gpio"
+  },
+  "resources": {
+    "fd_gpio": {
+      "type": "fd",
+      "spec": "resource fd_gpio[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/gpio/gpiolib-cdev.c:2780",
+  "ioctls": {
+    "GPIO_GET_CHIPINFO_IOCTL": {
+      "arg": "ptr[out, gpiochip_info]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "GPIO_GET_LINEHANDLE_IOCTL": {
+      "arg": "ptr[in, gpiohandle_request]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "GPIO_GET_LINEEVENT_IOCTL": {
+      "arg": "ptr[in, gpioevent_request]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "GPIO_GET_LINEINFO_IOCTL": {
+      "arg": "ptr[in,out, gpioline_info]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "GPIO_GET_LINEINFO_WATCH_IOCTL": {
+      "arg": "ptr[inout, gpioline_info]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "GPIO_V2_GET_LINEINFO_IOCTL": {
+      "arg": "ptr[inout, gpio_v2_line_info]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "GPIO_V2_GET_LINEINFO_WATCH_IOCTL": {
+      "arg": "ptr[in,out, gpio_v2_line_info]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "GPIO_V2_GET_LINE_IOCTL": {
+      "arg": "ptr[in, gpio_v2_line_request]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "GPIO_GET_LINEINFO_UNWATCH_IOCTL": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "gpiochip_info": "gpiochip_info {\n\tname\tarray[int8, GPIO_MAX_NAME_SIZE]\n\tlabel\tarray[int8, GPIO_MAX_NAME_SIZE]\n\tlines\tint32\n}",
+    "gpiohandle_request": "gpiohandle_request {\n\tlineoffsets\tarray[int32, GPIOHANDLES_MAX]\n\tflags\tint32\n\tdefault_values\tarray[int8, GPIOHANDLES_MAX]\n\tconsumer_label\tarray[int8, GPIO_MAX_NAME_SIZE]\n\tlines\tint32\n\tfd\tint32\n}",
+    "gpioevent_request": "gpioevent_request {\n\tlineoffset\tint32\n\thandleflags\tint32\n\teventflags\tint32\n\tconsumer_label\tarray[int8, GPIO_MAX_NAME_SIZE]\n\tfd\tint32\n}",
+    "gpioline_info": "gpioline_info {\n\tline_offset\tint32\n\tflags\tint32\n\tname\tarray[int8, GPIO_MAX_NAME_SIZE]\n\tconsumer\tarray[int8, GPIO_MAX_NAME_SIZE]\n}",
+    "gpio_v2_line_info": "gpio_v2_line_info {\n\tname\tarray[int8, GPIO_MAX_NAME_SIZE]\n\tconsumer\tarray[int8, GPIO_MAX_NAME_SIZE]\n\toffset\tint32\n\tnum_attrs\tint32\n\tflags\tint64\n\tattrs\tarray[gpio_v2_line_attribute, GPIO_V2_LINE_NUM_ATTRS_MAX]\n\tpadding\tarray[int32, 4]\n}",
+    "gpio_v2_line_request": "gpio_v2_line_request {\n\toffsets\tarray[int32, GPIO_V2_LINES_MAX]\n\tconsumer\tarray[int8, GPIO_MAX_NAME_SIZE]\n\tconfig\tgpio_v2_line_config\n\tnum_lines\tint32\n\tevent_buffer_size\tint32\n\tpadding\tarray[int32, 5]\n\tfd\tint32\n}",
+    "gpio_v2_line_attribute": "gpio_v2_line_attribute {\n\tid\tint32\n\tpadding\tint32\n\tflags\tint64\n\tvalues\tint64\n\tdebounce_period_us\tint32\n}",
+    "gpio_v2_line_config": "gpio_v2_line_config {\n\tflags\tint64\n\tnum_attrs\tint32\n\tpadding\tarray[int32, 5]\n\tattrs\tarray[gpio_v2_line_config_attribute, GPIO_V2_LINE_NUM_ATTRS_MAX]\n}",
+    "gpio_v2_line_config_attribute": "gpio_v2_line_config_attribute {\n\tattr\tgpio_v2_line_attribute\n\tmask\tint64\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_gpiochip": "syz_open_dev$KGPT_gpiochip(dev ptr[in, string[\"/dev/gpiochip#\"]], id proc[0, 1], flags flags[open_flags]) fd_gpio",
+    "ioctl$KGPT_GPIO_GET_CHIPINFO_IOCTL": "ioctl$KGPT_GPIO_GET_CHIPINFO_IOCTL(fd fd_gpio, cmd const[GPIO_GET_CHIPINFO_IOCTL], arg ptr[out, gpiochip_info])",
+    "ioctl$KGPT_GPIO_GET_LINEHANDLE_IOCTL": "ioctl$KGPT_GPIO_GET_LINEHANDLE_IOCTL(fd fd_gpio, cmd const[GPIO_GET_LINEHANDLE_IOCTL], arg ptr[in, gpiohandle_request])",
+    "ioctl$KGPT_GPIO_GET_LINEEVENT_IOCTL": "ioctl$KGPT_GPIO_GET_LINEEVENT_IOCTL(fd fd_gpio, cmd const[GPIO_GET_LINEEVENT_IOCTL], arg ptr[in, gpioevent_request])",
+    "ioctl$KGPT_GPIO_GET_LINEINFO_IOCTL": "ioctl$KGPT_GPIO_GET_LINEINFO_IOCTL(fd fd_gpio, cmd const[GPIO_GET_LINEINFO_IOCTL], arg ptr[inout, gpioline_info])",
+    "ioctl$KGPT_GPIO_GET_LINEINFO_WATCH_IOCTL": "ioctl$KGPT_GPIO_GET_LINEINFO_WATCH_IOCTL(fd fd_gpio, cmd const[GPIO_GET_LINEINFO_WATCH_IOCTL], arg ptr[inout, gpioline_info])",
+    "ioctl$KGPT_GPIO_V2_GET_LINEINFO_IOCTL": "ioctl$KGPT_GPIO_V2_GET_LINEINFO_IOCTL(fd fd_gpio, cmd const[GPIO_V2_GET_LINEINFO_IOCTL], arg ptr[inout, gpio_v2_line_info])",
+    "ioctl$KGPT_GPIO_V2_GET_LINEINFO_WATCH_IOCTL": "ioctl$KGPT_GPIO_V2_GET_LINEINFO_WATCH_IOCTL(fd fd_gpio, cmd const[GPIO_V2_GET_LINEINFO_WATCH_IOCTL], arg ptr[inout, gpio_v2_line_info])",
+    "ioctl$KGPT_GPIO_V2_GET_LINE_IOCTL": "ioctl$KGPT_GPIO_V2_GET_LINE_IOCTL(fd fd_gpio, cmd const[GPIO_V2_GET_LINE_IOCTL], arg ptr[in, gpio_v2_line_request])",
+    "ioctl$KGPT_GPIO_GET_LINEINFO_UNWATCH_IOCTL": "ioctl$KGPT_GPIO_GET_LINEINFO_UNWATCH_IOCTL(fd fd_gpio, cmd const[GPIO_GET_LINEINFO_UNWATCH_IOCTL], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_gpiochip"
+  ],
+  "includes": [
+    "uapi/linux/gpio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/gup_test_fops#mm_gup_test.c:380.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/gup_test_fops#mm_gup_test.c:380.json
@@ -1,0 +1,91 @@
+{
+  "open": {
+    "filename": "/sys/kernel/debug/gup_test",
+    "fd_name": "fd_gup_test",
+    "spec": "openat$KGPT_gup_test(fd const[AT_FDCWD], file ptr[in, string[\"/sys/kernel/debug/gup_test\"]], flags const[O_RDWR], mode const[0]) fd_gup_test"
+  },
+  "resources": {
+    "fd_gup_test": {
+      "type": "fd",
+      "spec": "resource fd_gup_test[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/mm/gup_test.c:380",
+  "ioctls": {
+    "GUP_FAST_BENCHMARK": {
+      "arg": "ptr[inout, gup_test]",
+      "arg_name_in_usage": "gup",
+      "arg_inference": null
+    },
+    "PIN_FAST_BENCHMARK": {
+      "arg": "ptr[inout, gup_test]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "PIN_LONGTERM_BENCHMARK": {
+      "arg": "ptr[inout, gup_test]",
+      "arg_name_in_usage": "gup",
+      "arg_inference": null
+    },
+    "GUP_BASIC_TEST": {
+      "arg": "ptr[inout, gup_test]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "PIN_BASIC_TEST": {
+      "arg": "ptr[inout, gup_test]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "DUMP_USER_PAGES_TEST": {
+      "arg": "ptr[inout, gup_test]",
+      "arg_name_in_usage": "gup",
+      "arg_inference": null
+    },
+    "PIN_LONGTERM_TEST_START": {
+      "arg": "int64",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "PIN_LONGTERM_TEST_STOP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "PIN_LONGTERM_TEST_READ": {
+      "arg": "ptr[in, pin_longterm_test_args]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "gup_test": "gup_test {\n\tget_delta_usec\tint64\n\tput_delta_usec\tint64\n\taddr\tint64\n\tsize\tint64\n\tnr_pages_per_call\tint32\n\tgup_flags\tint32\n\ttest_flags\tint32\n\twhich_pages\tarray[int32, GUP_TEST_MAX_PAGES_TO_DUMP]\n}",
+    "pin_longterm_test_args": "type pin_longterm_test_args ptr[in, array[int8]]"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_gup_test": "openat$KGPT_gup_test(fd const[AT_FDCWD], file ptr[in, string[\"/sys/kernel/debug/gup_test\"]], flags const[O_RDWR], mode const[0]) fd_gup_test",
+    "ioctl$KGPT_GUP_FAST_BENCHMARK": "ioctl$KGPT_GUP_FAST_BENCHMARK(fd fd_gup_test, cmd const[GUP_FAST_BENCHMARK], arg ptr[inout, gup_test])",
+    "ioctl$KGPT_PIN_FAST_BENCHMARK": "ioctl$KGPT_PIN_FAST_BENCHMARK(fd fd_gup_test, cmd const[PIN_FAST_BENCHMARK], arg ptr[inout, gup_test])",
+    "ioctl$KGPT_PIN_LONGTERM_BENCHMARK": "ioctl$KGPT_PIN_LONGTERM_BENCHMARK(fd fd_gup_test, cmd const[PIN_LONGTERM_BENCHMARK], arg ptr[inout, gup_test])",
+    "ioctl$KGPT_GUP_BASIC_TEST": "ioctl$KGPT_GUP_BASIC_TEST(fd fd_gup_test, cmd const[GUP_BASIC_TEST], arg ptr[inout, gup_test])",
+    "ioctl$KGPT_PIN_BASIC_TEST": "ioctl$KGPT_PIN_BASIC_TEST(fd fd_gup_test, cmd const[PIN_BASIC_TEST], arg ptr[inout, gup_test])",
+    "ioctl$KGPT_DUMP_USER_PAGES_TEST": "ioctl$KGPT_DUMP_USER_PAGES_TEST(fd fd_gup_test, cmd const[DUMP_USER_PAGES_TEST], arg ptr[inout, gup_test])",
+    "ioctl$KGPT_PIN_LONGTERM_TEST_START": "ioctl$KGPT_PIN_LONGTERM_TEST_START(fd fd_gup_test, cmd const[PIN_LONGTERM_TEST_START], arg int64)",
+    "ioctl$KGPT_PIN_LONGTERM_TEST_STOP": "ioctl$KGPT_PIN_LONGTERM_TEST_STOP(fd fd_gup_test, cmd const[PIN_LONGTERM_TEST_STOP], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_PIN_LONGTERM_TEST_READ": "ioctl$KGPT_PIN_LONGTERM_TEST_READ(fd fd_gup_test, cmd const[PIN_LONGTERM_TEST_READ], arg ptr[in, pin_longterm_test_args])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_gup_test"
+  ],
+  "includes": [
+    "mm/gup_test.h",
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "GUP_TEST_MAX_PAGES_TO_DUMP": "UNFOUND_MACRO"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/h3a_aewb_subdev_core_ops#drivers_media_platform_ti_omap3isp_isph3a_aewb.c:269.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/h3a_aewb_subdev_core_ops#drivers_media_platform_ti_omap3isp_isph3a_aewb.c:269.json
@@ -1,0 +1,60 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_h3a_aewb",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_h3a_aewb"
+  },
+  "resources": {
+    "fd_h3a_aewb": {
+      "type": "fd",
+      "spec": "resource fd_h3a_aewb[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/platform/ti/omap3isp/isph3a_aewb.c:269",
+  "ioctls": {
+    "VIDIOC_OMAP3ISP_AEWB_CFG": {
+      "arg": "ptr[in, ispstat_generic_config]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_OMAP3ISP_STAT_REQ": {
+      "arg": "ptr[in,out, omap3isp_stat_data]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_OMAP3ISP_STAT_REQ_TIME32": {
+      "arg": "ptr[in, omap3isp_stat_data_time32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_OMAP3ISP_STAT_EN": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "omap3isp_stat_data": "omap3isp_stat_data {\n\tts\ttimespec\n\tbuf\tptr[out, array[int8]]\n\tframe\tomap3isp_stat_data_frame\n}",
+    "ispstat_generic_config": "ispstat_generic_config {\n\tbuf_size\tint32\n\tconfig_counter\tint16\n}",
+    "omap3isp_stat_data_time32": "omap3isp_stat_data_time32 {\n\tts\ttimespec32\n\tbuf\tint32\n\tbuf_size\tint32\n\tframe_number\tint16\n\tcur_frame\tint16\n\tconfig_counter\tint16\n}",
+    "omap3isp_stat_data_frame": "omap3isp_stat_data_frame {\n\tbuf_size\tint32\n\tframe_number\tint16\n\tcur_frame\tint16\n\tconfig_counter\tint16\n}",
+    "timespec32": "timespec32 {\n\ttv_sec\tint32\n\ttv_usec\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_h3a_aewb",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_AEWB_CFG": "ioctl$KGPT_VIDIOC_OMAP3ISP_AEWB_CFG(fd fd_h3a_aewb, cmd const[VIDIOC_OMAP3ISP_AEWB_CFG], arg ptr[in, ispstat_generic_config])",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ": "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ(fd fd_h3a_aewb, cmd const[VIDIOC_OMAP3ISP_STAT_REQ], arg ptr[inout, omap3isp_stat_data])",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ_TIME32": "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ_TIME32(fd fd_h3a_aewb, cmd const[VIDIOC_OMAP3ISP_STAT_REQ_TIME32], arg ptr[in, omap3isp_stat_data_time32])",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_EN": "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_EN(fd fd_h3a_aewb, cmd const[VIDIOC_OMAP3ISP_STAT_EN], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "uapi/linux/omap3isp.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/h3a_af_subdev_core_ops#drivers_media_platform_ti_omap3isp_isph3a_af.c:334.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/h3a_af_subdev_core_ops#drivers_media_platform_ti_omap3isp_isph3a_af.c:334.json
@@ -1,0 +1,60 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_h3a_af",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_h3a_af"
+  },
+  "resources": {
+    "fd_h3a_af": {
+      "type": "fd",
+      "spec": "resource fd_h3a_af[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/platform/ti/omap3isp/isph3a_af.c:334",
+  "ioctls": {
+    "VIDIOC_OMAP3ISP_AF_CFG": {
+      "arg": "ptr[in, ispstat_generic_config]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_OMAP3ISP_STAT_REQ": {
+      "arg": "ptr[in,out, omap3isp_stat_data]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_OMAP3ISP_STAT_REQ_TIME32": {
+      "arg": "ptr[in,out, omap3isp_stat_data_time32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_OMAP3ISP_STAT_EN": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "omap3isp_stat_data": "omap3isp_stat_data {\n\tts\ttimespec\n\tbuf\tptr[out, array[int8]]\n\tframe\tomap3isp_stat_data_frame\n}",
+    "ispstat_generic_config": "ispstat_generic_config {\n\tbuf_size\tint32\n\tconfig_counter\tint16\n}",
+    "omap3isp_stat_data_time32": "omap3isp_stat_data_time32 {\n\tts\ttimespec32\n\tbuf\tint32\n\tbuf_size\tint32\n\tframe_number\tint16\n\tcur_frame\tint16\n\tconfig_counter\tint16\n}",
+    "omap3isp_stat_data_frame": "omap3isp_stat_data_frame {\n\tbuf_size\tint32\n\tframe_number\tint16\n\tcur_frame\tint16\n\tconfig_counter\tint16\n}",
+    "timespec32": "timespec32 {\n\ttv_sec\tint32\n\ttv_usec\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_h3a_af",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_AF_CFG": "ioctl$KGPT_VIDIOC_OMAP3ISP_AF_CFG(fd fd_h3a_af, cmd const[VIDIOC_OMAP3ISP_AF_CFG], arg ptr[in, ispstat_generic_config])",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ": "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ(fd fd_h3a_af, cmd const[VIDIOC_OMAP3ISP_STAT_REQ], arg ptr[inout, omap3isp_stat_data])",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ_TIME32": "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ_TIME32(fd fd_h3a_af, cmd const[VIDIOC_OMAP3ISP_STAT_REQ_TIME32], arg ptr[inout, omap3isp_stat_data_time32])",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_EN": "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_EN(fd fd_h3a_af, cmd const[VIDIOC_OMAP3ISP_STAT_EN], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "uapi/linux/omap3isp.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/hci_uart_ldisc#drivers_bluetooth_hci_ldisc.c:822.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/hci_uart_ldisc#drivers_bluetooth_hci_ldisc.c:822.json
@@ -1,0 +1,359 @@
+{
+  "open": {
+    "filename": "/dev/pts/#",
+    "fd_name": "fd_hci_uart",
+    "spec": "syz_open_dev$KGPT_hci_uart(dev ptr[in, string[\"/dev/pts/#\"]], id proc[0, 1], flags flags[open_flags]) fd_hci_uart"
+  },
+  "resources": {
+    "fd_hci_uart": {
+      "type": "fd",
+      "spec": "resource fd_hci_uart[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/bluetooth/hci_ldisc.c:822",
+  "ioctls": {
+    "HCIUARTGETPROTO": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "HCIUARTGETDEVICE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "HCIUARTGETFLAGS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "HCIUARTSETPROTO": {
+      "arg": "intptr",
+      "arg_name_in_usage": "id",
+      "arg_inference": null
+    },
+    "HCIUARTSETFLAGS": {
+      "arg": "flags[hci_uart_flags]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "TIOCSETN": {
+      "arg": "ptr[in, sgttyb]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "TCXONC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_check_change",
+          "__stop_tty",
+          "__start_tty",
+          "tty_send_xchar"
+        ],
+        "type": [],
+        "usage": [
+          "switch (arg) {",
+          "case TCOOFF:",
+          "case TCOON:",
+          "case TCIOFF:",
+          "case TCION:",
+          "default:"
+        ]
+      }
+    },
+    "TCFLSH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_check_change",
+          "__tty_perform_flush"
+        ],
+        "type": [],
+        "usage": [
+          "retval = tty_check_change(tty);",
+          "return __tty_perform_flush(tty, arg);"
+        ]
+      }
+    },
+    "TIOCGETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return get_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCSETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return set_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCGETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCGLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETSF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p,  TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETSW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCGETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))\n\t\t\tret = -EFAULT;"
+        ]
+      }
+    },
+    "TCGETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_termio"
+        ],
+        "type": [],
+        "usage": [
+          "return get_termio(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETAF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETAW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TIOCGSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "ret = put_user((kterm.c_cflag & CLOCAL) ? 1 : 0,\n\t\t\t\t\t(int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCSSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user",
+          "tty_change_softcar"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(arg, (unsigned int __user *) arg))\n\t\t\treturn -EFAULT;",
+          "return tty_change_softcar(real_tty, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_hci_uart": "syz_open_dev$KGPT_hci_uart(dev ptr[in, string[\"/dev/pts/#\"]], id proc[0, 1], flags flags[open_flags]) fd_hci_uart",
+    "ioctl$KGPT_HCIUARTGETPROTO": "ioctl$KGPT_HCIUARTGETPROTO(fd fd_hci_uart, cmd const[HCIUARTGETPROTO], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_HCIUARTGETDEVICE": "ioctl$KGPT_HCIUARTGETDEVICE(fd fd_hci_uart, cmd const[HCIUARTGETDEVICE], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_HCIUARTGETFLAGS": "ioctl$KGPT_HCIUARTGETFLAGS(fd fd_hci_uart, cmd const[HCIUARTGETFLAGS], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_HCIUARTSETPROTO": "ioctl$KGPT_HCIUARTSETPROTO(fd fd_hci_uart, cmd const[HCIUARTSETPROTO], arg intptr)",
+    "ioctl$KGPT_HCIUARTSETFLAGS": "ioctl$KGPT_HCIUARTSETFLAGS(fd fd_hci_uart, cmd const[HCIUARTSETFLAGS], arg const[0])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_hci_uart"
+  ],
+  "includes": [
+    "arch/powerpc/include/uapi/asm/ioctls.h",
+    "drivers/bluetooth/hci_uart.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/hisi_acc_vfio_pci_migrn_ops#drivers_vfio_pci_hisilicon_hisi_acc_vfio_pci.c:1360.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/hisi_acc_vfio_pci_migrn_ops#drivers_vfio_pci_hisilicon_hisi_acc_vfio_pci.c:1360.json
@@ -1,0 +1,107 @@
+{
+  "open": {
+    "filename": "/dev/vfio/#",
+    "fd_name": "fd_hisi_acc_vfio_pci",
+    "spec": "syz_open_dev$KGPT_vfio(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_hisi_acc_vfio_pci"
+  },
+  "resources": {
+    "fd_hisi_acc_vfio_pci": {
+      "type": "fd",
+      "spec": "resource fd_hisi_acc_vfio_pci[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/vfio/pci/hisilicon/hisi_acc_vfio_pci.c:1360",
+  "ioctls": {
+    "VFIO_DEVICE_GET_REGION_INFO": {
+      "arg": "ptr[inout, vfio_region_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_INFO": {
+      "arg": "ptr[out, vfio_device_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_IRQ_INFO": {
+      "arg": "ptr[in,out, vfio_irq_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_PCI_HOT_RESET_INFO": {
+      "arg": "ptr[inout, vfio_pci_hot_reset_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_IOEVENTFD": {
+      "arg": "ptr[in, vfio_device_ioeventfd]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_PCI_HOT_RESET": {
+      "arg": "ptr[in, vfio_pci_hot_reset]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_SET_IRQS": {
+      "arg": "ptr[in, vfio_irq_set]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "vfio_device_info": "vfio_device_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_flags, int32]\n\tnum_regions\tint32\n\tnum_irqs\tint32\n\tcap_offset\tint32\n\tpad\tint32\n}",
+    "vfio_device_ioeventfd": "vfio_device_ioeventfd {\n\targsz\tint32\n\tflags\tflags[vfio_device_ioeventfd_flags, int32]\n\toffset\tint64\n\tdata\tint64\n\tfd\tint32\n\treserved\tint32\n}",
+    "vfio_region_info": "vfio_region_info {\n\targsz\tint32\n\tflags\tflags[vfio_region_info_flags, int32]\n\tindex\tint32\n\tcap_offset\tint32\n\tsize\tint64\n\toffset\tint64\n}",
+    "vfio_pci_hot_reset_info": "vfio_pci_hot_reset_info {\n\targsz\tint32\n\tflags\tflags[vfio_pci_hot_reset_flags, int32]\n\tcount\tlen[devices, int32]\n\tdevices\tptr[inout, array[vfio_pci_dependent_device]]\n}",
+    "vfio_pci_hot_reset": "vfio_pci_hot_reset {\n\targsz\tint32\n\tflags\tint32\n\tcount\tlen[group_fds, int32]\n\tgroup_fds\tptr[in, array[int32]]\n}",
+    "vfio_irq_set": "vfio_irq_set {\n\targsz\tint32\n\tflags\tflags[vfio_irq_set_flags, int32]\n\tindex\tint32\n\tstart\tint32\n\tcount\tlen[data, int32]\n\tdata\tptr[in, array[int8]]\n}",
+    "vfio_irq_info": "vfio_irq_info {\n\targsz\tint32\n\tflags\tflags[vfio_irq_info_flags, int32]\n\tindex\tint32\n\tcount\tint32\n}",
+    "vfio_region_info_flags": "vfio_region_info_flags = VFIO_REGION_INFO_FLAG_READ, VFIO_REGION_INFO_FLAG_WRITE, VFIO_REGION_INFO_FLAG_MMAP, VFIO_REGION_INFO_FLAG_CAPS",
+    "vfio_device_flags": "vfio_device_flags = VFIO_DEVICE_FLAGS_RESET, VFIO_DEVICE_FLAGS_PCI, VFIO_DEVICE_FLAGS_PLATFORM, VFIO_DEVICE_FLAGS_AMBA, VFIO_DEVICE_FLAGS_CCW, VFIO_DEVICE_FLAGS_AP, VFIO_DEVICE_FLAGS_FSL_MC, VFIO_DEVICE_FLAGS_CAPS, VFIO_DEVICE_FLAGS_CDX",
+    "vfio_irq_info_flags": "vfio_irq_info_flags = VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_INFO_MASKABLE, VFIO_IRQ_INFO_AUTOMASKED, VFIO_IRQ_INFO_NORESIZE",
+    "vfio_pci_hot_reset_flags": "vfio_pci_hot_reset_flags = VFIO_PCI_HOT_RESET_FLAG_DEV_ID, VFIO_PCI_HOT_RESET_FLAG_DEV_ID_OWNED",
+    "vfio_device_ioeventfd_flags": "vfio_device_ioeventfd_flags = VFIO_DEVICE_IOEVENTFD_8, VFIO_DEVICE_IOEVENTFD_16, VFIO_DEVICE_IOEVENTFD_32, VFIO_DEVICE_IOEVENTFD_64",
+    "vfio_irq_set_flags": "vfio_irq_set_flags = VFIO_IRQ_SET_DATA_NONE, VFIO_IRQ_SET_DATA_BOOL, VFIO_IRQ_SET_DATA_EVENTFD, VFIO_IRQ_SET_ACTION_MASK, VFIO_IRQ_SET_ACTION_UNMASK, VFIO_IRQ_SET_ACTION_TRIGGER",
+    "vfio_pci_dependent_device": "vfio_pci_dependent_device {\n\tgroup_id\tint32\n\tsegment\tint16\n\tbus\tint8\n\tdevfn\tint8\n}",
+    "VFIO_REGION_INFO_FLAG_READ": "define VFIO_REGION_INFO_FLAG_READ 0x1",
+    "VFIO_REGION_INFO_FLAG_WRITE": "define VFIO_REGION_INFO_FLAG_WRITE 0x2",
+    "VFIO_REGION_INFO_FLAG_MMAP": "define VFIO_REGION_INFO_FLAG_MMAP 0x4",
+    "VFIO_REGION_INFO_FLAG_CAPS": "define VFIO_REGION_INFO_FLAG_CAPS 0x8",
+    "VFIO_IRQ_INFO_EVENTFD": "define VFIO_IRQ_INFO_EVENTFD 1",
+    "VFIO_IRQ_INFO_MASKABLE": "define VFIO_IRQ_INFO_MASKABLE 2",
+    "VFIO_IRQ_INFO_AUTOMASKED": "define VFIO_IRQ_INFO_AUTOMASKED 4",
+    "VFIO_IRQ_INFO_NORESIZE": "define VFIO_IRQ_INFO_NORESIZE 8",
+    "VFIO_IRQ_SET_DATA_NONE": "define VFIO_IRQ_SET_DATA_NONE 1",
+    "VFIO_IRQ_SET_DATA_BOOL": "define VFIO_IRQ_SET_DATA_BOOL 2",
+    "VFIO_IRQ_SET_DATA_EVENTFD": "define VFIO_IRQ_SET_DATA_EVENTFD 4",
+    "VFIO_IRQ_SET_ACTION_MASK": "define VFIO_IRQ_SET_ACTION_MASK 8",
+    "VFIO_IRQ_SET_ACTION_UNMASK": "define VFIO_IRQ_SET_ACTION_UNMASK 16",
+    "VFIO_IRQ_SET_ACTION_TRIGGER": "define VFIO_IRQ_SET_ACTION_TRIGGER 32"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_vfio": "syz_open_dev$KGPT_vfio(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_hisi_acc_vfio_pci",
+    "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_GET_REGION_INFO], arg ptr[inout, vfio_region_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_INFO(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_GET_INFO], arg ptr[out, vfio_device_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_GET_IRQ_INFO], arg ptr[inout, vfio_irq_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_PCI_HOT_RESET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_PCI_HOT_RESET_INFO(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_GET_PCI_HOT_RESET_INFO], arg ptr[inout, vfio_pci_hot_reset_info])",
+    "ioctl$KGPT_VFIO_DEVICE_IOEVENTFD": "ioctl$KGPT_VFIO_DEVICE_IOEVENTFD(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_IOEVENTFD], arg ptr[in, vfio_device_ioeventfd])",
+    "ioctl$KGPT_VFIO_DEVICE_PCI_HOT_RESET": "ioctl$KGPT_VFIO_DEVICE_PCI_HOT_RESET(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_PCI_HOT_RESET], arg ptr[in, vfio_pci_hot_reset])",
+    "ioctl$KGPT_VFIO_DEVICE_RESET": "ioctl$KGPT_VFIO_DEVICE_RESET(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_SET_IRQS": "ioctl$KGPT_VFIO_DEVICE_SET_IRQS(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_SET_IRQS], arg ptr[in, vfio_irq_set])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_vfio"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/hisi_acc_vfio_pci_ops#drivers_vfio_pci_hisilicon_hisi_acc_vfio_pci.c:1379.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/hisi_acc_vfio_pci_ops#drivers_vfio_pci_hisilicon_hisi_acc_vfio_pci.c:1379.json
@@ -1,0 +1,97 @@
+{
+  "open": {
+    "filename": "/dev/vfio/#",
+    "fd_name": "fd_hisi_acc_vfio_pci",
+    "spec": "syz_open_dev$KGPT_vfio_pci(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_hisi_acc_vfio_pci"
+  },
+  "resources": {
+    "fd_hisi_acc_vfio_pci": {
+      "type": "fd",
+      "spec": "resource fd_hisi_acc_vfio_pci[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/vfio/pci/hisilicon/hisi_acc_vfio_pci.c:1379",
+  "ioctls": {
+    "VFIO_DEVICE_GET_INFO": {
+      "arg": "ptr[out, vfio_device_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_IRQ_INFO": {
+      "arg": "ptr[in,out, vfio_irq_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_PCI_HOT_RESET_INFO": {
+      "arg": "ptr[inout, vfio_pci_hot_reset_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_REGION_INFO": {
+      "arg": "ptr[in,out, vfio_region_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_IOEVENTFD": {
+      "arg": "ptr[in, vfio_device_ioeventfd]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_PCI_HOT_RESET": {
+      "arg": "ptr[in, vfio_pci_hot_reset]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_SET_IRQS": {
+      "arg": "ptr[in, vfio_irq_set]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "vfio_device_info": "vfio_device_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_flags, int32]\n\tnum_regions\tint32\n\tnum_irqs\tint32\n\tcap_offset\tint32\n\tpad\tint32\n}",
+    "vfio_region_info": "vfio_region_info {\n\targsz\tint32\n\tflags\tflags[vfio_region_info_flags, int32]\n\tindex\tint32\n\tcap_offset\tint32\n\tsize\tint64\n\toffset\tint64\n}",
+    "vfio_device_ioeventfd": "vfio_device_ioeventfd {\n\targsz\tint32\n\tflags\tflags[vfio_device_ioeventfd_flags, int32]\n\toffset\tint64\n\tdata\tint64\n\tfd\tint32\n\treserved\tint32\n}",
+    "vfio_pci_hot_reset_info": "vfio_pci_hot_reset_info {\n\targsz\tint32\n\tflags\tflags[vfio_pci_hot_reset_flags, int32]\n\tcount\tlen[devices, int32]\n\tdevices\tptr[inout, array[vfio_pci_dependent_device]]\n}",
+    "vfio_pci_hot_reset": "vfio_pci_hot_reset {\n\targsz\tint32\n\tflags\tint32\n\tcount\tlen[group_fds, int32]\n\tgroup_fds\tptr[in, array[int32]]\n}",
+    "vfio_irq_set": "vfio_irq_set {\n\targsz\tint32\n\tflags\tflags[vfio_irq_set_flags, int32]\n\tindex\tint32\n\tstart\tint32\n\tcount\tlen[data, int32]\n\tdata\tptr[in, array[int8]]\n}",
+    "vfio_irq_info": "vfio_irq_info {\n\targsz\tint32\n\tflags\tflags[vfio_irq_info_flags, int32]\n\tindex\tint32\n\tcount\tint32\n}",
+    "vfio_device_flags": "vfio_device_flags = VFIO_DEVICE_FLAGS_RESET, VFIO_DEVICE_FLAGS_PCI, VFIO_DEVICE_FLAGS_PLATFORM, VFIO_DEVICE_FLAGS_AMBA, VFIO_DEVICE_FLAGS_CCW, VFIO_DEVICE_FLAGS_AP, VFIO_DEVICE_FLAGS_FSL_MC, VFIO_DEVICE_FLAGS_CAPS, VFIO_DEVICE_FLAGS_CDX",
+    "vfio_irq_info_flags": "vfio_irq_info_flags = VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_INFO_MASKABLE, VFIO_IRQ_INFO_AUTOMASKED, VFIO_IRQ_INFO_NORESIZE",
+    "vfio_pci_hot_reset_flags": "vfio_pci_hot_reset_flags = VFIO_PCI_HOT_RESET_FLAG_DEV_ID, VFIO_PCI_HOT_RESET_FLAG_DEV_ID_OWNED",
+    "vfio_region_info_flags": "vfio_region_info_flags = VFIO_REGION_INFO_FLAG_READ, VFIO_REGION_INFO_FLAG_WRITE, VFIO_REGION_INFO_FLAG_MMAP, VFIO_REGION_INFO_FLAG_CAPS",
+    "vfio_device_ioeventfd_flags": "vfio_device_ioeventfd_flags = VFIO_DEVICE_IOEVENTFD_8, VFIO_DEVICE_IOEVENTFD_16, VFIO_DEVICE_IOEVENTFD_32, VFIO_DEVICE_IOEVENTFD_64",
+    "vfio_irq_set_flags": "vfio_irq_set_flags = VFIO_IRQ_SET_DATA_NONE, VFIO_IRQ_SET_DATA_BOOL, VFIO_IRQ_SET_DATA_EVENTFD, VFIO_IRQ_SET_ACTION_MASK, VFIO_IRQ_SET_ACTION_UNMASK, VFIO_IRQ_SET_ACTION_TRIGGER",
+    "vfio_pci_dependent_device": "vfio_pci_dependent_device {\n\tgroup_id\tint32\n\tsegment\tint16\n\tbus\tint8\n\tdevfn\tint8\n}",
+    "VFIO_IRQ_INFO_EVENTFD": "define VFIO_IRQ_INFO_EVENTFD 1",
+    "VFIO_IRQ_INFO_MASKABLE": "define VFIO_IRQ_INFO_MASKABLE 2",
+    "VFIO_IRQ_INFO_AUTOMASKED": "define VFIO_IRQ_INFO_AUTOMASKED 4",
+    "VFIO_IRQ_INFO_NORESIZE": "define VFIO_IRQ_INFO_NORESIZE 8"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_vfio_pci": "syz_open_dev$KGPT_vfio_pci(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_hisi_acc_vfio_pci",
+    "ioctl$KGPT_VFIO_DEVICE_GET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_INFO(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_GET_INFO], arg ptr[out, vfio_device_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_GET_IRQ_INFO], arg ptr[inout, vfio_irq_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_PCI_HOT_RESET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_PCI_HOT_RESET_INFO(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_GET_PCI_HOT_RESET_INFO], arg ptr[inout, vfio_pci_hot_reset_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_GET_REGION_INFO], arg ptr[inout, vfio_region_info])",
+    "ioctl$KGPT_VFIO_DEVICE_IOEVENTFD": "ioctl$KGPT_VFIO_DEVICE_IOEVENTFD(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_IOEVENTFD], arg ptr[in, vfio_device_ioeventfd])",
+    "ioctl$KGPT_VFIO_DEVICE_PCI_HOT_RESET": "ioctl$KGPT_VFIO_DEVICE_PCI_HOT_RESET(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_PCI_HOT_RESET], arg ptr[in, vfio_pci_hot_reset])",
+    "ioctl$KGPT_VFIO_DEVICE_RESET": "ioctl$KGPT_VFIO_DEVICE_RESET(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_SET_IRQS": "ioctl$KGPT_VFIO_DEVICE_SET_IRQS(fd fd_hisi_acc_vfio_pci, cmd const[VFIO_DEVICE_SET_IRQS], arg ptr[in, vfio_irq_set])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_vfio_pci"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/hist_subdev_core_ops#drivers_media_platform_ti_omap3isp_isphist.c:456.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/hist_subdev_core_ops#drivers_media_platform_ti_omap3isp_isphist.c:456.json
@@ -1,0 +1,60 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_isphist",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_isphist"
+  },
+  "resources": {
+    "fd_isphist": {
+      "type": "fd",
+      "spec": "resource fd_isphist[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/platform/ti/omap3isp/isphist.c:456",
+  "ioctls": {
+    "VIDIOC_OMAP3ISP_HIST_CFG": {
+      "arg": "ptr[in, ispstat_generic_config]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_OMAP3ISP_STAT_REQ": {
+      "arg": "ptr[in,out, omap3isp_stat_data]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_OMAP3ISP_STAT_REQ_TIME32": {
+      "arg": "ptr[in,out, omap3isp_stat_data_time32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_OMAP3ISP_STAT_EN": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "omap3isp_stat_data": "omap3isp_stat_data {\n\tts\ttimespec\n\tbuf\tptr[out, array[int8]]\n\tframe\tomap3isp_stat_data_frame\n}",
+    "ispstat_generic_config": "ispstat_generic_config {\n\tbuf_size\tint32\n\tconfig_counter\tint16\n}",
+    "omap3isp_stat_data_time32": "omap3isp_stat_data_time32 {\n\tts\ttimespec32\n\tbuf\tint32\n\tbuf_size\tint32\n\tframe_number\tint16\n\tcur_frame\tint16\n\tconfig_counter\tint16\n}",
+    "omap3isp_stat_data_frame": "omap3isp_stat_data_frame {\n\tbuf_size\tint32\n\tframe_number\tint16\n\tcur_frame\tint16\n\tconfig_counter\tint16\n}",
+    "timespec32": "timespec32 {\n\ttv_sec\tint32\n\ttv_usec\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_isphist",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_HIST_CFG": "ioctl$KGPT_VIDIOC_OMAP3ISP_HIST_CFG(fd fd_isphist, cmd const[VIDIOC_OMAP3ISP_HIST_CFG], arg ptr[in, ispstat_generic_config])",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ": "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ(fd fd_isphist, cmd const[VIDIOC_OMAP3ISP_STAT_REQ], arg ptr[inout, omap3isp_stat_data])",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ_TIME32": "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_REQ_TIME32(fd fd_isphist, cmd const[VIDIOC_OMAP3ISP_STAT_REQ_TIME32], arg ptr[inout, omap3isp_stat_data_time32])",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_EN": "ioctl$KGPT_VIDIOC_OMAP3ISP_STAT_EN(fd fd_isphist, cmd const[VIDIOC_OMAP3ISP_STAT_EN], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "uapi/linux/omap3isp.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/hpet_fops#drivers_char_hpet.c:678.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/hpet_fops#drivers_char_hpet.c:678.json
@@ -1,0 +1,82 @@
+{
+  "open": {
+    "filename": "/dev/hpet",
+    "fd_name": "fd_hpet",
+    "spec": "openat$KGPT_hpets(fd const[AT_FDCWD], file ptr[in, string[\"/dev/hpet\"]], flags const[O_RDWR], mode const[0]) fd_hpet"
+  },
+  "resources": {
+    "fd_hpet": {
+      "type": "fd",
+      "spec": "resource fd_hpet[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/char/hpet.c:678",
+  "ioctls": {
+    "HPET_IE_OFF": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "HPET_EPI": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "HPET_DPI": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "HPET_IE_ON": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "HPET_INFO": {
+      "arg": "ptr[out, hpet_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "hpet_ioctl_common",
+          "copy_to_user"
+        ],
+        "type": [
+          "hpet_info"
+        ],
+        "usage": [
+          "err = hpet_ioctl_common(file->private_data, cmd, arg, &info);",
+          "if ((cmd == HPET_INFO) && !err && (copy_to_user((void __user *)arg, &info, sizeof(info))))"
+        ]
+      }
+    },
+    "HPET_IRQFREQ": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "hpet_info": "hpet_info {\n\thi_ireqfreq\tint64\n\thi_flags\tint64\n\thi_hpet\tint16\n\thi_timer\tint16\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_hpets": "openat$KGPT_hpets(fd const[AT_FDCWD], file ptr[in, string[\"/dev/hpet\"]], flags const[O_RDWR], mode const[0]) fd_hpet",
+    "ioctl$KGPT_HPET_IE_OFF": "ioctl$KGPT_HPET_IE_OFF(fd fd_hpet, cmd const[HPET_IE_OFF], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_HPET_EPI": "ioctl$KGPT_HPET_EPI(fd fd_hpet, cmd const[HPET_EPI], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_HPET_DPI": "ioctl$KGPT_HPET_DPI(fd fd_hpet, cmd const[HPET_DPI], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_HPET_IE_ON": "ioctl$KGPT_HPET_IE_ON(fd fd_hpet, cmd const[HPET_IE_ON], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_HPET_INFO": "ioctl$KGPT_HPET_INFO(fd fd_hpet, cmd const[HPET_INFO], arg ptr[out, hpet_info])",
+    "ioctl$KGPT_HPET_IRQFREQ": "ioctl$KGPT_HPET_IRQFREQ(fd fd_hpet, cmd const[HPET_IRQFREQ], arg intptr)"
+  },
+  "init_syscalls": [
+    "openat$KGPT_hpets"
+  ],
+  "includes": [
+    "uapi/linux/hpet.h",
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/hub_driver#drivers_usb_core_hub.c:5930.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/hub_driver#drivers_usb_core_hub.c:5930.json
@@ -1,0 +1,38 @@
+{
+  "open": {
+    "filename": "/dev/bus/usb/###/###",
+    "fd_name": "fd_usb_hub",
+    "spec": "syz_open_dev$KGPT_usb_hub(dev ptr[in, string[\"/dev/bus/usb/###/###\"]], id proc[0, 1], flags flags[open_flags]) fd_usb_hub"
+  },
+  "resources": {
+    "fd_usb_hub": {
+      "type": "fd",
+      "spec": "resource fd_usb_hub[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/usb/core/hub.c:5930",
+  "ioctls": {
+    "USBDEVFS_HUB_PORTINFO": {
+      "arg": "ptr[out, usbdevfs_hub_portinfo]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "usbdevfs_hub_portinfo": "usbdevfs_hub_portinfo {\n\tnports\tint8\n\tport\tarray[int8, 127]\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_usb_hub": "syz_open_dev$KGPT_usb_hub(dev ptr[in, string[\"/dev/bus/usb/###/###\"]], id proc[0, 1], flags flags[open_flags]) fd_usb_hub",
+    "ioctl$KGPT_USBDEVFS_HUB_PORTINFO": "ioctl$KGPT_USBDEVFS_HUB_PORTINFO(fd fd_usb_hub, cmd const[USBDEVFS_HUB_PORTINFO], arg ptr[out, usbdevfs_hub_portinfo])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_usb_hub"
+  ],
+  "includes": [
+    "uapi/linux/usbdevice_fs.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/intel_vgpu_dev_ops#drivers_gpu_drm_i915_gvt_kvmgt.c:1461.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/intel_vgpu_dev_ops#drivers_gpu_drm_i915_gvt_kvmgt.c:1461.json
@@ -1,0 +1,111 @@
+{
+  "open": {
+    "filename": "/dev/vfio/vfio",
+    "fd_name": "fd_vgpu",
+    "spec": "openat$KGPT_vgpu(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vfio/vfio\"]], flags const[O_RDWR], mode const[0]) fd_vgpu"
+  },
+  "resources": {
+    "fd_vgpu": {
+      "type": "fd",
+      "spec": "resource fd_vgpu[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/gpu/drm/i915/gvt/kvmgt.c:1461",
+  "ioctls": {
+    "VFIO_DEVICE_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_INFO": {
+      "arg": "ptr[in, vfio_device_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_REGION_INFO": {
+      "arg": "ptr[in, vfio_region_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_IRQ_INFO": {
+      "arg": "ptr[in, vfio_irq_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_SET_IRQS": {
+      "arg": "ptr[in, vfio_irq_set]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_QUERY_GFX_PLANE": {
+      "arg": "ptr[inout, vfio_device_gfx_plane_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_GFX_DMABUF": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "intel_vgpu_get_dmabuf"
+        ],
+        "type": [
+          "__u32"
+        ],
+        "usage": [
+          "__u32 dmabuf_id;",
+          "if (get_user(dmabuf_id, (__u32 __user *)arg))"
+        ]
+      }
+    }
+  },
+  "types": {
+    "vfio_device_info": "vfio_device_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_flags, int32]\n\tnum_regions\tint32\n\tnum_irqs\tint32\n\tcap_offset\tint32\n\tpad\tint32\n}",
+    "vfio_device_gfx_plane_info": "vfio_device_gfx_plane_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_gfx_plane_info_flags, int32]\n\tdrm_plane_type\tint32\n\tdrm_format\tint32\n\tdrm_format_mod\tint64\n\twidth\tint32\n\theight\tint32\n\tstride\tint32\n\tsize\tint32\n\tx_pos\tint32\n\ty_pos\tint32\n\tx_hot\tint32\n\ty_hot\tint32\n\tunion\tvfio_device_gfx_plane_info_union\n\treserved\tint32\n}",
+    "vfio_region_info": "vfio_region_info {\n\targsz\tint32\n\tflags\tflags[vfio_region_info_flags, int32]\n\tindex\tint32\n\tcap_offset\tint32\n\tsize\tint64\n\toffset\tint64\n}",
+    "vfio_irq_info": "vfio_irq_info {\n\targsz\tint32\n\tflags\tflags[vfio_irq_info_flags, int32]\n\tindex\tint32\n\tcount\tint32\n}",
+    "vfio_irq_set": "vfio_irq_set {\n\targsz\tint32\n\tflags\tflags[vfio_irq_set_flags, int32]\n\tindex\tint32\n\tstart\tint32\n\tcount\tint32\n\tdata\tarray[int8]\n}",
+    "vfio_device_flags": "vfio_device_flags = VFIO_DEVICE_FLAGS_RESET, VFIO_DEVICE_FLAGS_PCI, VFIO_DEVICE_FLAGS_PLATFORM, VFIO_DEVICE_FLAGS_AMBA, VFIO_DEVICE_FLAGS_CCW, VFIO_DEVICE_FLAGS_AP, VFIO_DEVICE_FLAGS_FSL_MC, VFIO_DEVICE_FLAGS_CAPS, VFIO_DEVICE_FLAGS_CDX",
+    "vfio_region_info_flags": "vfio_region_info_flags = VFIO_REGION_INFO_FLAG_READ, VFIO_REGION_INFO_FLAG_WRITE, VFIO_REGION_INFO_FLAG_MMAP, VFIO_REGION_INFO_FLAG_CAPS",
+    "vfio_irq_info_flags": "vfio_irq_info_flags = VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_INFO_MASKABLE, VFIO_IRQ_INFO_AUTOMASKED, VFIO_IRQ_INFO_NORESIZE",
+    "vfio_irq_set_flags": "vfio_irq_set_flags = VFIO_IRQ_SET_DATA_NONE, VFIO_IRQ_SET_DATA_BOOL, VFIO_IRQ_SET_DATA_EVENTFD, VFIO_IRQ_SET_ACTION_MASK, VFIO_IRQ_SET_ACTION_UNMASK, VFIO_IRQ_SET_ACTION_TRIGGER",
+    "vfio_device_gfx_plane_info_flags": "vfio_device_gfx_plane_info_flags = VFIO_GFX_PLANE_TYPE_PROBE, VFIO_GFX_PLANE_TYPE_DMABUF, VFIO_GFX_PLANE_TYPE_REGION",
+    "vfio_device_gfx_plane_info_union": "vfio_device_gfx_plane_info_union [\n\tregion_index\tint32\n\tdmabuf_id\tint32\n]",
+    "VFIO_REGION_INFO_FLAG_READ": "define VFIO_REGION_INFO_FLAG_READ 0x1",
+    "VFIO_REGION_INFO_FLAG_WRITE": "define VFIO_REGION_INFO_FLAG_WRITE 0x2",
+    "VFIO_REGION_INFO_FLAG_MMAP": "define VFIO_REGION_INFO_FLAG_MMAP 0x4",
+    "VFIO_REGION_INFO_FLAG_CAPS": "define VFIO_REGION_INFO_FLAG_CAPS 0x8",
+    "VFIO_IRQ_INFO_EVENTFD": "define VFIO_IRQ_INFO_EVENTFD 1",
+    "VFIO_IRQ_INFO_MASKABLE": "define VFIO_IRQ_INFO_MASKABLE 2",
+    "VFIO_IRQ_INFO_AUTOMASKED": "define VFIO_IRQ_INFO_AUTOMASKED 4",
+    "VFIO_IRQ_INFO_NORESIZE": "define VFIO_IRQ_INFO_NORESIZE 8",
+    "VFIO_IRQ_SET_DATA_NONE": "define VFIO_IRQ_SET_DATA_NONE 0x1",
+    "VFIO_IRQ_SET_DATA_BOOL": "define VFIO_IRQ_SET_DATA_BOOL 0x2",
+    "VFIO_IRQ_SET_DATA_EVENTFD": "define VFIO_IRQ_SET_DATA_EVENTFD 0x4",
+    "VFIO_IRQ_SET_ACTION_MASK": "define VFIO_IRQ_SET_ACTION_MASK 0x8",
+    "VFIO_IRQ_SET_ACTION_UNMASK": "define VFIO_IRQ_SET_ACTION_UNMASK 0x10",
+    "VFIO_IRQ_SET_ACTION_TRIGGER": "define VFIO_IRQ_SET_ACTION_TRIGGER 0x20"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_vgpu": "openat$KGPT_vgpu(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vfio/vfio\"]], flags const[O_RDWR], mode const[0]) fd_vgpu",
+    "ioctl$KGPT_VFIO_DEVICE_RESET": "ioctl$KGPT_VFIO_DEVICE_RESET(fd fd_vgpu, cmd const[VFIO_DEVICE_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_INFO(fd fd_vgpu, cmd const[VFIO_DEVICE_GET_INFO], arg ptr[in, vfio_device_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO(fd fd_vgpu, cmd const[VFIO_DEVICE_GET_REGION_INFO], arg ptr[in, vfio_region_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO(fd fd_vgpu, cmd const[VFIO_DEVICE_GET_IRQ_INFO], arg ptr[in, vfio_irq_info])",
+    "ioctl$KGPT_VFIO_DEVICE_SET_IRQS": "ioctl$KGPT_VFIO_DEVICE_SET_IRQS(fd fd_vgpu, cmd const[VFIO_DEVICE_SET_IRQS], arg ptr[in, vfio_irq_set])",
+    "ioctl$KGPT_VFIO_DEVICE_QUERY_GFX_PLANE": "ioctl$KGPT_VFIO_DEVICE_QUERY_GFX_PLANE(fd fd_vgpu, cmd const[VFIO_DEVICE_QUERY_GFX_PLANE], arg ptr[inout, vfio_device_gfx_plane_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_GFX_DMABUF": "ioctl$KGPT_VFIO_DEVICE_GET_GFX_DMABUF(fd fd_vgpu, cmd const[VFIO_DEVICE_GET_GFX_DMABUF], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_vgpu"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h",
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ipmi_fops#drivers_char_ipmi_ipmi_devintf.c:779.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ipmi_fops#drivers_char_ipmi_ipmi_devintf.c:779.json
@@ -1,0 +1,166 @@
+{
+  "open": {
+    "filename": "/dev/ipmi0",
+    "fd_name": "fd_ipmi",
+    "spec": "openat$KGPT_ipmi(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ipmi0\"]], flags flags[open_flags], mode const[0]) fd_ipmi"
+  },
+  "resources": {
+    "fd_ipmi": {
+      "type": "fd",
+      "spec": "resource fd_ipmi[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/char/ipmi/ipmi_devintf.c:779",
+  "ioctls": {
+    "IPMICTL_SEND_COMMAND": {
+      "arg": "ptr[in, ipmi_req]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SEND_COMMAND_SETTIME": {
+      "arg": "ptr[in, ipmi_req_settime]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_RECEIVE_MSG": {
+      "arg": "ptr[in, ipmi_recv]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_RECEIVE_MSG_TRUNC": {
+      "arg": "ptr[in, ipmi_recv]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_REGISTER_FOR_CMD": {
+      "arg": "ptr[in, ipmi_cmdspec]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_UNREGISTER_FOR_CMD": {
+      "arg": "ptr[in, ipmi_cmdspec]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_REGISTER_FOR_CMD_CHANS": {
+      "arg": "ptr[in, ipmi_cmdspec_chans]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_UNREGISTER_FOR_CMD_CHANS": {
+      "arg": "ptr[in, ipmi_cmdspec_chans]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_GETS_EVENTS_CMD": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_MY_ADDRESS_CMD": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_MY_ADDRESS_CMD": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_MY_LUN_CMD": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_MY_LUN_CMD": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_MY_CHANNEL_ADDRESS_CMD": {
+      "arg": "ptr[in, ipmi_channel_lun_address_set]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_MY_CHANNEL_ADDRESS_CMD": {
+      "arg": "ptr[inout, ipmi_channel_lun_address_set]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_MY_CHANNEL_LUN_CMD": {
+      "arg": "ptr[in, ipmi_channel_lun_address_set]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_MY_CHANNEL_LUN_CMD": {
+      "arg": "ptr[out, ipmi_channel_lun_address_set]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_TIMING_PARMS_CMD": {
+      "arg": "ptr[in, ipmi_timing_parms]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_TIMING_PARMS_CMD": {
+      "arg": "ptr[out, ipmi_timing_parms]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_MAINTENANCE_MODE_CMD": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_MAINTENANCE_MODE_CMD": {
+      "arg": "intptr",
+      "arg_name_in_usage": "mode",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "ipmi_req": "ipmi_req {\n\taddr\tptr[in, ipmi_msg]\n\taddr_len\tint32\n\tmsgid\tint64\n\tmsg\tipmi_msg\n}",
+    "ipmi_cmdspec": "ipmi_cmdspec {\n\tnetfn\tint8\n\tcmd\tint8\n}",
+    "ipmi_cmdspec_chans": "ipmi_cmdspec_chans {\n\tnetfn\tint32\n\tcmd\tint32\n\tchans\tint32\n}",
+    "ipmi_channel_lun_address_set": "ipmi_channel_lun_address_set {\n\tchannel\tint16\n\tvalue\tint8\n}",
+    "ipmi_timing_parms": "ipmi_timing_parms {\n\tretries\tint32\n\tretry_time_ms\tint32\n}",
+    "ipmi_recv": "ipmi_recv {\n\trecv_type\tint32\n\taddr\tptr[inout, array[int8]]\n\taddr_len\tlen[addr, int32]\n\tmsgid\tint64\n\tmsg\tipmi_msg\n}",
+    "ipmi_req_settime": "ipmi_req_settime {\n\treq\tptr[in, ipmi_req]\n\tretries\tint32\n\tretry_time_ms\tint32\n}",
+    "ipmi_msg": "ipmi_msg {\n\tnetfn\tint8\n\tcmd\tint8\n\tdata_len\tint16\n\tdata\tarray[int8]\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_ipmi": "openat$KGPT_ipmi(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ipmi0\"]], flags flags[open_flags], mode const[0]) fd_ipmi",
+    "ioctl$KGPT_IPMICTL_SEND_COMMAND": "ioctl$KGPT_IPMICTL_SEND_COMMAND(fd fd_ipmi, cmd const[IPMICTL_SEND_COMMAND], arg ptr[in, ipmi_req])",
+    "ioctl$KGPT_IPMICTL_SEND_COMMAND_SETTIME": "ioctl$KGPT_IPMICTL_SEND_COMMAND_SETTIME(fd fd_ipmi, cmd const[IPMICTL_SEND_COMMAND_SETTIME], arg ptr[in, ipmi_req_settime])",
+    "ioctl$KGPT_IPMICTL_RECEIVE_MSG": "ioctl$KGPT_IPMICTL_RECEIVE_MSG(fd fd_ipmi, cmd const[IPMICTL_RECEIVE_MSG], arg ptr[in, ipmi_recv])",
+    "ioctl$KGPT_IPMICTL_RECEIVE_MSG_TRUNC": "ioctl$KGPT_IPMICTL_RECEIVE_MSG_TRUNC(fd fd_ipmi, cmd const[IPMICTL_RECEIVE_MSG_TRUNC], arg ptr[in, ipmi_recv])",
+    "ioctl$KGPT_IPMICTL_REGISTER_FOR_CMD": "ioctl$KGPT_IPMICTL_REGISTER_FOR_CMD(fd fd_ipmi, cmd const[IPMICTL_REGISTER_FOR_CMD], arg ptr[in, ipmi_cmdspec])",
+    "ioctl$KGPT_IPMICTL_UNREGISTER_FOR_CMD": "ioctl$KGPT_IPMICTL_UNREGISTER_FOR_CMD(fd fd_ipmi, cmd const[IPMICTL_UNREGISTER_FOR_CMD], arg ptr[in, ipmi_cmdspec])",
+    "ioctl$KGPT_IPMICTL_REGISTER_FOR_CMD_CHANS": "ioctl$KGPT_IPMICTL_REGISTER_FOR_CMD_CHANS(fd fd_ipmi, cmd const[IPMICTL_REGISTER_FOR_CMD_CHANS], arg ptr[in, ipmi_cmdspec_chans])",
+    "ioctl$KGPT_IPMICTL_UNREGISTER_FOR_CMD_CHANS": "ioctl$KGPT_IPMICTL_UNREGISTER_FOR_CMD_CHANS(fd fd_ipmi, cmd const[IPMICTL_UNREGISTER_FOR_CMD_CHANS], arg ptr[in, ipmi_cmdspec_chans])",
+    "ioctl$KGPT_IPMICTL_SET_GETS_EVENTS_CMD": "ioctl$KGPT_IPMICTL_SET_GETS_EVENTS_CMD(fd fd_ipmi, cmd const[IPMICTL_SET_GETS_EVENTS_CMD], arg ptr[in, int32])",
+    "ioctl$KGPT_IPMICTL_SET_MY_ADDRESS_CMD": "ioctl$KGPT_IPMICTL_SET_MY_ADDRESS_CMD(fd fd_ipmi, cmd const[IPMICTL_SET_MY_ADDRESS_CMD], arg intptr)",
+    "ioctl$KGPT_IPMICTL_GET_MY_ADDRESS_CMD": "ioctl$KGPT_IPMICTL_GET_MY_ADDRESS_CMD(fd fd_ipmi, cmd const[IPMICTL_GET_MY_ADDRESS_CMD], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_IPMICTL_SET_MY_LUN_CMD": "ioctl$KGPT_IPMICTL_SET_MY_LUN_CMD(fd fd_ipmi, cmd const[IPMICTL_SET_MY_LUN_CMD], arg intptr)",
+    "ioctl$KGPT_IPMICTL_GET_MY_LUN_CMD": "ioctl$KGPT_IPMICTL_GET_MY_LUN_CMD(fd fd_ipmi, cmd const[IPMICTL_GET_MY_LUN_CMD], arg ptr[out, int32])",
+    "ioctl$KGPT_IPMICTL_SET_MY_CHANNEL_ADDRESS_CMD": "ioctl$KGPT_IPMICTL_SET_MY_CHANNEL_ADDRESS_CMD(fd fd_ipmi, cmd const[IPMICTL_SET_MY_CHANNEL_ADDRESS_CMD], arg ptr[in, ipmi_channel_lun_address_set])",
+    "ioctl$KGPT_IPMICTL_GET_MY_CHANNEL_ADDRESS_CMD": "ioctl$KGPT_IPMICTL_GET_MY_CHANNEL_ADDRESS_CMD(fd fd_ipmi, cmd const[IPMICTL_GET_MY_CHANNEL_ADDRESS_CMD], arg ptr[inout, ipmi_channel_lun_address_set])",
+    "ioctl$KGPT_IPMICTL_SET_MY_CHANNEL_LUN_CMD": "ioctl$KGPT_IPMICTL_SET_MY_CHANNEL_LUN_CMD(fd fd_ipmi, cmd const[IPMICTL_SET_MY_CHANNEL_LUN_CMD], arg ptr[in, ipmi_channel_lun_address_set])",
+    "ioctl$KGPT_IPMICTL_GET_MY_CHANNEL_LUN_CMD": "ioctl$KGPT_IPMICTL_GET_MY_CHANNEL_LUN_CMD(fd fd_ipmi, cmd const[IPMICTL_GET_MY_CHANNEL_LUN_CMD], arg ptr[out, ipmi_channel_lun_address_set])",
+    "ioctl$KGPT_IPMICTL_SET_TIMING_PARMS_CMD": "ioctl$KGPT_IPMICTL_SET_TIMING_PARMS_CMD(fd fd_ipmi, cmd const[IPMICTL_SET_TIMING_PARMS_CMD], arg ptr[in, ipmi_timing_parms])",
+    "ioctl$KGPT_IPMICTL_GET_TIMING_PARMS_CMD": "ioctl$KGPT_IPMICTL_GET_TIMING_PARMS_CMD(fd fd_ipmi, cmd const[IPMICTL_GET_TIMING_PARMS_CMD], arg ptr[out, ipmi_timing_parms])",
+    "ioctl$KGPT_IPMICTL_GET_MAINTENANCE_MODE_CMD": "ioctl$KGPT_IPMICTL_GET_MAINTENANCE_MODE_CMD(fd fd_ipmi, cmd const[IPMICTL_GET_MAINTENANCE_MODE_CMD], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_IPMICTL_SET_MAINTENANCE_MODE_CMD": "ioctl$KGPT_IPMICTL_SET_MAINTENANCE_MODE_CMD(fd fd_ipmi, cmd const[IPMICTL_SET_MAINTENANCE_MODE_CMD], arg intptr)"
+  },
+  "init_syscalls": [
+    "openat$KGPT_ipmi"
+  ],
+  "includes": [
+    "uapi/linux/ipmi.h",
+    "uapi/linux/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ipmi_wdog_fops#drivers_char_ipmi_ipmi_watchdog.c:896.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ipmi_wdog_fops#drivers_char_ipmi_ipmi_watchdog.c:896.json
@@ -1,0 +1,201 @@
+{
+  "open": {
+    "filename": "/dev/watchdog",
+    "fd_name": "fd_ipmi_wdog",
+    "spec": "openat$KGPT_ipmi_wdog(fd const[AT_FDCWD], file ptr[in, string[\"/dev/watchdog\"]], flags const[O_RDWR], mode const[0]) fd_ipmi_wdog"
+  },
+  "resources": {
+    "fd_ipmi_wdog": {
+      "type": "fd",
+      "spec": "resource fd_ipmi_wdog[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/char/ipmi/ipmi_watchdog.c:896",
+  "ioctls": {
+    "IPMICTL_SEND_COMMAND": {
+      "arg": "ptr[in, ipmi_req]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SEND_COMMAND_SETTIME": {
+      "arg": "ptr[in, ipmi_req_settime]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_RECEIVE_MSG": {
+      "arg": "ptr[in, ipmi_recv]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "handle_recv"
+        ],
+        "type": [
+          "ipmi_recv"
+        ],
+        "usage": [
+          "struct ipmi_recv rsp;",
+          "if (copy_from_user(&rsp, arg, sizeof(rsp)))"
+        ]
+      }
+    },
+    "IPMICTL_RECEIVE_MSG_TRUNC": {
+      "arg": "ptr[in, ipmi_recv]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_REGISTER_FOR_CMD": {
+      "arg": "ptr[in, ipmi_cmdspec]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_UNREGISTER_FOR_CMD": {
+      "arg": "ptr[in, ipmi_cmdspec]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_REGISTER_FOR_CMD_CHANS": {
+      "arg": "ptr[in, ipmi_cmdspec_chans]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IPMICTL_UNREGISTER_FOR_CMD_CHANS": {
+      "arg": "ptr[in, ipmi_cmdspec_chans]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_GETS_EVENTS_CMD": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_MY_ADDRESS_CMD": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_MY_ADDRESS_CMD": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_MY_LUN_CMD": {
+      "arg": "intptr",
+      "arg_name_in_usage": "val",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_MY_LUN_CMD": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "ipmi_get_my_LUN"
+        ],
+        "type": [
+          "unsigned int"
+        ],
+        "usage": [
+          "unsigned int val;",
+          "unsigned char rval;",
+          "if (copy_to_user(arg, &val, sizeof(val)))"
+        ]
+      }
+    },
+    "IPMICTL_SET_MY_CHANNEL_ADDRESS_CMD": {
+      "arg": "ptr[in, ipmi_channel_lun_address_set]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_MY_CHANNEL_ADDRESS_CMD": {
+      "arg": "ptr[out, ipmi_channel_lun_address_set]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_MY_CHANNEL_LUN_CMD": {
+      "arg": "ptr[in, ipmi_channel_lun_address_set]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_MY_CHANNEL_LUN_CMD": {
+      "arg": "ptr[out, ipmi_channel_lun_address_set]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_SET_TIMING_PARMS_CMD": {
+      "arg": "ptr[in, ipmi_timing_parms]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_TIMING_PARMS_CMD": {
+      "arg": "ptr[out, ipmi_timing_parms]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IPMICTL_GET_MAINTENANCE_MODE_CMD": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "ipmi_get_maintenance_mode"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "int mode;",
+          "if (copy_to_user(arg, &mode, sizeof(mode)))"
+        ]
+      }
+    },
+    "IPMICTL_SET_MAINTENANCE_MODE_CMD": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "ipmi_req": "ipmi_req {\n\taddr\tptr[in, ipmi_msg]\n\taddr_len\tint32\n\tmsgid\tint64\n\tmsg\tipmi_msg\n}",
+    "ipmi_cmdspec": "ipmi_cmdspec {\n\tnetfn\tint8\n\tcmd\tint8\n}",
+    "ipmi_cmdspec_chans": "ipmi_cmdspec_chans {\n\tnetfn\tint32\n\tcmd\tint32\n\tchans\tint32\n}",
+    "ipmi_channel_lun_address_set": "ipmi_channel_lun_address_set {\n\tchannel\tint16\n\tvalue\tint8\n}",
+    "ipmi_timing_parms": "ipmi_timing_parms {\n\tretries\tint32\n\tretry_time_ms\tint32\n}",
+    "ipmi_recv": "ipmi_recv {\n\trecv_type\tint32\n\taddr\tptr[inout, array[int8]]\n\taddr_len\tlen[addr, int32]\n\tmsgid\tint64\n\tmsg\tipmi_msg\n}",
+    "ipmi_req_settime": "ipmi_req_settime {\n\treq\tptr[in, ipmi_req]\n\tretries\tint32\n\tretry_time_ms\tint32\n}",
+    "ipmi_msg": "ipmi_msg {\n\tnetfn\tint8\n\tcmd\tint8\n\tdata_len\tint16\n\tdata\tarray[int8]\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_ipmi_wdog": "openat$KGPT_ipmi_wdog(fd const[AT_FDCWD], file ptr[in, string[\"/dev/watchdog\"]], flags const[O_RDWR], mode const[0]) fd_ipmi_wdog",
+    "ioctl$KGPT_IPMICTL_SEND_COMMAND": "ioctl$KGPT_IPMICTL_SEND_COMMAND(fd fd_ipmi_wdog, cmd const[IPMICTL_SEND_COMMAND], arg ptr[in, ipmi_req])",
+    "ioctl$KGPT_IPMICTL_SEND_COMMAND_SETTIME": "ioctl$KGPT_IPMICTL_SEND_COMMAND_SETTIME(fd fd_ipmi_wdog, cmd const[IPMICTL_SEND_COMMAND_SETTIME], arg ptr[in, ipmi_req_settime])",
+    "ioctl$KGPT_IPMICTL_RECEIVE_MSG": "ioctl$KGPT_IPMICTL_RECEIVE_MSG(fd fd_ipmi_wdog, cmd const[IPMICTL_RECEIVE_MSG], arg ptr[in, ipmi_recv])",
+    "ioctl$KGPT_IPMICTL_RECEIVE_MSG_TRUNC": "ioctl$KGPT_IPMICTL_RECEIVE_MSG_TRUNC(fd fd_ipmi_wdog, cmd const[IPMICTL_RECEIVE_MSG_TRUNC], arg ptr[in, ipmi_recv])",
+    "ioctl$KGPT_IPMICTL_REGISTER_FOR_CMD": "ioctl$KGPT_IPMICTL_REGISTER_FOR_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_REGISTER_FOR_CMD], arg ptr[in, ipmi_cmdspec])",
+    "ioctl$KGPT_IPMICTL_UNREGISTER_FOR_CMD": "ioctl$KGPT_IPMICTL_UNREGISTER_FOR_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_UNREGISTER_FOR_CMD], arg ptr[in, ipmi_cmdspec])",
+    "ioctl$KGPT_IPMICTL_REGISTER_FOR_CMD_CHANS": "ioctl$KGPT_IPMICTL_REGISTER_FOR_CMD_CHANS(fd fd_ipmi_wdog, cmd const[IPMICTL_REGISTER_FOR_CMD_CHANS], arg ptr[in, ipmi_cmdspec_chans])",
+    "ioctl$KGPT_IPMICTL_UNREGISTER_FOR_CMD_CHANS": "ioctl$KGPT_IPMICTL_UNREGISTER_FOR_CMD_CHANS(fd fd_ipmi_wdog, cmd const[IPMICTL_UNREGISTER_FOR_CMD_CHANS], arg ptr[in, ipmi_cmdspec_chans])",
+    "ioctl$KGPT_IPMICTL_SET_GETS_EVENTS_CMD": "ioctl$KGPT_IPMICTL_SET_GETS_EVENTS_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_SET_GETS_EVENTS_CMD], arg intptr)",
+    "ioctl$KGPT_IPMICTL_SET_MY_ADDRESS_CMD": "ioctl$KGPT_IPMICTL_SET_MY_ADDRESS_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_SET_MY_ADDRESS_CMD], arg intptr)",
+    "ioctl$KGPT_IPMICTL_GET_MY_ADDRESS_CMD": "ioctl$KGPT_IPMICTL_GET_MY_ADDRESS_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_GET_MY_ADDRESS_CMD], arg ptr[out, int32])",
+    "ioctl$KGPT_IPMICTL_SET_MY_LUN_CMD": "ioctl$KGPT_IPMICTL_SET_MY_LUN_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_SET_MY_LUN_CMD], arg intptr)",
+    "ioctl$KGPT_IPMICTL_GET_MY_LUN_CMD": "ioctl$KGPT_IPMICTL_GET_MY_LUN_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_GET_MY_LUN_CMD], arg ptr[out, int32])",
+    "ioctl$KGPT_IPMICTL_SET_MY_CHANNEL_ADDRESS_CMD": "ioctl$KGPT_IPMICTL_SET_MY_CHANNEL_ADDRESS_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_SET_MY_CHANNEL_ADDRESS_CMD], arg ptr[in, ipmi_channel_lun_address_set])",
+    "ioctl$KGPT_IPMICTL_GET_MY_CHANNEL_ADDRESS_CMD": "ioctl$KGPT_IPMICTL_GET_MY_CHANNEL_ADDRESS_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_GET_MY_CHANNEL_ADDRESS_CMD], arg ptr[out, ipmi_channel_lun_address_set])",
+    "ioctl$KGPT_IPMICTL_SET_MY_CHANNEL_LUN_CMD": "ioctl$KGPT_IPMICTL_SET_MY_CHANNEL_LUN_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_SET_MY_CHANNEL_LUN_CMD], arg ptr[in, ipmi_channel_lun_address_set])",
+    "ioctl$KGPT_IPMICTL_GET_MY_CHANNEL_LUN_CMD": "ioctl$KGPT_IPMICTL_GET_MY_CHANNEL_LUN_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_GET_MY_CHANNEL_LUN_CMD], arg ptr[out, ipmi_channel_lun_address_set])",
+    "ioctl$KGPT_IPMICTL_SET_TIMING_PARMS_CMD": "ioctl$KGPT_IPMICTL_SET_TIMING_PARMS_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_SET_TIMING_PARMS_CMD], arg ptr[in, ipmi_timing_parms])",
+    "ioctl$KGPT_IPMICTL_GET_TIMING_PARMS_CMD": "ioctl$KGPT_IPMICTL_GET_TIMING_PARMS_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_GET_TIMING_PARMS_CMD], arg ptr[out, ipmi_timing_parms])",
+    "ioctl$KGPT_IPMICTL_GET_MAINTENANCE_MODE_CMD": "ioctl$KGPT_IPMICTL_GET_MAINTENANCE_MODE_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_GET_MAINTENANCE_MODE_CMD], arg ptr[out, int32])",
+    "ioctl$KGPT_IPMICTL_SET_MAINTENANCE_MODE_CMD": "ioctl$KGPT_IPMICTL_SET_MAINTENANCE_MODE_CMD(fd fd_ipmi_wdog, cmd const[IPMICTL_SET_MAINTENANCE_MODE_CMD], arg intptr)"
+  },
+  "init_syscalls": [
+    "openat$KGPT_ipmi_wdog"
+  ],
+  "includes": [
+    "uapi/linux/ipmi.h",
+    "uapi/asm-generic/fcntl.h",
+    "uapi/linux/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/kcov_fops#kernel_kcov.c:748.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/kcov_fops#kernel_kcov.c:748.json
@@ -1,0 +1,63 @@
+{
+  "open": {
+    "filename": "/sys/kernel/debug/kcov",
+    "fd_name": "fd_kcov",
+    "spec": "openat$KGPT_kcov(fd const[AT_FDCWD], file ptr[in, string[\"/sys/kernel/debug/kcov\"]], flags flags[open_flags], mode const[0]) fd_kcov"
+  },
+  "resources": {
+    "fd_kcov": {
+      "type": "fd",
+      "spec": "resource fd_kcov[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/kernel/kcov.c:748",
+  "ioctls": {
+    "KCOV_DISABLE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "KCOV_INIT_TRACE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "size",
+      "arg_inference": null
+    },
+    "KCOV_REMOTE_ENABLE": {
+      "arg": "ptr[in, kcov_remote_arg]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "KCOV_ENABLE": {
+      "arg": "flags[kcov_mode]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "kcov_remote_arg": "kcov_remote_arg {\n\ttrace_mode\tint32\n\tarea_size\tint32\n\tnum_handles\tint32\n\tcommon_handle\tint64\n\thandles\tarray[int64]\n}",
+    "kcov_mode": "kcov_mode = KCOV_MODE_DISABLED, KCOV_MODE_INIT, KCOV_MODE_TRACE_PC, KCOV_MODE_TRACE_CMP",
+    "KCOV_MODE_DISABLED": "define KCOV_MODE_DISABLED 0",
+    "KCOV_MODE_INIT": "define KCOV_MODE_INIT 1",
+    "KCOV_MODE_TRACE_PC": "define KCOV_MODE_TRACE_PC 2",
+    "KCOV_MODE_TRACE_CMP": "define KCOV_MODE_TRACE_CMP 3"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_kcov": "openat$KGPT_kcov(fd const[AT_FDCWD], file ptr[in, string[\"/sys/kernel/debug/kcov\"]], flags flags[open_flags], mode const[0]) fd_kcov",
+    "ioctl$KGPT_KCOV_DISABLE": "ioctl$KGPT_KCOV_DISABLE(fd fd_kcov, cmd const[KCOV_DISABLE], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_KCOV_INIT_TRACE": "ioctl$KGPT_KCOV_INIT_TRACE(fd fd_kcov, cmd const[KCOV_INIT_TRACE], arg intptr)",
+    "ioctl$KGPT_KCOV_REMOTE_ENABLE": "ioctl$KGPT_KCOV_REMOTE_ENABLE(fd fd_kcov, cmd const[KCOV_REMOTE_ENABLE], arg ptr[in, kcov_remote_arg])",
+    "ioctl$KGPT_KCOV_ENABLE": "ioctl$KGPT_KCOV_ENABLE(fd fd_kcov, cmd const[KCOV_ENABLE], arg flags[kcov_mode])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_kcov"
+  ],
+  "includes": [
+    "linux/kcov.h",
+    "uapi/linux/fcntl.h",
+    "uapi/linux/kcov.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/kcs_bmc_ipmi_fops#drivers_char_ipmi_kcs_bmc_cdev_ipmi.c:459.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/kcs_bmc_ipmi_fops#drivers_char_ipmi_kcs_bmc_cdev_ipmi.c:459.json
@@ -1,0 +1,48 @@
+{
+  "open": {
+    "filename": "/dev/ipmi#",
+    "fd_name": "fd_ipmi",
+    "spec": "syz_open_dev$KGPT_ipmi(dev ptr[in, string[\"/dev/ipmi#\"]], id proc[0, 1], flags flags[open_flags]) fd_ipmi"
+  },
+  "resources": {
+    "fd_ipmi": {
+      "type": "fd",
+      "spec": "resource fd_ipmi[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/char/ipmi/kcs_bmc_cdev_ipmi.c:459",
+  "ioctls": {
+    "IPMI_BMC_IOCTL_SET_SMS_ATN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "IPMI_BMC_IOCTL_CLEAR_SMS_ATN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "IPMI_BMC_IOCTL_FORCE_ABORT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_ipmi": "syz_open_dev$KGPT_ipmi(dev ptr[in, string[\"/dev/ipmi#\"]], id proc[0, 1], flags flags[open_flags]) fd_ipmi",
+    "ioctl$KGPT_IPMI_BMC_IOCTL_SET_SMS_ATN": "ioctl$KGPT_IPMI_BMC_IOCTL_SET_SMS_ATN(fd fd_ipmi, cmd const[IPMI_BMC_IOCTL_SET_SMS_ATN], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_IPMI_BMC_IOCTL_CLEAR_SMS_ATN": "ioctl$KGPT_IPMI_BMC_IOCTL_CLEAR_SMS_ATN(fd fd_ipmi, cmd const[IPMI_BMC_IOCTL_CLEAR_SMS_ATN], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_IPMI_BMC_IOCTL_FORCE_ABORT": "ioctl$KGPT_IPMI_BMC_IOCTL_FORCE_ABORT(fd fd_ipmi, cmd const[IPMI_BMC_IOCTL_FORCE_ABORT], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_ipmi"
+  ],
+  "includes": [
+    "uapi/linux/ipmi_bmc.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/lineevent_fileops#drivers_gpio_gpiolib-cdev.c:2009.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/lineevent_fileops#drivers_gpio_gpiolib-cdev.c:2009.json
@@ -1,0 +1,40 @@
+{
+  "open": {
+    "filename": "/dev/gpiochip#",
+    "fd_name": "fd_gpioevent",
+    "spec": "syz_open_dev$KGPT_gpioevent(dev ptr[in, string[\"/dev/gpiochip#\"]], id proc[0, 1], flags flags[open_flags]) fd_gpioevent"
+  },
+  "resources": {
+    "fd_gpioevent": {
+      "type": "fd",
+      "spec": "resource fd_gpioevent[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/gpio/gpiolib-cdev.c:2009",
+  "ioctls": {
+    "GPIOHANDLE_GET_LINE_VALUES_IOCTL": {
+      "arg": "ptr[out, gpiohandle_data]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "gpiohandle_data": "gpiohandle_data {\n\tvalues\tarray[int8, GPIOHANDLES_MAX]\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_gpioevent": "syz_open_dev$KGPT_gpioevent(dev ptr[in, string[\"/dev/gpiochip#\"]], id proc[0, 1], flags flags[open_flags]) fd_gpioevent",
+    "ioctl$KGPT_GPIOHANDLE_GET_LINE_VALUES_IOCTL": "ioctl$KGPT_GPIOHANDLE_GET_LINE_VALUES_IOCTL(fd fd_gpioevent, cmd const[GPIOHANDLE_GET_LINE_VALUES_IOCTL], arg ptr[out, gpiohandle_data])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_gpioevent"
+  ],
+  "includes": [
+    "uapi/linux/gpio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "GPIOHANDLES_MAX": "UNFOUND_MACRO"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/linehandle_fileops#drivers_gpio_gpiolib-cdev.c:332.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/linehandle_fileops#drivers_gpio_gpiolib-cdev.c:332.json
@@ -1,0 +1,53 @@
+{
+  "open": {
+    "filename": "/dev/gpiochip#",
+    "fd_name": "fd_gpiochip",
+    "spec": "syz_open_dev$KGPT_gpiochip(dev ptr[in, string[\"/dev/gpiochip#\"]], id proc[0, 1], flags flags[open_flags]) fd_gpiochip"
+  },
+  "resources": {
+    "fd_gpiochip": {
+      "type": "fd",
+      "spec": "resource fd_gpiochip[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/gpio/gpiolib-cdev.c:332",
+  "ioctls": {
+    "GPIOHANDLE_GET_LINE_VALUES_IOCTL": {
+      "arg": "ptr[inout, gpiohandle_data]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "GPIOHANDLE_SET_LINE_VALUES_IOCTL": {
+      "arg": "ptr[in, gpiohandle_data]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    },
+    "GPIOHANDLE_SET_CONFIG_IOCTL": {
+      "arg": "ptr[in, gpiohandle_config]",
+      "arg_name_in_usage": "ip",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "gpiohandle_data": "gpiohandle_data {\n\tvalues\tarray[int8, GPIOHANDLES_MAX]\n}",
+    "gpiohandle_config": "gpiohandle_config {\n\tflags\tint32\n\tdefault_values\tarray[int8, GPIOHANDLES_MAX]\n\tpadding\tarray[int32, 4]\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_gpiochip": "syz_open_dev$KGPT_gpiochip(dev ptr[in, string[\"/dev/gpiochip#\"]], id proc[0, 1], flags flags[open_flags]) fd_gpiochip",
+    "ioctl$KGPT_GPIOHANDLE_GET_LINE_VALUES_IOCTL": "ioctl$KGPT_GPIOHANDLE_GET_LINE_VALUES_IOCTL(fd fd_gpiochip, cmd const[GPIOHANDLE_GET_LINE_VALUES_IOCTL], arg ptr[inout, gpiohandle_data])",
+    "ioctl$KGPT_GPIOHANDLE_SET_LINE_VALUES_IOCTL": "ioctl$KGPT_GPIOHANDLE_SET_LINE_VALUES_IOCTL(fd fd_gpiochip, cmd const[GPIOHANDLE_SET_LINE_VALUES_IOCTL], arg ptr[in, gpiohandle_data])",
+    "ioctl$KGPT_GPIOHANDLE_SET_CONFIG_IOCTL": "ioctl$KGPT_GPIOHANDLE_SET_CONFIG_IOCTL(fd fd_gpiochip, cmd const[GPIOHANDLE_SET_CONFIG_IOCTL], arg ptr[in, gpiohandle_config])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_gpiochip"
+  ],
+  "includes": [
+    "uapi/linux/gpio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "GPIOHANDLES_MAX": "UNFOUND_MACRO"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/loadpin_dm_verity_ops#security_loadpin_loadpin.c:400.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/loadpin_dm_verity_ops#security_loadpin_loadpin.c:400.json
@@ -1,0 +1,50 @@
+{
+  "open": {
+    "filename": "/sys/kernel/security/loadpin/dm-verity",
+    "fd_name": "fd_loadpin_dm_verity",
+    "spec": "openat$KGPT_loadpin_dm_verity(fd const[AT_FDCWD], file ptr[in, string[\"/sys/kernel/security/loadpin/dm-verity\"]], flags const[O_RDWR], mode const[0600]) fd_loadpin_dm_verity"
+  },
+  "resources": {
+    "fd_loadpin_dm_verity": {
+      "type": "fd",
+      "spec": "resource fd_loadpin_dm_verity[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/security/loadpin/loadpin.c:400",
+  "ioctls": {
+    "LOADPIN_IOC_SET_TRUSTED_VERITY_DIGESTS": {
+      "arg": "intptr",
+      "arg_name_in_usage": "fd",
+      "arg_inference": {
+        "function": [
+          "read_trusted_verity_root_digests"
+        ],
+        "type": [
+          "unsigned int"
+        ],
+        "usage": [
+          "unsigned int fd;",
+          "if (copy_from_user(&fd, uarg, sizeof(fd)))",
+          "return read_trusted_verity_root_digests(fd);"
+        ]
+      }
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_loadpin_dm_verity": "openat$KGPT_loadpin_dm_verity(fd const[AT_FDCWD], file ptr[in, string[\"/sys/kernel/security/loadpin/dm-verity\"]], flags const[O_RDWR], mode const[0600]) fd_loadpin_dm_verity",
+    "ioctl$KGPT_LOADPIN_IOC_SET_TRUSTED_VERITY_DIGESTS": "ioctl$KGPT_LOADPIN_IOC_SET_TRUSTED_VERITY_DIGESTS(fd fd_loadpin_dm_verity, cmd const[LOADPIN_IOC_SET_TRUSTED_VERITY_DIGESTS], arg intptr)"
+  },
+  "init_syscalls": [
+    "openat$KGPT_loadpin_dm_verity"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/loadpin.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/master_pty_ops_bsd#drivers_tty_pty.c:498.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/master_pty_ops_bsd#drivers_tty_pty.c:498.json
@@ -1,0 +1,112 @@
+{
+  "open": {
+    "filename": "/dev/pty#",
+    "fd_name": "fd_pty_master",
+    "spec": "syz_open_dev$KGPT_pty_master(dev ptr[in, string[\"/dev/pty#\"]], id proc[0, 1], flags flags[open_flags]) fd_pty_master"
+  },
+  "resources": {
+    "fd_pty_master": {
+      "type": "fd",
+      "spec": "resource fd_pty_master[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/tty/pty.c:498",
+  "ioctls": {
+    "TIOCGPTN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "TIOCSPTLCK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "pty_set_lock"
+        ],
+        "type": [],
+        "usage": [
+          "return pty_set_lock(tty, (int __user *) arg);"
+        ]
+      }
+    },
+    "TIOCGPTLCK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "pty_get_lock"
+        ],
+        "type": [],
+        "usage": [
+          "return pty_get_lock(tty, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCPKT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "pty_set_pktmode"
+        ],
+        "type": [],
+        "usage": [
+          "return pty_set_pktmode(tty, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCGPKT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "pty_get_pktmode"
+        ],
+        "type": [],
+        "usage": [
+          "return pty_get_pktmode(tty, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCSIG": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "pty_signal"
+        ],
+        "type": [],
+        "usage": [
+          "return pty_signal(tty, (int) arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_pty_master": "syz_open_dev$KGPT_pty_master(dev ptr[in, string[\"/dev/pty#\"]], id proc[0, 1], flags flags[open_flags]) fd_pty_master",
+    "ioctl$KGPT_TIOCGPTN": "ioctl$KGPT_TIOCGPTN(fd fd_pty_master, cmd const[TIOCGPTN], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_pty_master"
+  ],
+  "includes": [
+    "uapi/asm-generic/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/mbochs_dev_ops#samples_vfio-mdev_mbochs.c:1369.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/mbochs_dev_ops#samples_vfio-mdev_mbochs.c:1369.json
@@ -1,0 +1,96 @@
+{
+  "open": {
+    "filename": "/dev/vfio/#",
+    "fd_name": "fd_mbochs",
+    "spec": "syz_open_dev$KGPT_vfio(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_mbochs"
+  },
+  "resources": {
+    "fd_mbochs": {
+      "type": "fd",
+      "spec": "resource fd_mbochs[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/samples/vfio-mdev/mbochs.c:1369",
+  "ioctls": {
+    "VFIO_DEVICE_SET_IRQS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": {
+        "function": [
+          "mbochs_reset"
+        ],
+        "type": [],
+        "usage": [
+          "return mbochs_reset(mdev_state);"
+        ]
+      }
+    },
+    "VFIO_DEVICE_GET_INFO": {
+      "arg": "ptr[inout, vfio_device_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_REGION_INFO": {
+      "arg": "ptr[inout, vfio_region_info_ext]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_IRQ_INFO": {
+      "arg": "ptr[inout, vfio_irq_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_QUERY_GFX_PLANE": {
+      "arg": "ptr[inout, vfio_device_gfx_plane_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_GFX_DMABUF": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "vfio_device_info": "vfio_device_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_flags, int32]\n\tnum_regions\tint32\n\tnum_irqs\tint32\n\tcap_offset\tint32\n\tpad\tint32\n}",
+    "vfio_region_info_ext": "vfio_region_info_ext {\n\tbase\tvfio_region_info\n\ttype\tvfio_region_info_cap_type\n}",
+    "vfio_device_gfx_plane_info": "vfio_device_gfx_plane_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_gfx_plane_info_flags, int32]\n\tdrm_plane_type\tint32\n\tdrm_format\tint32\n\tdrm_format_mod\tint64\n\twidth\tint32\n\theight\tint32\n\tstride\tint32\n\tsize\tint32\n\tx_pos\tint32\n\ty_pos\tint32\n\tx_hot\tint32\n\ty_hot\tint32\n\tunion\tvfio_device_gfx_plane_info_union\n\treserved\tint32\n}",
+    "vfio_irq_info": "vfio_irq_info {\n\targsz\tint32\n\tflags\tflags[vfio_irq_info_flags, int32]\n\tindex\tint32\n\tcount\tint32\n}",
+    "vfio_device_flags": "vfio_device_flags = VFIO_DEVICE_FLAGS_RESET, VFIO_DEVICE_FLAGS_PCI, VFIO_DEVICE_FLAGS_PLATFORM, VFIO_DEVICE_FLAGS_AMBA, VFIO_DEVICE_FLAGS_CCW, VFIO_DEVICE_FLAGS_AP, VFIO_DEVICE_FLAGS_FSL_MC, VFIO_DEVICE_FLAGS_CAPS, VFIO_DEVICE_FLAGS_CDX",
+    "vfio_region_info": "vfio_region_info {\n\targsz\tint32\n\tflags\tflags[vfio_region_info_flags, int32]\n\tindex\tint32\n\tcap_offset\tint32\n\tsize\tint64\n\toffset\tint64\n}",
+    "vfio_region_info_cap_type": "vfio_region_info_cap_type {\n\theader\tvfio_info_cap_header\n\ttype\tint32\n\tsubtype\tint32\n}",
+    "vfio_region_info_flags": "vfio_region_info_flags = VFIO_REGION_INFO_FLAG_READ, VFIO_REGION_INFO_FLAG_WRITE, VFIO_REGION_INFO_FLAG_MMAP, VFIO_REGION_INFO_FLAG_CAPS",
+    "vfio_irq_info_flags": "vfio_irq_info_flags = VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_INFO_MASKABLE, VFIO_IRQ_INFO_AUTOMASKED, VFIO_IRQ_INFO_NORESIZE",
+    "vfio_device_gfx_plane_info_flags": "vfio_device_gfx_plane_info_flags = VFIO_GFX_PLANE_TYPE_PROBE, VFIO_GFX_PLANE_TYPE_DMABUF, VFIO_GFX_PLANE_TYPE_REGION",
+    "vfio_device_gfx_plane_info_union": "vfio_device_gfx_plane_info_union [\n\tregion_index\tint32\n\tdmabuf_id\tint32\n]",
+    "VFIO_IRQ_INFO_EVENTFD": "define VFIO_IRQ_INFO_EVENTFD 1",
+    "VFIO_IRQ_INFO_MASKABLE": "define VFIO_IRQ_INFO_MASKABLE 2",
+    "VFIO_IRQ_INFO_AUTOMASKED": "define VFIO_IRQ_INFO_AUTOMASKED 4",
+    "VFIO_IRQ_INFO_NORESIZE": "define VFIO_IRQ_INFO_NORESIZE 8"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_vfio": "syz_open_dev$KGPT_vfio(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_mbochs",
+    "ioctl$KGPT_VFIO_DEVICE_SET_IRQS": "ioctl$KGPT_VFIO_DEVICE_SET_IRQS(fd fd_mbochs, cmd const[VFIO_DEVICE_SET_IRQS], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_RESET": "ioctl$KGPT_VFIO_DEVICE_RESET(fd fd_mbochs, cmd const[VFIO_DEVICE_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_INFO(fd fd_mbochs, cmd const[VFIO_DEVICE_GET_INFO], arg ptr[inout, vfio_device_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO(fd fd_mbochs, cmd const[VFIO_DEVICE_GET_REGION_INFO], arg ptr[inout, vfio_region_info_ext])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO(fd fd_mbochs, cmd const[VFIO_DEVICE_GET_IRQ_INFO], arg ptr[inout, vfio_irq_info])",
+    "ioctl$KGPT_VFIO_DEVICE_QUERY_GFX_PLANE": "ioctl$KGPT_VFIO_DEVICE_QUERY_GFX_PLANE(fd fd_mbochs, cmd const[VFIO_DEVICE_QUERY_GFX_PLANE], arg ptr[inout, vfio_device_gfx_plane_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_GFX_DMABUF": "ioctl$KGPT_VFIO_DEVICE_GET_GFX_DMABUF(fd fd_mbochs, cmd const[VFIO_DEVICE_GET_GFX_DMABUF], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_vfio"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/mdpy_dev_ops#samples_vfio-mdev_mdpy.c:659.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/mdpy_dev_ops#samples_vfio-mdev_mdpy.c:659.json
@@ -1,0 +1,114 @@
+{
+  "open": {
+    "filename": "/dev/vfio/#",
+    "fd_name": "fd_mdpy",
+    "spec": "syz_open_dev$KGPT_mdpy(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_mdpy"
+  },
+  "resources": {
+    "fd_mdpy": {
+      "type": "fd",
+      "spec": "resource fd_mdpy[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/samples/vfio-mdev/mdpy.c:659",
+  "ioctls": {
+    "VFIO_DEVICE_SET_IRQS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": {
+        "function": [
+          "mdpy_reset"
+        ],
+        "type": [],
+        "usage": [
+          "return mdpy_reset(mdev_state);"
+        ]
+      }
+    },
+    "VFIO_DEVICE_GET_INFO": {
+      "arg": "ptr[inout, vfio_device_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_REGION_INFO": {
+      "arg": "ptr[inout, vfio_region_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "mdpy_get_region_info"
+        ],
+        "type": [
+          "vfio_region_info"
+        ],
+        "usage": [
+          "struct vfio_region_info info;",
+          "if (copy_from_user(&info, (void __user *)arg, minsz))",
+          "ret = mdpy_get_region_info(mdev_state, &info, &cap_type_id, &cap_type);",
+          "if (copy_to_user((void __user *)arg, &info, minsz))"
+        ]
+      }
+    },
+    "VFIO_DEVICE_GET_IRQ_INFO": {
+      "arg": "ptr[inout, vfio_irq_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_QUERY_GFX_PLANE": {
+      "arg": "ptr[inout, vfio_device_gfx_plane_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "vfio_device_gfx_plane_info": "vfio_device_gfx_plane_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_gfx_plane_info_flags, int32]\n\tdrm_plane_type\tint32\n\tdrm_format\tint32\n\tdrm_format_mod\tint64\n\twidth\tint32\n\theight\tint32\n\tstride\tint32\n\tsize\tint32\n\tx_pos\tint32\n\ty_pos\tint32\n\tx_hot\tint32\n\ty_hot\tint32\n\tunion\tvfio_device_gfx_plane_info_union\n\treserved\tint32\n}",
+    "vfio_device_info": "vfio_device_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_flags, int32]\n\tnum_regions\tint32\n\tnum_irqs\tint32\n\tcap_offset\tint32\n\tpad\tint32\n}",
+    "vfio_region_info": "vfio_region_info {\n\targsz\tint32\n\tflags\tflags[vfio_region_info_flags, int32]\n\tindex\tint32\n\tcap_offset\tint32\n\tsize\tint64\n\toffset\tint64\n}",
+    "vfio_irq_info": "vfio_irq_info {\n\targsz\tint32\n\tflags\tflags[vfio_irq_info_flags, int32]\n\tindex\tint32\n\tcount\tint32\n}",
+    "vfio_device_flags": "vfio_device_flags = VFIO_DEVICE_FLAGS_RESET, VFIO_DEVICE_FLAGS_PCI, VFIO_DEVICE_FLAGS_PLATFORM, VFIO_DEVICE_FLAGS_AMBA, VFIO_DEVICE_FLAGS_CCW, VFIO_DEVICE_FLAGS_AP, VFIO_DEVICE_FLAGS_FSL_MC, VFIO_DEVICE_FLAGS_CAPS, VFIO_DEVICE_FLAGS_CDX",
+    "vfio_region_info_flags": "vfio_region_info_flags = VFIO_REGION_INFO_FLAG_READ, VFIO_REGION_INFO_FLAG_WRITE, VFIO_REGION_INFO_FLAG_MMAP, VFIO_REGION_INFO_FLAG_CAPS",
+    "vfio_irq_info_flags": "vfio_irq_info_flags = VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_INFO_MASKABLE, VFIO_IRQ_INFO_AUTOMASKED, VFIO_IRQ_INFO_NORESIZE",
+    "vfio_device_gfx_plane_info_flags": "vfio_device_gfx_plane_info_flags = VFIO_GFX_PLANE_TYPE_PROBE, VFIO_GFX_PLANE_TYPE_DMABUF, VFIO_GFX_PLANE_TYPE_REGION",
+    "vfio_device_gfx_plane_info_union": "vfio_device_gfx_plane_info_union [\n\tregion_index\tint32\n\tdmabuf_id\tint32\n]",
+    "VFIO_DEVICE_FLAGS_RESET": "define VFIO_DEVICE_FLAGS_RESET 0x1",
+    "VFIO_DEVICE_FLAGS_PCI": "define VFIO_DEVICE_FLAGS_PCI 0x2",
+    "VFIO_DEVICE_FLAGS_PLATFORM": "define VFIO_DEVICE_FLAGS_PLATFORM 0x4",
+    "VFIO_DEVICE_FLAGS_AMBA": "define VFIO_DEVICE_FLAGS_AMBA 0x8",
+    "VFIO_DEVICE_FLAGS_CCW": "define VFIO_DEVICE_FLAGS_CCW 0x10",
+    "VFIO_DEVICE_FLAGS_AP": "define VFIO_DEVICE_FLAGS_AP 0x20",
+    "VFIO_DEVICE_FLAGS_FSL_MC": "define VFIO_DEVICE_FLAGS_FSL_MC 0x40",
+    "VFIO_DEVICE_FLAGS_CAPS": "define VFIO_DEVICE_FLAGS_CAPS 0x80",
+    "VFIO_DEVICE_FLAGS_CDX": "define VFIO_DEVICE_FLAGS_CDX 0x100",
+    "VFIO_REGION_INFO_FLAG_READ": "define VFIO_REGION_INFO_FLAG_READ 0x1",
+    "VFIO_REGION_INFO_FLAG_WRITE": "define VFIO_REGION_INFO_FLAG_WRITE 0x2",
+    "VFIO_REGION_INFO_FLAG_MMAP": "define VFIO_REGION_INFO_FLAG_MMAP 0x4",
+    "VFIO_REGION_INFO_FLAG_CAPS": "define VFIO_REGION_INFO_FLAG_CAPS 0x8",
+    "VFIO_IRQ_INFO_EVENTFD": "define VFIO_IRQ_INFO_EVENTFD 1",
+    "VFIO_IRQ_INFO_MASKABLE": "define VFIO_IRQ_INFO_MASKABLE 2",
+    "VFIO_IRQ_INFO_AUTOMASKED": "define VFIO_IRQ_INFO_AUTOMASKED 4",
+    "VFIO_IRQ_INFO_NORESIZE": "define VFIO_IRQ_INFO_NORESIZE 8"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_mdpy": "syz_open_dev$KGPT_mdpy(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_mdpy",
+    "ioctl$KGPT_VFIO_DEVICE_SET_IRQS": "ioctl$KGPT_VFIO_DEVICE_SET_IRQS(fd fd_mdpy, cmd const[VFIO_DEVICE_SET_IRQS], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_RESET": "ioctl$KGPT_VFIO_DEVICE_RESET(fd fd_mdpy, cmd const[VFIO_DEVICE_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_INFO(fd fd_mdpy, cmd const[VFIO_DEVICE_GET_INFO], arg ptr[inout, vfio_device_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO(fd fd_mdpy, cmd const[VFIO_DEVICE_GET_REGION_INFO], arg ptr[inout, vfio_region_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO(fd fd_mdpy, cmd const[VFIO_DEVICE_GET_IRQ_INFO], arg ptr[inout, vfio_irq_info])",
+    "ioctl$KGPT_VFIO_DEVICE_QUERY_GFX_PLANE": "ioctl$KGPT_VFIO_DEVICE_QUERY_GFX_PLANE(fd fd_mdpy, cmd const[VFIO_DEVICE_QUERY_GFX_PLANE], arg ptr[inout, vfio_device_gfx_plane_info])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_mdpy"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/mlx5vf_pci_ops#drivers_vfio_pci_mlx5_main.c:1448.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/mlx5vf_pci_ops#drivers_vfio_pci_mlx5_main.c:1448.json
@@ -1,0 +1,93 @@
+{
+  "open": {
+    "filename": "/dev/vfio/#",
+    "fd_name": "fd_mlx5vf_pci",
+    "spec": "syz_open_dev$KGPT_mlx5vf_pci(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_mlx5vf_pci"
+  },
+  "resources": {
+    "fd_mlx5vf_pci": {
+      "type": "fd",
+      "spec": "resource fd_mlx5vf_pci[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/vfio/pci/mlx5/main.c:1448",
+  "ioctls": {
+    "VFIO_DEVICE_GET_INFO": {
+      "arg": "ptr[out, vfio_device_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_IRQ_INFO": {
+      "arg": "ptr[in,out, vfio_irq_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_PCI_HOT_RESET_INFO": {
+      "arg": "ptr[inout, vfio_pci_hot_reset_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_REGION_INFO": {
+      "arg": "ptr[in,out, vfio_region_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_IOEVENTFD": {
+      "arg": "ptr[in, vfio_device_ioeventfd]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_PCI_HOT_RESET": {
+      "arg": "ptr[in, vfio_pci_hot_reset]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_SET_IRQS": {
+      "arg": "ptr[in, vfio_irq_set]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "vfio_device_info": "vfio_device_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_flags, int32]\n\tnum_regions\tint32\n\tnum_irqs\tint32\n\tcap_offset\tint32\n\tpad\tint32\n}",
+    "vfio_region_info": "vfio_region_info {\n\targsz\tint32\n\tflags\tflags[vfio_region_info_flags, int32]\n\tindex\tint32\n\tcap_offset\tint32\n\tsize\tint64\n\toffset\tint64\n}",
+    "vfio_device_ioeventfd": "vfio_device_ioeventfd {\n\targsz\tint32\n\tflags\tflags[vfio_device_ioeventfd_flags, int32]\n\toffset\tint64\n\tdata\tint64\n\tfd\tint32\n\treserved\tint32\n}",
+    "vfio_pci_hot_reset_info": "vfio_pci_hot_reset_info {\n\targsz\tint32\n\tflags\tflags[vfio_pci_hot_reset_flags, int32]\n\tcount\tlen[devices, int32]\n\tdevices\tptr[inout, array[vfio_pci_dependent_device]]\n}",
+    "vfio_pci_hot_reset": "vfio_pci_hot_reset {\n\targsz\tint32\n\tflags\tint32\n\tcount\tlen[group_fds, int32]\n\tgroup_fds\tptr[in, array[int32]]\n}",
+    "vfio_irq_set": "vfio_irq_set {\n\targsz\tint32\n\tflags\tflags[vfio_irq_set_flags, int32]\n\tindex\tint32\n\tstart\tint32\n\tcount\tlen[data, int32]\n\tdata\tarray[int8]\n}",
+    "vfio_irq_info": "vfio_irq_info {\n\targsz\tint32\n\tflags\tflags[vfio_irq_info_flags, int32]\n\tindex\tint32\n\tcount\tint32\n}",
+    "vfio_device_flags": "vfio_device_flags = VFIO_DEVICE_FLAGS_RESET, VFIO_DEVICE_FLAGS_PCI, VFIO_DEVICE_FLAGS_PLATFORM, VFIO_DEVICE_FLAGS_AMBA, VFIO_DEVICE_FLAGS_CCW, VFIO_DEVICE_FLAGS_AP, VFIO_DEVICE_FLAGS_FSL_MC, VFIO_DEVICE_FLAGS_CAPS, VFIO_DEVICE_FLAGS_CDX",
+    "vfio_irq_info_flags": "vfio_irq_info_flags = VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_INFO_MASKABLE, VFIO_IRQ_INFO_AUTOMASKED, VFIO_IRQ_INFO_NORESIZE",
+    "vfio_pci_hot_reset_flags": "vfio_pci_hot_reset_flags = VFIO_PCI_HOT_RESET_FLAG_DEV_ID, VFIO_PCI_HOT_RESET_FLAG_DEV_ID_OWNED",
+    "vfio_region_info_flags": "vfio_region_info_flags = VFIO_REGION_INFO_FLAG_READ, VFIO_REGION_INFO_FLAG_WRITE, VFIO_REGION_INFO_FLAG_MMAP, VFIO_REGION_INFO_FLAG_CAPS",
+    "vfio_device_ioeventfd_flags": "vfio_device_ioeventfd_flags = VFIO_DEVICE_IOEVENTFD_8, VFIO_DEVICE_IOEVENTFD_16, VFIO_DEVICE_IOEVENTFD_32, VFIO_DEVICE_IOEVENTFD_64",
+    "vfio_irq_set_flags": "vfio_irq_set_flags = VFIO_IRQ_SET_DATA_NONE, VFIO_IRQ_SET_DATA_BOOL, VFIO_IRQ_SET_DATA_EVENTFD, VFIO_IRQ_SET_ACTION_MASK, VFIO_IRQ_SET_ACTION_UNMASK, VFIO_IRQ_SET_ACTION_TRIGGER",
+    "vfio_pci_dependent_device": "vfio_pci_dependent_device {\n\tgroup_id\tint32\n\tsegment\tint16\n\tbus\tint8\n\tdevfn\tint8\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_mlx5vf_pci": "syz_open_dev$KGPT_mlx5vf_pci(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_mlx5vf_pci",
+    "ioctl$KGPT_VFIO_DEVICE_GET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_INFO(fd fd_mlx5vf_pci, cmd const[VFIO_DEVICE_GET_INFO], arg ptr[out, vfio_device_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO(fd fd_mlx5vf_pci, cmd const[VFIO_DEVICE_GET_IRQ_INFO], arg ptr[inout, vfio_irq_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_PCI_HOT_RESET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_PCI_HOT_RESET_INFO(fd fd_mlx5vf_pci, cmd const[VFIO_DEVICE_GET_PCI_HOT_RESET_INFO], arg ptr[inout, vfio_pci_hot_reset_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO(fd fd_mlx5vf_pci, cmd const[VFIO_DEVICE_GET_REGION_INFO], arg ptr[inout, vfio_region_info])",
+    "ioctl$KGPT_VFIO_DEVICE_IOEVENTFD": "ioctl$KGPT_VFIO_DEVICE_IOEVENTFD(fd fd_mlx5vf_pci, cmd const[VFIO_DEVICE_IOEVENTFD], arg ptr[in, vfio_device_ioeventfd])",
+    "ioctl$KGPT_VFIO_DEVICE_PCI_HOT_RESET": "ioctl$KGPT_VFIO_DEVICE_PCI_HOT_RESET(fd fd_mlx5vf_pci, cmd const[VFIO_DEVICE_PCI_HOT_RESET], arg ptr[in, vfio_pci_hot_reset])",
+    "ioctl$KGPT_VFIO_DEVICE_RESET": "ioctl$KGPT_VFIO_DEVICE_RESET(fd fd_mlx5vf_pci, cmd const[VFIO_DEVICE_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_SET_IRQS": "ioctl$KGPT_VFIO_DEVICE_SET_IRQS(fd fd_mlx5vf_pci, cmd const[VFIO_DEVICE_SET_IRQS], arg ptr[in, vfio_irq_set])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_mlx5vf_pci"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/msr_fops#arch_x86_kernel_msr.c:227.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/msr_fops#arch_x86_kernel_msr.c:227.json
@@ -1,0 +1,58 @@
+{
+  "open": {
+    "filename": "/dev/cpu/#/msr",
+    "fd_name": "fd_msr",
+    "spec": "syz_open_dev$KGPT_msr(dev ptr[in, string[\"/dev/cpu/#/msr\"]], id proc[0, NR_CPUS], flags flags[open_flags]) fd_msr"
+  },
+  "resources": {
+    "fd_msr": {
+      "type": "fd",
+      "spec": "resource fd_msr[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/arch/x86/kernel/msr.c:227",
+  "ioctls": {
+    "X86_IOC_WRMSR_REGS": {
+      "arg": "ptr[inout, array[u32, 8]]",
+      "arg_name_in_usage": "uregs",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "X86_IOC_RDMSR_REGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uregs"
+      ],
+      "arg_inference": {
+        "function": [
+          "rdmsr_safe_regs_on_cpu"
+        ],
+        "type": [
+          "u32[8]"
+        ],
+        "usage": [
+          "u32 __user *uregs = (u32 __user *)arg;",
+          "u32 regs[8];",
+          "if (copy_from_user(&regs, uregs, sizeof(regs)))",
+          "err = rdmsr_safe_regs_on_cpu(cpu, regs);",
+          "if (copy_to_user(uregs, &regs, sizeof(regs)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_msr": "syz_open_dev$KGPT_msr(dev ptr[in, string[\"/dev/cpu/#/msr\"]], id proc[0, NR_CPUS], flags flags[open_flags]) fd_msr",
+    "ioctl$KGPT_X86_IOC_WRMSR_REGS": "ioctl$KGPT_X86_IOC_WRMSR_REGS(fd fd_msr, cmd const[X86_IOC_WRMSR_REGS], arg ptr[inout, array[int32, 8]])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_msr"
+  ],
+  "includes": [
+    "linux/threads.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/mt9m114_core_ops#drivers_staging_media_atomisp_i2c_atomisp-mt9m114.c:1489.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/mt9m114_core_ops#drivers_staging_media_atomisp_i2c_atomisp-mt9m114.c:1489.json
@@ -1,0 +1,38 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_mt9m114",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_mt9m114"
+  },
+  "resources": {
+    "fd_mt9m114": {
+      "type": "fd",
+      "spec": "resource fd_mt9m114[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/staging/media/atomisp/i2c/atomisp-mt9m114.c:1489",
+  "ioctls": {
+    "ATOMISP_IOC_S_EXPOSURE": {
+      "arg": "ptr[in, atomisp_exposure]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "atomisp_exposure": "atomisp_exposure {\n\tintegration_time\tarray[int32, 8]\n\tshutter_speed\tarray[int32, 8]\n\tgain\tarray[int32, 4]\n\taperture\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_mt9m114",
+    "ioctl$KGPT_ATOMISP_IOC_S_EXPOSURE": "ioctl$KGPT_ATOMISP_IOC_S_EXPOSURE(fd fd_mt9m114, cmd const[ATOMISP_IOC_S_EXPOSURE], arg ptr[in, atomisp_exposure])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "drivers/staging/media/atomisp/include/linux/atomisp.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/mtd_fops#drivers_mtd_mtdchar.c:1401.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/mtd_fops#drivers_mtd_mtdchar.c:1401.json
@@ -1,0 +1,217 @@
+{
+  "open": {
+    "filename": "/dev/mtd#",
+    "fd_name": "fd_mtd",
+    "spec": "syz_open_dev$KGPT_mtd(dev ptr[in, string[\"/dev/mtd#\"]], id proc[0, 1], flags flags[open_flags]) fd_mtd"
+  },
+  "resources": {
+    "fd_mtd": {
+      "type": "fd",
+      "spec": "resource fd_mtd[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/mtd/mtdchar.c:1401",
+  "ioctls": {
+    "MEMGETREGIONCOUNT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "MEMGETINFO": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "MEMGETOOBSEL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "OTPGETREGIONCOUNT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ECCGETLAYOUT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ECCGETSTATS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "MEMGETREGIONINFO": {
+      "arg": "ptr[inout, region_info_user]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMREADOOB": {
+      "arg": "ptr[in, mtd_oob_buf]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMREADOOB64": {
+      "arg": "ptr[in, mtd_oob_buf64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMREAD": {
+      "arg": "ptr[in, mtd_read_req]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "MEMERASE": {
+      "arg": "ptr[in, erase_info_user]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMERASE64": {
+      "arg": "ptr[in, erase_info_user64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMWRITEOOB": {
+      "arg": "ptr[in, mtd_oob_buf]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMWRITEOOB64": {
+      "arg": "ptr[in, mtd_oob_buf64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMWRITE": {
+      "arg": "ptr[in, mtd_write_req]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "MEMLOCK": {
+      "arg": "ptr[in, erase_info_user]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMUNLOCK": {
+      "arg": "ptr[in, erase_info_user]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMISLOCKED": {
+      "arg": "ptr[in, erase_info_user]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMGETBADBLOCK": {
+      "arg": "ptr[in, int64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MEMSETBADBLOCK": {
+      "arg": "ptr[in, int64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "OTPSELECT": {
+      "arg": "intptr",
+      "arg_name_in_usage": "mode",
+      "arg_inference": null
+    },
+    "OTPGETREGIONINFO": {
+      "arg": "ptr[out, array[otp_info]]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "OTPLOCK": {
+      "arg": "ptr[in, otp_info]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "OTPERASE": {
+      "arg": "ptr[in, otp_info]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "MTDFILEMODE": {
+      "arg": "flags[mtd_file_modes]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "region_info_user": "region_info_user {\n\toffset\tint32\n\terasesize\tint32\n\tnumblocks\tint32\n\tregionindex\tint32\n}",
+    "mtd_oob_buf": "mtd_oob_buf {\n\tstart\tint32\n\tlength\tint32\n\tptr\tptr[in, array[int8]]\n}",
+    "mtd_oob_buf64": "mtd_oob_buf64 {\n\tstart\tint64\n\tpad\tint32\n\tlength\tint32\n\tusr_ptr\tint64\n}",
+    "mtd_read_req": "mtd_read_req {\n\tstart\tint64\n\tlen\tint64\n\tooblen\tint64\n\tusr_data\tint64\n\tusr_oob\tint64\n\tmode\tint8\n\tpadding\tarray[int8, 7]\n\tecc_stats\tmtd_read_req_ecc_stats\n}",
+    "erase_info_user": "erase_info_user {\n\tstart\tint32\n\tlength\tint32\n}",
+    "erase_info_user64": "erase_info_user64 {\n\tstart\tint64\n\tlength\tint64\n}",
+    "mtd_write_req": "mtd_write_req {\n\tstart\tint64\n\tlen\tint64\n\tooblen\tint64\n\tusr_data\tint64\n\tusr_oob\tint64\n\tmode\tint8\n\tpadding\tarray[int8, 7]\n}",
+    "otp_info": "otp_info {\n\tstart\tint32\n\tlength\tint32\n\tlocked\tint32\n}",
+    "mtd_file_modes": "mtd_file_modes = MTD_FILE_MODE_NORMAL, MTD_FILE_MODE_OTP_FACTORY, MTD_FILE_MODE_OTP_USER, MTD_FILE_MODE_RAW",
+    "mtd_read_req_ecc_stats": "mtd_read_req_ecc_stats {\n\tuncorrectable_errors\tint32\n\tcorrected_bitflips\tint32\n\tmax_bitflips\tint32\n}"
+  },
+  "existing_ioctls": {
+    "BLKPG": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "mtdchar_blkpg_ioctl"
+        ],
+        "type": [
+          "blkpg_ioctl_arg"
+        ],
+        "usage": [
+          "struct blkpg_ioctl_arg __user *blk_arg = argp;",
+          "struct blkpg_ioctl_arg a;",
+          "if (copy_from_user(&a, blk_arg, sizeof(a)))",
+          "ret = mtdchar_blkpg_ioctl(mtd, &a);"
+        ]
+      }
+    },
+    "BLKRRPART": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_mtd": "syz_open_dev$KGPT_mtd(dev ptr[in, string[\"/dev/mtd#\"]], id proc[0, 1], flags flags[open_flags]) fd_mtd",
+    "ioctl$KGPT_MEMGETREGIONCOUNT": "ioctl$KGPT_MEMGETREGIONCOUNT(fd fd_mtd, cmd const[MEMGETREGIONCOUNT], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_MEMGETINFO": "ioctl$KGPT_MEMGETINFO(fd fd_mtd, cmd const[MEMGETINFO], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_MEMGETOOBSEL": "ioctl$KGPT_MEMGETOOBSEL(fd fd_mtd, cmd const[MEMGETOOBSEL], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_OTPGETREGIONCOUNT": "ioctl$KGPT_OTPGETREGIONCOUNT(fd fd_mtd, cmd const[OTPGETREGIONCOUNT], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ECCGETLAYOUT": "ioctl$KGPT_ECCGETLAYOUT(fd fd_mtd, cmd const[ECCGETLAYOUT], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ECCGETSTATS": "ioctl$KGPT_ECCGETSTATS(fd fd_mtd, cmd const[ECCGETSTATS], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_MEMGETREGIONINFO": "ioctl$KGPT_MEMGETREGIONINFO(fd fd_mtd, cmd const[MEMGETREGIONINFO], arg ptr[inout, region_info_user])",
+    "ioctl$KGPT_MEMREADOOB": "ioctl$KGPT_MEMREADOOB(fd fd_mtd, cmd const[MEMREADOOB], arg ptr[in, mtd_oob_buf])",
+    "ioctl$KGPT_MEMREADOOB64": "ioctl$KGPT_MEMREADOOB64(fd fd_mtd, cmd const[MEMREADOOB64], arg ptr[in, mtd_oob_buf64])",
+    "ioctl$KGPT_MEMREAD": "ioctl$KGPT_MEMREAD(fd fd_mtd, cmd const[MEMREAD], arg ptr[in, mtd_read_req])",
+    "ioctl$KGPT_MEMERASE": "ioctl$KGPT_MEMERASE(fd fd_mtd, cmd const[MEMERASE], arg ptr[in, erase_info_user])",
+    "ioctl$KGPT_MEMERASE64": "ioctl$KGPT_MEMERASE64(fd fd_mtd, cmd const[MEMERASE64], arg ptr[in, erase_info_user64])",
+    "ioctl$KGPT_MEMWRITEOOB": "ioctl$KGPT_MEMWRITEOOB(fd fd_mtd, cmd const[MEMWRITEOOB], arg ptr[in, mtd_oob_buf])",
+    "ioctl$KGPT_MEMWRITEOOB64": "ioctl$KGPT_MEMWRITEOOB64(fd fd_mtd, cmd const[MEMWRITEOOB64], arg ptr[in, mtd_oob_buf64])",
+    "ioctl$KGPT_MEMWRITE": "ioctl$KGPT_MEMWRITE(fd fd_mtd, cmd const[MEMWRITE], arg ptr[in, mtd_write_req])",
+    "ioctl$KGPT_MEMLOCK": "ioctl$KGPT_MEMLOCK(fd fd_mtd, cmd const[MEMLOCK], arg ptr[in, erase_info_user])",
+    "ioctl$KGPT_MEMUNLOCK": "ioctl$KGPT_MEMUNLOCK(fd fd_mtd, cmd const[MEMUNLOCK], arg ptr[in, erase_info_user])",
+    "ioctl$KGPT_MEMISLOCKED": "ioctl$KGPT_MEMISLOCKED(fd fd_mtd, cmd const[MEMISLOCKED], arg ptr[in, erase_info_user])",
+    "ioctl$KGPT_MEMGETBADBLOCK": "ioctl$KGPT_MEMGETBADBLOCK(fd fd_mtd, cmd const[MEMGETBADBLOCK], arg ptr[in, int64])",
+    "ioctl$KGPT_MEMSETBADBLOCK": "ioctl$KGPT_MEMSETBADBLOCK(fd fd_mtd, cmd const[MEMSETBADBLOCK], arg ptr[in, int64])",
+    "ioctl$KGPT_OTPSELECT": "ioctl$KGPT_OTPSELECT(fd fd_mtd, cmd const[OTPSELECT], arg intptr)",
+    "ioctl$KGPT_OTPGETREGIONINFO": "ioctl$KGPT_OTPGETREGIONINFO(fd fd_mtd, cmd const[OTPGETREGIONINFO], arg ptr[out, array[otp_info]])",
+    "ioctl$KGPT_OTPLOCK": "ioctl$KGPT_OTPLOCK(fd fd_mtd, cmd const[OTPLOCK], arg ptr[in, otp_info])",
+    "ioctl$KGPT_OTPERASE": "ioctl$KGPT_OTPERASE(fd fd_mtd, cmd const[OTPERASE], arg ptr[in, otp_info])",
+    "ioctl$KGPT_MTDFILEMODE": "ioctl$KGPT_MTDFILEMODE(fd fd_mtd, cmd const[MTDFILEMODE], arg flags[mtd_file_modes])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_mtd"
+  ],
+  "includes": [
+    "uapi/mtd/mtd-abi.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/mtty_dev_ops#samples_vfio-mdev_mtty.c:1947.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/mtty_dev_ops#samples_vfio-mdev_mtty.c:1947.json
@@ -1,0 +1,105 @@
+{
+  "open": {
+    "filename": "/dev/vfio/vfio-mtty#",
+    "fd_name": "fd_mtty",
+    "spec": "syz_open_dev$KGPT_mtty(dev ptr[in, string[\"/dev/vfio/vfio-mtty#\"]], id proc[0, 1], flags flags[open_flags]) fd_mtty"
+  },
+  "resources": {
+    "fd_mtty": {
+      "type": "fd",
+      "spec": "resource fd_mtty[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/samples/vfio-mdev/mtty.c:1947",
+  "ioctls": {
+    "VFIO_DEVICE_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_INFO": {
+      "arg": "ptr[inout, vfio_device_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_REGION_INFO": {
+      "arg": "ptr[inout, vfio_region_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "mtty_get_region_info"
+        ],
+        "type": [
+          "vfio_region_info"
+        ],
+        "usage": [
+          "struct vfio_region_info info;",
+          "if (copy_from_user(&info, (void __user *)arg, minsz))",
+          "ret = mtty_get_region_info(mdev_state, &info, &cap_type_id, &cap_type);",
+          "if (copy_to_user((void __user *)arg, &info, minsz))"
+        ]
+      }
+    },
+    "VFIO_DEVICE_GET_IRQ_INFO": {
+      "arg": "ptr[inout, vfio_irq_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_SET_IRQS": {
+      "arg": "ptr[in, vfio_irq_set]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "vfio_device_info": "vfio_device_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_flags, int32]\n\tnum_regions\tint32\n\tnum_irqs\tint32\n\tcap_offset\tint32\n\tpad\tint32\n}",
+    "vfio_region_info": "vfio_region_info {\n\targsz\tint32\n\tflags\tflags[vfio_region_info_flags, int32]\n\tindex\tint32\n\tcap_offset\tint32\n\tsize\tint64\n\toffset\tint64\n}",
+    "vfio_irq_info": "vfio_irq_info {\n\targsz\tint32\n\tflags\tflags[vfio_irq_info_flags, int32]\n\tindex\tint32\n\tcount\tint32\n}",
+    "vfio_irq_set": "vfio_irq_set {\n\targsz\tint32\n\tflags\tflags[vfio_irq_set_flags, int32]\n\tindex\tint32\n\tstart\tint32\n\tcount\tint32\n\tdata\tarray[int8]\n}",
+    "vfio_device_flags": "vfio_device_flags = VFIO_DEVICE_FLAGS_RESET, VFIO_DEVICE_FLAGS_PCI, VFIO_DEVICE_FLAGS_PLATFORM, VFIO_DEVICE_FLAGS_AMBA, VFIO_DEVICE_FLAGS_CCW, VFIO_DEVICE_FLAGS_AP, VFIO_DEVICE_FLAGS_FSL_MC, VFIO_DEVICE_FLAGS_CAPS, VFIO_DEVICE_FLAGS_CDX",
+    "vfio_region_info_flags": "vfio_region_info_flags = VFIO_REGION_INFO_FLAG_READ, VFIO_REGION_INFO_FLAG_WRITE, VFIO_REGION_INFO_FLAG_MMAP, VFIO_REGION_INFO_FLAG_CAPS",
+    "vfio_irq_info_flags": "vfio_irq_info_flags = VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_INFO_MASKABLE, VFIO_IRQ_INFO_AUTOMASKED, VFIO_IRQ_INFO_NORESIZE",
+    "vfio_irq_set_flags": "vfio_irq_set_flags = VFIO_IRQ_SET_DATA_NONE, VFIO_IRQ_SET_DATA_BOOL, VFIO_IRQ_SET_DATA_EVENTFD, VFIO_IRQ_SET_ACTION_MASK, VFIO_IRQ_SET_ACTION_UNMASK, VFIO_IRQ_SET_ACTION_TRIGGER",
+    "VFIO_DEVICE_FLAGS_RESET": "define VFIO_DEVICE_FLAGS_RESET 0x1",
+    "VFIO_DEVICE_FLAGS_PCI": "define VFIO_DEVICE_FLAGS_PCI 0x2",
+    "VFIO_DEVICE_FLAGS_PLATFORM": "define VFIO_DEVICE_FLAGS_PLATFORM 0x4",
+    "VFIO_DEVICE_FLAGS_AMBA": "define VFIO_DEVICE_FLAGS_AMBA 0x8",
+    "VFIO_DEVICE_FLAGS_CCW": "define VFIO_DEVICE_FLAGS_CCW 0x10",
+    "VFIO_DEVICE_FLAGS_AP": "define VFIO_DEVICE_FLAGS_AP 0x20",
+    "VFIO_DEVICE_FLAGS_FSL_MC": "define VFIO_DEVICE_FLAGS_FSL_MC 0x40",
+    "VFIO_DEVICE_FLAGS_CAPS": "define VFIO_DEVICE_FLAGS_CAPS 0x80",
+    "VFIO_DEVICE_FLAGS_CDX": "define VFIO_DEVICE_FLAGS_CDX 0x100",
+    "VFIO_REGION_INFO_FLAG_READ": "define VFIO_REGION_INFO_FLAG_READ 0x1",
+    "VFIO_REGION_INFO_FLAG_WRITE": "define VFIO_REGION_INFO_FLAG_WRITE 0x2",
+    "VFIO_REGION_INFO_FLAG_MMAP": "define VFIO_REGION_INFO_FLAG_MMAP 0x4",
+    "VFIO_REGION_INFO_FLAG_CAPS": "define VFIO_REGION_INFO_FLAG_CAPS 0x8",
+    "VFIO_IRQ_INFO_EVENTFD": "define VFIO_IRQ_INFO_EVENTFD 1",
+    "VFIO_IRQ_INFO_MASKABLE": "define VFIO_IRQ_INFO_MASKABLE 2",
+    "VFIO_IRQ_INFO_AUTOMASKED": "define VFIO_IRQ_INFO_AUTOMASKED 4",
+    "VFIO_IRQ_INFO_NORESIZE": "define VFIO_IRQ_INFO_NORESIZE 8",
+    "VFIO_IRQ_SET_DATA_NONE": "define VFIO_IRQ_SET_DATA_NONE 0x1",
+    "VFIO_IRQ_SET_DATA_BOOL": "define VFIO_IRQ_SET_DATA_BOOL 0x2",
+    "VFIO_IRQ_SET_DATA_EVENTFD": "define VFIO_IRQ_SET_DATA_EVENTFD 0x4",
+    "VFIO_IRQ_SET_ACTION_MASK": "define VFIO_IRQ_SET_ACTION_MASK 0x8",
+    "VFIO_IRQ_SET_ACTION_UNMASK": "define VFIO_IRQ_SET_ACTION_UNMASK 0x10",
+    "VFIO_IRQ_SET_ACTION_TRIGGER": "define VFIO_IRQ_SET_ACTION_TRIGGER 0x20"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_mtty": "syz_open_dev$KGPT_mtty(dev ptr[in, string[\"/dev/vfio/vfio-mtty#\"]], id proc[0, 1], flags flags[open_flags]) fd_mtty",
+    "ioctl$KGPT_VFIO_DEVICE_RESET": "ioctl$KGPT_VFIO_DEVICE_RESET(fd fd_mtty, cmd const[VFIO_DEVICE_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_INFO(fd fd_mtty, cmd const[VFIO_DEVICE_GET_INFO], arg ptr[inout, vfio_device_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO(fd fd_mtty, cmd const[VFIO_DEVICE_GET_REGION_INFO], arg ptr[inout, vfio_region_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO(fd fd_mtty, cmd const[VFIO_DEVICE_GET_IRQ_INFO], arg ptr[inout, vfio_irq_info])",
+    "ioctl$KGPT_VFIO_DEVICE_SET_IRQS": "ioctl$KGPT_VFIO_DEVICE_SET_IRQS(fd fd_mtty, cmd const[VFIO_DEVICE_SET_IRQS], arg ptr[in, vfio_irq_set])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_mtty"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/n_tty_ops#drivers_tty_n_tty.c:2515.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/n_tty_ops#drivers_tty_n_tty.c:2515.json
@@ -1,0 +1,474 @@
+{
+  "open": {
+    "filename": "/dev/tty#",
+    "fd_name": "fd_tty",
+    "spec": "syz_open_dev$KGPT_tty(dev ptr[in, string[\"/dev/tty#\"]], id proc[0, 1], flags flags[open_flags]) fd_tty"
+  },
+  "resources": {
+    "fd_tty": {
+      "type": "fd",
+      "spec": "resource fd_tty[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/tty/n_tty.c:2515",
+  "ioctls": {
+    "TIOCSETN": {
+      "arg": "ptr[in, sgttyb]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "TIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int __user *"
+        ],
+        "usage": [
+          "return put_user(tty_chars_in_buffer(tty), (int __user *) arg);"
+        ]
+      }
+    },
+    "TIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "unsigned int __user *"
+        ],
+        "usage": [
+          "unsigned int num;",
+          "down_write(&tty->termios_rwsem);",
+          "if (L_ICANON(tty) && !L_EXTPROC(tty))",
+          "\tnum = inq_canon(ldata);",
+          "else",
+          "\tnum = read_cnt(ldata);",
+          "up_write(&tty->termios_rwsem);",
+          "return put_user(num, (unsigned int __user *) arg);"
+        ]
+      }
+    },
+    "TCXONC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_check_change",
+          "__stop_tty",
+          "__start_tty",
+          "tty_send_xchar"
+        ],
+        "type": [],
+        "usage": [
+          "switch (arg) {",
+          "case TCOOFF:",
+          "case TCOON:",
+          "case TCIOFF:",
+          "if (STOP_CHAR(tty) != __DISABLED_CHAR)",
+          "retval = tty_send_xchar(tty, STOP_CHAR(tty));",
+          "case TCION:",
+          "if (START_CHAR(tty) != __DISABLED_CHAR)",
+          "retval = tty_send_xchar(tty, START_CHAR(tty));"
+        ]
+      }
+    },
+    "TCFLSH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_check_change",
+          "__tty_perform_flush"
+        ],
+        "type": [],
+        "usage": [
+          "retval = tty_check_change(tty);",
+          "return __tty_perform_flush(tty, arg);"
+        ]
+      }
+    },
+    "TIOCGETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return get_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCSETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return set_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCGETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCGLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETSF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETSW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCGETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TCGETS2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios2"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios2 __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TCSETSF2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT);"
+        ]
+      }
+    },
+    "TCSETSW2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT);"
+        ]
+      }
+    },
+    "TCSETS2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, 0);"
+        ]
+      }
+    },
+    "TCGETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_termio"
+        ],
+        "type": [],
+        "usage": [
+          "return get_termio(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETAF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETAW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TIOCGLCKTRMIOS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios_locked",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "copy_termios_locked(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TIOCSLCKTRMIOS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios_locked",
+          "user_termios_to_kernel_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "copy_termios_locked(real_tty, &kterm);",
+          "if (user_termios_to_kernel_termios(&kterm, (struct termios __user *) arg))"
+        ]
+      }
+    },
+    "TIOCGSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "ret = put_user((kterm.c_cflag & CLOCAL) ? 1 : 0, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCSSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user",
+          "tty_change_softcar"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(arg, (unsigned int __user *) arg))",
+          "return tty_change_softcar(real_tty, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_tty": "syz_open_dev$KGPT_tty(dev ptr[in, string[\"/dev/tty#\"]], id proc[0, 1], flags flags[open_flags]) fd_tty"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_tty"
+  ],
+  "includes": [
+    "arch/powerpc/include/uapi/asm/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/nci_uart_ldisc#net_nfc_nci_uart.c:424.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/nci_uart_ldisc#net_nfc_nci_uart.c:424.json
@@ -1,0 +1,437 @@
+{
+  "open": {
+    "filename": "/dev/tty#",
+    "fd_name": "fd_nci_uart",
+    "spec": "syz_open_dev$KGPT_nci_uart(dev ptr[in, string[\"/dev/tty#\"]], id proc[0, 1], flags flags[open_flags]) fd_nci_uart"
+  },
+  "resources": {
+    "fd_nci_uart": {
+      "type": "fd",
+      "spec": "resource fd_nci_uart[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/nfc/nci/uart.c:424",
+  "ioctls": {
+    "NCIUARTSETDRIVER": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "TIOCSETN": {
+      "arg": "ptr[in, sgttyb]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "TCXONC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_check_change",
+          "__stop_tty",
+          "__start_tty",
+          "tty_send_xchar"
+        ],
+        "type": [],
+        "usage": [
+          "switch (arg) {",
+          "case TCOOFF:",
+          "case TCOON:",
+          "case TCIOFF:",
+          "case TCION:",
+          "default:"
+        ]
+      }
+    },
+    "TCFLSH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_check_change",
+          "__tty_perform_flush"
+        ],
+        "type": [],
+        "usage": [
+          "return __tty_perform_flush(tty, arg);"
+        ]
+      }
+    },
+    "TIOCGETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return get_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCSETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return set_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCGETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCGLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETSF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p,  TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETSW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCGETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TCGETS2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios2"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios2 __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TCSETSF2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p,  TERMIOS_FLUSH | TERMIOS_WAIT);"
+        ]
+      }
+    },
+    "TCSETSW2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT);"
+        ]
+      }
+    },
+    "TCSETS2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, 0);"
+        ]
+      }
+    },
+    "TCGETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_termio"
+        ],
+        "type": [],
+        "usage": [
+          "return get_termio(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETAF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETAW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TIOCGLCKTRMIOS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios_locked",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "copy_termios_locked(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TIOCSLCKTRMIOS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios_locked",
+          "user_termios_to_kernel_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "if (!capable(CAP_SYS_ADMIN))",
+          "copy_termios_locked(real_tty, &kterm);",
+          "if (user_termios_to_kernel_termios(&kterm, (struct termios __user *) arg))"
+        ]
+      }
+    },
+    "TIOCGSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "ret = put_user((kterm.c_cflag & CLOCAL) ? 1 : 0, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCSSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user",
+          "tty_change_softcar"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(arg, (unsigned int __user *) arg))",
+          "return tty_change_softcar(real_tty, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_nci_uart": "syz_open_dev$KGPT_nci_uart(dev ptr[in, string[\"/dev/tty#\"]], id proc[0, 1], flags flags[open_flags]) fd_nci_uart",
+    "ioctl$KGPT_NCIUARTSETDRIVER": "ioctl$KGPT_NCIUARTSETDRIVER(fd fd_nci_uart, cmd const[NCIUARTSETDRIVER], arg intptr)"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_nci_uart"
+  ],
+  "includes": [
+    "net/nfc/nci_core.h",
+    "arch/powerpc/include/uapi/asm/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/nouveau_driver_fops#drivers_gpu_drm_nouveau_nouveau_drm.c:1249.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/nouveau_driver_fops#drivers_gpu_drm_nouveau_nouveau_drm.c:1249.json
@@ -1,0 +1,38 @@
+{
+  "open": {
+    "filename": "/dev/dri/card#",
+    "fd_name": "fd_dri",
+    "spec": "syz_open_dev$KGPT_dri(dev ptr[in, string[\"/dev/dri/card#\"]], id proc[0, 1], flags flags[open_flags]) fd_dri"
+  },
+  "resources": {
+    "fd_dri": {
+      "type": "fd",
+      "spec": "resource fd_dri[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/gpu/drm/nouveau/nouveau_drm.c:1249",
+  "ioctls": {
+    "DRM_NOUVEAU_NVIF": {
+      "arg": "ptr[in, nvif_ioctl]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "nvif_ioctl": "type nvif_ioctl ptr[in, array[int8]]"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_dri": "syz_open_dev$KGPT_dri(dev ptr[in, string[\"/dev/dri/card#\"]], id proc[0, 1], flags flags[open_flags]) fd_dri",
+    "ioctl$KGPT_DRM_NOUVEAU_NVIF": "ioctl$KGPT_DRM_NOUVEAU_NVIF(fd fd_dri, cmd const[DRM_NOUVEAU_NVIF], arg ptr[in, nvif_ioctl])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_dri"
+  ],
+  "includes": [
+    "uapi/drm/nouveau_drm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/nvme_bdev_ops#drivers_nvme_host_core.c:2160.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/nvme_bdev_ops#drivers_nvme_host_core.c:2160.json
@@ -1,0 +1,222 @@
+{
+  "open": {
+    "filename": "/dev/nvme#n#",
+    "fd_name": "fd_nvme",
+    "spec": "syz_open_dev$KGPT_nvme(dev ptr[in, string[\"/dev/nvme#n#\"]], id proc[0, 1], flags flags[open_flags]) fd_nvme"
+  },
+  "resources": {
+    "fd_nvme": {
+      "type": "fd",
+      "spec": "resource fd_nvme[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/nvme/host/core.c:2160",
+  "ioctls": {
+    "NVME_IOCTL_ID": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "NVME_IOCTL_ADMIN_CMD": {
+      "arg": "ptr[in,out, nvme_passthru_cmd]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "NVME_IOCTL_ADMIN64_CMD": {
+      "arg": "ptr[in, nvme_passthru_cmd64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "NVME_IOCTL_IO_CMD": {
+      "arg": "ptr[in, nvme_passthru_cmd]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "NVME_IOCTL_SUBMIT_IO": {
+      "arg": "ptr[in, nvme_user_io]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "NVME_IOCTL_IO64_CMD_VEC": {
+      "arg": "ptr[in, nvme_passthru_cmd64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "NVME_IOCTL_IO64_CMD": {
+      "arg": "ptr[in, nvme_passthru_cmd64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "IOC_OPAL_SAVE": {
+      "arg": "ptr[in, opal_lock_unlock]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_LOCK_UNLOCK": {
+      "arg": "ptr[in, opal_lock_unlock]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IOC_OPAL_TAKE_OWNERSHIP": {
+      "arg": "ptr[in, opal_key]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_ACTIVATE_LSP": {
+      "arg": "ptr[in, opal_lr_act]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_SET_PW": {
+      "arg": "ptr[in, opal_new_pw]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_ACTIVATE_USR": {
+      "arg": "ptr[in, opal_session_info]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_REVERT_TPR": {
+      "arg": "ptr[in, opal_key]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_LR_SETUP": {
+      "arg": "ptr[in, opal_user_lr_setup]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_ADD_USR_TO_LR": {
+      "arg": "ptr[in, opal_lock_unlock]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_ENABLE_DISABLE_MBR": {
+      "arg": "ptr[in, opal_mbr_data]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_MBR_DONE": {
+      "arg": "ptr[in, opal_mbr_done]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_WRITE_SHADOW_MBR": {
+      "arg": "ptr[in, opal_shadow_mbr]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_ERASE_LR": {
+      "arg": "ptr[in, opal_session_info]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_SECURE_ERASE_LR": {
+      "arg": "ptr[in, opal_session_info]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_PSID_REVERT_TPR": {
+      "arg": "ptr[in, opal_key]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_GENERIC_TABLE_RW": {
+      "arg": "ptr[in, opal_read_write_table]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_GET_STATUS": {
+      "arg": "ptr[out, opal_status]",
+      "arg_name_in_usage": "data",
+      "arg_inference": null
+    },
+    "IOC_OPAL_GET_LR_STATUS": {
+      "arg": "ptr[inout, opal_lr_status]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IOC_OPAL_GET_GEOMETRY": {
+      "arg": "ptr[out, opal_geometry]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "IOC_OPAL_REVERT_LSP": {
+      "arg": "ptr[in, opal_revert_lsp]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "IOC_OPAL_DISCOVERY": {
+      "arg": "ptr[out, opal_discovery]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "nvme_passthru_cmd": "nvme_passthru_cmd {\n\topcode\tint8\n\tflags\tint8\n\trsvd1\tint16\n\tnsid\tint32\n\tcdw2\tint32\n\tcdw3\tint32\n\tmetadata\tint64\n\taddr\tint64\n\tmetadata_len\tint32\n\tdata_len\tint32\n\tcdw10\tint32\n\tcdw11\tint32\n\tcdw12\tint32\n\tcdw13\tint32\n\tcdw14\tint32\n\tcdw15\tint32\n\ttimeout_ms\tint32\n\tresult\tint32\n}",
+    "nvme_passthru_cmd64": "nvme_passthru_cmd64 {\n\topcode\tint8\n\tflags\tint8\n\trsvd1\tint16\n\tnsid\tint32\n\tcdw2\tint32\n\tcdw3\tint32\n\tmetadata\tint64\n\taddr\tint64\n\tmetadata_len\tint32\n\tdata_len\tint32\n\tvec_cnt\tint32\n\tcdw10\tint32\n\tcdw11\tint32\n\tcdw12\tint32\n\tcdw13\tint32\n\tcdw14\tint32\n\tcdw15\tint32\n\ttimeout_ms\tint32\n\trsvd2\tint32\n\tresult\tint64\n}",
+    "nvme_user_io": "nvme_user_io {\n\topcode\tint8\n\tflags\tint8\n\tcontrol\tint16\n\tnblocks\tint16\n\trsvd\tint16\n\tmetadata\tint64\n\taddr\tint64\n\tslba\tint64\n\tdsmgmt\tint32\n\treftag\tint32\n\tapptag\tint16\n\tappmask\tint16\n}",
+    "opal_lock_unlock": "opal_lock_unlock {\n\tsession\topal_session_info\n\tl_state\tint32\n\tflags\tint16\n\t__align\tarray[int8, 2]\n}",
+    "opal_session_info": "opal_session_info {\n\tsum\tint32\n\twho\tint32\n\topal_key\topal_key\n}",
+    "opal_key": "opal_key {\n\tlr\tint8\n\tkey_len\tint8\n\tkey_type\tint8\n\t__align\tarray[int8, 5]\n\tkey\tarray[int8, OPAL_KEY_MAX]\n}",
+    "opal_lr_act": "opal_lr_act {\n\tkey\topal_key\n\tsum\tint32\n\tnum_lrs\tint8\n\tlr\tarray[int8, OPAL_MAX_LRS]\n\talign\tarray[int8, 2]\n}",
+    "opal_new_pw": "opal_new_pw {\n\tsession\topal_session_info\n\tnew_user_pw\topal_session_info\n}",
+    "opal_user_lr_setup": "opal_user_lr_setup {\n\trange_start\tint64\n\trange_length\tint64\n\tRLE\tint32\n\tWLE\tint32\n\tsession\topal_session_info\n}",
+    "opal_mbr_data": "opal_mbr_data {\n\tkey\topal_key\n\tenable_disable\tint8\n\t__align\tarray[int8, 7]\n}",
+    "opal_mbr_done": "opal_mbr_done {\n\tkey\topal_key\n\tdone_flag\tint8\n\t__align\tarray[int8, 7]\n}",
+    "opal_status": "opal_status {\n\tflags\tint32\n\treserved\tint32\n}",
+    "opal_lr_status": "opal_lr_status {\n\tsession\topal_session_info\n\trange_start\tint64\n\trange_length\tint64\n\tRLE\tint32\n\tWLE\tint32\n\tl_state\tint32\n\talign\tarray[int8, 4]\n}",
+    "opal_geometry": "opal_geometry {\n\talign\tint8\n\tlogical_block_size\tint32\n\talignment_granularity\tint64\n\tlowest_aligned_lba\tint64\n\t__align\tarray[int8, 3]\n}",
+    "opal_revert_lsp": "opal_revert_lsp {\n\tkey\topal_key\n\toptions\tint32\n\t__pad\tint32\n}",
+    "opal_discovery": "opal_discovery {\n\tdata\tint64\n\tsize\tint64\n}",
+    "opal_shadow_mbr": "opal_shadow_mbr {\n\tkey\topal_key\n\tdata\tconst[0, int64]\n\toffset\tint64\n\tsize\tint64\n}",
+    "opal_read_write_table": "opal_read_write_table {\n\tkey\topal_key\n\tdata\tint64\n\ttable_uid\tarray[const[0, int8], OPAL_UID_LENGTH]\n\toffset\tint64\n\tsize\tint64\n\tflags\tflags[opal_table_flags, int64]\n\tpriv\tint64\n}",
+    "opal_table_flags": "opal_table_flags = OPAL_TABLE_READ, OPAL_TABLE_WRITE",
+    "OPAL_TABLE_READ": "define OPAL_TABLE_READ 1",
+    "OPAL_TABLE_WRITE": "define OPAL_TABLE_WRITE 2",
+    "OPAL_UID_LENGTH": "define OPAL_UID_LENGTH 8"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_nvme": "syz_open_dev$KGPT_nvme(dev ptr[in, string[\"/dev/nvme#n#\"]], id proc[0, 1], flags flags[open_flags]) fd_nvme",
+    "ioctl$KGPT_NVME_IOCTL_ID": "ioctl$KGPT_NVME_IOCTL_ID(fd fd_nvme, cmd const[NVME_IOCTL_ID], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_NVME_IOCTL_ADMIN_CMD": "ioctl$KGPT_NVME_IOCTL_ADMIN_CMD(fd fd_nvme, cmd const[NVME_IOCTL_ADMIN_CMD], arg ptr[inout, nvme_passthru_cmd])",
+    "ioctl$KGPT_NVME_IOCTL_ADMIN64_CMD": "ioctl$KGPT_NVME_IOCTL_ADMIN64_CMD(fd fd_nvme, cmd const[NVME_IOCTL_ADMIN64_CMD], arg ptr[in, nvme_passthru_cmd64])",
+    "ioctl$KGPT_NVME_IOCTL_IO_CMD": "ioctl$KGPT_NVME_IOCTL_IO_CMD(fd fd_nvme, cmd const[NVME_IOCTL_IO_CMD], arg ptr[in, nvme_passthru_cmd])",
+    "ioctl$KGPT_NVME_IOCTL_SUBMIT_IO": "ioctl$KGPT_NVME_IOCTL_SUBMIT_IO(fd fd_nvme, cmd const[NVME_IOCTL_SUBMIT_IO], arg ptr[in, nvme_user_io])",
+    "ioctl$KGPT_NVME_IOCTL_IO64_CMD_VEC": "ioctl$KGPT_NVME_IOCTL_IO64_CMD_VEC(fd fd_nvme, cmd const[NVME_IOCTL_IO64_CMD_VEC], arg ptr[in, nvme_passthru_cmd64])",
+    "ioctl$KGPT_NVME_IOCTL_IO64_CMD": "ioctl$KGPT_NVME_IOCTL_IO64_CMD(fd fd_nvme, cmd const[NVME_IOCTL_IO64_CMD], arg ptr[in, nvme_passthru_cmd64])",
+    "ioctl$KGPT_IOC_OPAL_SAVE": "ioctl$KGPT_IOC_OPAL_SAVE(fd fd_nvme, cmd const[IOC_OPAL_SAVE], arg ptr[in, opal_lock_unlock])",
+    "ioctl$KGPT_IOC_OPAL_LOCK_UNLOCK": "ioctl$KGPT_IOC_OPAL_LOCK_UNLOCK(fd fd_nvme, cmd const[IOC_OPAL_LOCK_UNLOCK], arg ptr[in, opal_lock_unlock])",
+    "ioctl$KGPT_IOC_OPAL_TAKE_OWNERSHIP": "ioctl$KGPT_IOC_OPAL_TAKE_OWNERSHIP(fd fd_nvme, cmd const[IOC_OPAL_TAKE_OWNERSHIP], arg ptr[in, opal_key])",
+    "ioctl$KGPT_IOC_OPAL_ACTIVATE_LSP": "ioctl$KGPT_IOC_OPAL_ACTIVATE_LSP(fd fd_nvme, cmd const[IOC_OPAL_ACTIVATE_LSP], arg ptr[in, opal_lr_act])",
+    "ioctl$KGPT_IOC_OPAL_SET_PW": "ioctl$KGPT_IOC_OPAL_SET_PW(fd fd_nvme, cmd const[IOC_OPAL_SET_PW], arg ptr[in, opal_new_pw])",
+    "ioctl$KGPT_IOC_OPAL_ACTIVATE_USR": "ioctl$KGPT_IOC_OPAL_ACTIVATE_USR(fd fd_nvme, cmd const[IOC_OPAL_ACTIVATE_USR], arg ptr[in, opal_session_info])",
+    "ioctl$KGPT_IOC_OPAL_REVERT_TPR": "ioctl$KGPT_IOC_OPAL_REVERT_TPR(fd fd_nvme, cmd const[IOC_OPAL_REVERT_TPR], arg ptr[in, opal_key])",
+    "ioctl$KGPT_IOC_OPAL_LR_SETUP": "ioctl$KGPT_IOC_OPAL_LR_SETUP(fd fd_nvme, cmd const[IOC_OPAL_LR_SETUP], arg ptr[in, opal_user_lr_setup])",
+    "ioctl$KGPT_IOC_OPAL_ADD_USR_TO_LR": "ioctl$KGPT_IOC_OPAL_ADD_USR_TO_LR(fd fd_nvme, cmd const[IOC_OPAL_ADD_USR_TO_LR], arg ptr[in, opal_lock_unlock])",
+    "ioctl$KGPT_IOC_OPAL_ENABLE_DISABLE_MBR": "ioctl$KGPT_IOC_OPAL_ENABLE_DISABLE_MBR(fd fd_nvme, cmd const[IOC_OPAL_ENABLE_DISABLE_MBR], arg ptr[in, opal_mbr_data])",
+    "ioctl$KGPT_IOC_OPAL_MBR_DONE": "ioctl$KGPT_IOC_OPAL_MBR_DONE(fd fd_nvme, cmd const[IOC_OPAL_MBR_DONE], arg ptr[in, opal_mbr_done])",
+    "ioctl$KGPT_IOC_OPAL_WRITE_SHADOW_MBR": "ioctl$KGPT_IOC_OPAL_WRITE_SHADOW_MBR(fd fd_nvme, cmd const[IOC_OPAL_WRITE_SHADOW_MBR], arg ptr[in, opal_shadow_mbr])",
+    "ioctl$KGPT_IOC_OPAL_ERASE_LR": "ioctl$KGPT_IOC_OPAL_ERASE_LR(fd fd_nvme, cmd const[IOC_OPAL_ERASE_LR], arg ptr[in, opal_session_info])",
+    "ioctl$KGPT_IOC_OPAL_SECURE_ERASE_LR": "ioctl$KGPT_IOC_OPAL_SECURE_ERASE_LR(fd fd_nvme, cmd const[IOC_OPAL_SECURE_ERASE_LR], arg ptr[in, opal_session_info])",
+    "ioctl$KGPT_IOC_OPAL_PSID_REVERT_TPR": "ioctl$KGPT_IOC_OPAL_PSID_REVERT_TPR(fd fd_nvme, cmd const[IOC_OPAL_PSID_REVERT_TPR], arg ptr[in, opal_key])",
+    "ioctl$KGPT_IOC_OPAL_GENERIC_TABLE_RW": "ioctl$KGPT_IOC_OPAL_GENERIC_TABLE_RW(fd fd_nvme, cmd const[IOC_OPAL_GENERIC_TABLE_RW], arg ptr[in, opal_read_write_table])",
+    "ioctl$KGPT_IOC_OPAL_GET_STATUS": "ioctl$KGPT_IOC_OPAL_GET_STATUS(fd fd_nvme, cmd const[IOC_OPAL_GET_STATUS], arg ptr[out, opal_status])",
+    "ioctl$KGPT_IOC_OPAL_GET_LR_STATUS": "ioctl$KGPT_IOC_OPAL_GET_LR_STATUS(fd fd_nvme, cmd const[IOC_OPAL_GET_LR_STATUS], arg ptr[inout, opal_lr_status])",
+    "ioctl$KGPT_IOC_OPAL_GET_GEOMETRY": "ioctl$KGPT_IOC_OPAL_GET_GEOMETRY(fd fd_nvme, cmd const[IOC_OPAL_GET_GEOMETRY], arg ptr[out, opal_geometry])",
+    "ioctl$KGPT_IOC_OPAL_REVERT_LSP": "ioctl$KGPT_IOC_OPAL_REVERT_LSP(fd fd_nvme, cmd const[IOC_OPAL_REVERT_LSP], arg ptr[in, opal_revert_lsp])",
+    "ioctl$KGPT_IOC_OPAL_DISCOVERY": "ioctl$KGPT_IOC_OPAL_DISCOVERY(fd fd_nvme, cmd const[IOC_OPAL_DISCOVERY], arg ptr[out, opal_discovery])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_nvme"
+  ],
+  "includes": [
+    "uapi/linux/nvme_ioctl.h",
+    "uapi/linux/sed-opal.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/nvme_dev_fops#drivers_nvme_host_core.c:3239.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/nvme_dev_fops#drivers_nvme_host_core.c:3239.json
@@ -1,0 +1,69 @@
+{
+  "open": {
+    "filename": "/dev/nvme#",
+    "fd_name": "fd_nvme",
+    "spec": "syz_open_dev$KGPT_nvme(dev ptr[in, string[\"/dev/nvme#\"]], id proc[0, 1], flags flags[open_flags]) fd_nvme"
+  },
+  "resources": {
+    "fd_nvme": {
+      "type": "fd",
+      "spec": "resource fd_nvme[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/nvme/host/core.c:3239",
+  "ioctls": {
+    "NVME_IOCTL_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "NVME_IOCTL_SUBSYS_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "NVME_IOCTL_RESCAN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "NVME_IOCTL_ADMIN_CMD": {
+      "arg": "ptr[in, nvme_passthru_cmd]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "NVME_IOCTL_ADMIN64_CMD": {
+      "arg": "ptr[in,out, nvme_passthru_cmd64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "NVME_IOCTL_IO_CMD": {
+      "arg": "ptr[in, nvme_passthru_cmd]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "nvme_passthru_cmd": "nvme_passthru_cmd {\n\topcode\tint8\n\tflags\tint8\n\trsvd1\tint16\n\tnsid\tint32\n\tcdw2\tint32\n\tcdw3\tint32\n\tmetadata\tint64\n\taddr\tint64\n\tmetadata_len\tint32\n\tdata_len\tint32\n\tcdw10\tint32\n\tcdw11\tint32\n\tcdw12\tint32\n\tcdw13\tint32\n\tcdw14\tint32\n\tcdw15\tint32\n\ttimeout_ms\tint32\n\tresult\tint32\n}",
+    "nvme_passthru_cmd64": "nvme_passthru_cmd64 {\n\topcode\tint8\n\tflags\tint8\n\trsvd1\tint16\n\tnsid\tint32\n\tcdw2\tint32\n\tcdw3\tint32\n\tmetadata\tint64\n\taddr\tint64\n\tmetadata_len\tint32\n\tdata_len\tint32\n\tvec_cnt\tint32\n\tcdw10\tint32\n\tcdw11\tint32\n\tcdw12\tint32\n\tcdw13\tint32\n\tcdw14\tint32\n\tcdw15\tint32\n\ttimeout_ms\tint32\n\trsvd2\tint32\n\tresult\tint64\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_nvme": "syz_open_dev$KGPT_nvme(dev ptr[in, string[\"/dev/nvme#\"]], id proc[0, 1], flags flags[open_flags]) fd_nvme",
+    "ioctl$KGPT_NVME_IOCTL_RESET": "ioctl$KGPT_NVME_IOCTL_RESET(fd fd_nvme, cmd const[NVME_IOCTL_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_NVME_IOCTL_SUBSYS_RESET": "ioctl$KGPT_NVME_IOCTL_SUBSYS_RESET(fd fd_nvme, cmd const[NVME_IOCTL_SUBSYS_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_NVME_IOCTL_RESCAN": "ioctl$KGPT_NVME_IOCTL_RESCAN(fd fd_nvme, cmd const[NVME_IOCTL_RESCAN], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_NVME_IOCTL_ADMIN_CMD": "ioctl$KGPT_NVME_IOCTL_ADMIN_CMD(fd fd_nvme, cmd const[NVME_IOCTL_ADMIN_CMD], arg ptr[in, nvme_passthru_cmd])",
+    "ioctl$KGPT_NVME_IOCTL_ADMIN64_CMD": "ioctl$KGPT_NVME_IOCTL_ADMIN64_CMD(fd fd_nvme, cmd const[NVME_IOCTL_ADMIN64_CMD], arg ptr[inout, nvme_passthru_cmd64])",
+    "ioctl$KGPT_NVME_IOCTL_IO_CMD": "ioctl$KGPT_NVME_IOCTL_IO_CMD(fd fd_nvme, cmd const[NVME_IOCTL_IO_CMD], arg ptr[in, nvme_passthru_cmd])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_nvme"
+  ],
+  "includes": [
+    "uapi/linux/nvme_ioctl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/nvram_misc_fops#drivers_char_nvram.c:490.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/nvram_misc_fops#drivers_char_nvram.c:490.json
@@ -1,0 +1,65 @@
+{
+  "open": {
+    "filename": "/dev/nvram",
+    "fd_name": "fd_nvram",
+    "spec": "openat$KGPT_nvram(fd const[AT_FDCWD], file ptr[in, string[\"/dev/nvram\"]], flags flags[open_flags], mode const[0]) fd_nvram"
+  },
+  "resources": {
+    "fd_nvram": {
+      "type": "fd",
+      "spec": "resource fd_nvram[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/char/nvram.c:490",
+  "ioctls": {
+    "IOC_NVRAM_SYNC": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "NVRAM_INIT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "NVRAM_SETCKS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "OBSOLETE_PMAC_NVRAM_GET_OFFSET": {
+      "arg": "ptr[inout, pmac_nvram_partition]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IOC_NVRAM_GET_OFFSET": {
+      "arg": "ptr[inout, nvram_partition]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "pmac_nvram_partition": "type pmac_nvram_partition ptr[in, array[int8]]",
+    "nvram_partition": "type nvram_partition ptr[in, array[int8]]"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_nvram": "openat$KGPT_nvram(fd const[AT_FDCWD], file ptr[in, string[\"/dev/nvram\"]], flags flags[open_flags], mode const[0]) fd_nvram",
+    "ioctl$KGPT_IOC_NVRAM_SYNC": "ioctl$KGPT_IOC_NVRAM_SYNC(fd fd_nvram, cmd const[IOC_NVRAM_SYNC], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_NVRAM_INIT": "ioctl$KGPT_NVRAM_INIT(fd fd_nvram, cmd const[NVRAM_INIT], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_NVRAM_SETCKS": "ioctl$KGPT_NVRAM_SETCKS(fd fd_nvram, cmd const[NVRAM_SETCKS], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_OBSOLETE_PMAC_NVRAM_GET_OFFSET": "ioctl$KGPT_OBSOLETE_PMAC_NVRAM_GET_OFFSET(fd fd_nvram, cmd const[OBSOLETE_PMAC_NVRAM_GET_OFFSET], arg ptr[inout, pmac_nvram_partition])",
+    "ioctl$KGPT_IOC_NVRAM_GET_OFFSET": "ioctl$KGPT_IOC_NVRAM_GET_OFFSET(fd fd_nvram, cmd const[IOC_NVRAM_GET_OFFSET], arg ptr[inout, nvram_partition])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_nvram"
+  ],
+  "includes": [
+    "arch/powerpc/include/uapi/asm/nvram.h",
+    "uapi/linux/fcntl.h",
+    "uapi/linux/nvram.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ops#drivers_atm_eni.c:2203.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ops#drivers_atm_eni.c:2203.json
@@ -1,0 +1,52 @@
+{
+  "open": {
+    "filename": "/dev/atm/eni#",
+    "fd_name": "fd_eni",
+    "spec": "syz_open_dev$KGPT_eni(dev ptr[in, string[\"/dev/atm/eni#\"]], id proc[0, 1], flags flags[open_flags]) fd_eni"
+  },
+  "resources": {
+    "fd_eni": {
+      "type": "fd",
+      "spec": "resource fd_eni[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/atm/eni.c:2203",
+  "ioctls": {
+    "ENI_MEMDUMP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ENI_SETMULT": {
+      "arg": "ptr[in, eni_multipliers]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "ATM_SETCIRANGE": {
+      "arg": "ptr[in, atm_cirange]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "eni_multipliers": "eni_multipliers {\n\ttx\tint32\n\trx\tint32\n}",
+    "atm_cirange": "atm_cirange {\n\tvpi_bits\tint8\n\tvci_bits\tint8\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_eni": "syz_open_dev$KGPT_eni(dev ptr[in, string[\"/dev/atm/eni#\"]], id proc[0, 1], flags flags[open_flags]) fd_eni",
+    "ioctl$KGPT_ENI_MEMDUMP": "ioctl$KGPT_ENI_MEMDUMP(fd fd_eni, cmd const[ENI_MEMDUMP], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ENI_SETMULT": "ioctl$KGPT_ENI_SETMULT(fd fd_eni, cmd const[ENI_SETMULT], arg ptr[in, eni_multipliers])",
+    "ioctl$KGPT_ATM_SETCIRANGE": "ioctl$KGPT_ATM_SETCIRANGE(fd fd_eni, cmd const[ATM_SETCIRANGE], arg ptr[in, atm_cirange])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_eni"
+  ],
+  "includes": [
+    "uapi/linux/atmdev.h",
+    "uapi/linux/atm_eni.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ops#sound_firewire_motu_motu-hwdep.c:279.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ops#sound_firewire_motu_motu-hwdep.c:279.json
@@ -1,0 +1,85 @@
+{
+  "open": {
+    "filename": "/dev/snd/hwC#D#",
+    "fd_name": "fd_snd_motu",
+    "spec": "syz_open_dev$KGPT_snd_motu(dev ptr[in, string[\"/dev/snd/hwC#D#\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_motu"
+  },
+  "resources": {
+    "fd_snd_motu": {
+      "type": "fd",
+      "spec": "resource fd_snd_motu[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/firewire/motu/motu-hwdep.c:279",
+  "ioctls": {
+    "SNDRV_FIREWIRE_IOCTL_MOTU_REGISTER_DSP_METER": {
+      "arg": "ptr[out, snd_firewire_motu_register_dsp_meter]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_FIREWIRE_IOCTL_MOTU_COMMAND_DSP_METER": {
+      "arg": "ptr[out, snd_firewire_motu_command_dsp_meter]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_FIREWIRE_IOCTL_MOTU_REGISTER_DSP_PARAMETER": {
+      "arg": "ptr[inout, snd_firewire_motu_register_dsp_parameter]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "snd_firewire_motu_register_dsp_meter": "snd_firewire_motu_register_dsp_meter {\n\tdata\tarray[int8, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_METER_COUNT]\n}",
+    "snd_firewire_motu_register_dsp_parameter": "snd_firewire_motu_register_dsp_parameter {\n\tmixer\tsnd_firewire_motu_register_dsp_mixer\n\toutput\tsnd_firewire_motu_register_dsp_output\n\tline_input\tsnd_firewire_motu_register_dsp_line_input\n\tinput\tsnd_firewire_motu_register_dsp_input\n\treserved\tarray[int8, 64]\n}",
+    "snd_firewire_motu_command_dsp_meter": "snd_firewire_motu_command_dsp_meter {\n\tdata\tarray[int32, SNDRV_FIREWIRE_MOTU_COMMAND_DSP_METER_COUNT]\n}",
+    "snd_firewire_motu_register_dsp_mixer": "snd_firewire_motu_register_dsp_mixer {\n\tsource\tarray[snd_firewire_motu_register_dsp_mixer_source, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_MIXER_COUNT]\n\toutput\tsnd_firewire_motu_register_dsp_mixer_output\n}",
+    "snd_firewire_motu_register_dsp_mixer_source": "snd_firewire_motu_register_dsp_mixer_source {\n\tgain\tarray[int8, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_MIXER_SRC_COUNT]\n\tpan\tarray[int8, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_MIXER_SRC_COUNT]\n\tflag\tarray[int8, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_MIXER_SRC_COUNT]\n\tpaired_balance\tarray[int8, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_MIXER_SRC_COUNT]\n\tpaired_width\tarray[int8, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_MIXER_SRC_COUNT]\n}",
+    "snd_firewire_motu_register_dsp_mixer_output": "snd_firewire_motu_register_dsp_mixer_output {\n\tpaired_volume\tarray[int8, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_MIXER_COUNT]\n\tpaired_flag\tarray[int8, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_MIXER_COUNT]\n}",
+    "snd_firewire_motu_register_dsp_output": "snd_firewire_motu_register_dsp_output {\n\tmain_paired_volume\tint8\n\thp_paired_volume\tint8\n\thp_paired_assignment\tint8\n\treserved\tarray[int8, 5]\n}",
+    "snd_firewire_motu_register_dsp_line_input": "snd_firewire_motu_register_dsp_line_input {\n\tboost_flag\tint8\n\tnominal_level_flag\tint8\n\treserved\tarray[int8, 6]\n}",
+    "snd_firewire_motu_register_dsp_input": "snd_firewire_motu_register_dsp_input {\n\tgain_and_invert\tarray[int8, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_ALIGNED_INPUT_COUNT]\n\tflag\tarray[int8, SNDRV_FIREWIRE_MOTU_REGISTER_DSP_ALIGNED_INPUT_COUNT]\n}",
+    "SNDRV_FIREWIRE_MOTU_COMMAND_DSP_METER_COUNT": "define SNDRV_FIREWIRE_MOTU_COMMAND_DSP_METER_COUNT 0x100"
+  },
+  "existing_ioctls": {
+    "SNDRV_FIREWIRE_IOCTL_GET_INFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "hwdep_get_info"
+        ],
+        "type": [],
+        "usage": [
+          "return hwdep_get_info(motu, (void __user *)arg);"
+        ]
+      }
+    },
+    "SNDRV_FIREWIRE_IOCTL_LOCK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_FIREWIRE_IOCTL_UNLOCK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_snd_motu": "syz_open_dev$KGPT_snd_motu(dev ptr[in, string[\"/dev/snd/hwC#D#\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_motu",
+    "ioctl$KGPT_SNDRV_FIREWIRE_IOCTL_MOTU_REGISTER_DSP_METER": "ioctl$KGPT_SNDRV_FIREWIRE_IOCTL_MOTU_REGISTER_DSP_METER(fd fd_snd_motu, cmd const[SNDRV_FIREWIRE_IOCTL_MOTU_REGISTER_DSP_METER], arg ptr[out, snd_firewire_motu_register_dsp_meter])",
+    "ioctl$KGPT_SNDRV_FIREWIRE_IOCTL_MOTU_COMMAND_DSP_METER": "ioctl$KGPT_SNDRV_FIREWIRE_IOCTL_MOTU_COMMAND_DSP_METER(fd fd_snd_motu, cmd const[SNDRV_FIREWIRE_IOCTL_MOTU_COMMAND_DSP_METER], arg ptr[out, snd_firewire_motu_command_dsp_meter])",
+    "ioctl$KGPT_SNDRV_FIREWIRE_IOCTL_MOTU_REGISTER_DSP_PARAMETER": "ioctl$KGPT_SNDRV_FIREWIRE_IOCTL_MOTU_REGISTER_DSP_PARAMETER(fd fd_snd_motu, cmd const[SNDRV_FIREWIRE_IOCTL_MOTU_REGISTER_DSP_PARAMETER], arg ptr[inout, snd_firewire_motu_register_dsp_parameter])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_snd_motu"
+  ],
+  "includes": [
+    "uapi/sound/firewire.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ov2722_core_ops#drivers_staging_media_atomisp_i2c_atomisp-ov2722.c:907.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ov2722_core_ops#drivers_staging_media_atomisp_i2c_atomisp-ov2722.c:907.json
@@ -1,0 +1,38 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_ov2722",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_ov2722"
+  },
+  "resources": {
+    "fd_ov2722": {
+      "type": "fd",
+      "spec": "resource fd_ov2722[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/staging/media/atomisp/i2c/atomisp-ov2722.c:907",
+  "ioctls": {
+    "ATOMISP_IOC_S_EXPOSURE": {
+      "arg": "ptr[in, atomisp_exposure]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "atomisp_exposure": "atomisp_exposure {\n\tintegration_time\tarray[int32, 8]\n\tshutter_speed\tarray[int32, 8]\n\tgain\tarray[int32, 4]\n\taperture\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_ov2722",
+    "ioctl$KGPT_ATOMISP_IOC_S_EXPOSURE": "ioctl$KGPT_ATOMISP_IOC_S_EXPOSURE(fd fd_ov2722, cmd const[ATOMISP_IOC_S_EXPOSURE], arg ptr[in, atomisp_exposure])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "drivers/staging/media/atomisp/include/linux/atomisp.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ov5693_core_ops#drivers_staging_media_atomisp_i2c_ov5693_atomisp-ov5693.c:1627.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ov5693_core_ops#drivers_staging_media_atomisp_i2c_ov5693_atomisp-ov5693.c:1627.json
@@ -1,0 +1,38 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_ov5693",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_ov5693"
+  },
+  "resources": {
+    "fd_ov5693": {
+      "type": "fd",
+      "spec": "resource fd_ov5693[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/staging/media/atomisp/i2c/ov5693/atomisp-ov5693.c:1627",
+  "ioctls": {
+    "ATOMISP_IOC_S_EXPOSURE": {
+      "arg": "ptr[in, atomisp_exposure]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "atomisp_exposure": "atomisp_exposure {\n\tintegration_time\tarray[int32, 8]\n\tshutter_speed\tarray[int32, 8]\n\tgain\tarray[int32, 4]\n\taperture\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_ov5693",
+    "ioctl$KGPT_ATOMISP_IOC_S_EXPOSURE": "ioctl$KGPT_ATOMISP_IOC_S_EXPOSURE(fd fd_ov5693, cmd const[ATOMISP_IOC_S_EXPOSURE], arg ptr[in, atomisp_exposure])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "drivers/staging/media/atomisp/include/linux/atomisp.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/pds_vfio_ops#drivers_vfio_pci_pds_vfio_dev.c:206.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/pds_vfio_ops#drivers_vfio_pci_pds_vfio_dev.c:206.json
@@ -1,0 +1,93 @@
+{
+  "open": {
+    "filename": "/dev/vfio/#",
+    "fd_name": "fd_vfio",
+    "spec": "syz_open_dev$KGPT_vfio(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_vfio"
+  },
+  "resources": {
+    "fd_vfio": {
+      "type": "fd",
+      "spec": "resource fd_vfio[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/vfio/pci/pds/vfio_dev.c:206",
+  "ioctls": {
+    "VFIO_DEVICE_GET_INFO": {
+      "arg": "ptr[out, vfio_device_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_IRQ_INFO": {
+      "arg": "ptr[in,out, vfio_irq_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_PCI_HOT_RESET_INFO": {
+      "arg": "ptr[inout, vfio_pci_hot_reset_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_REGION_INFO": {
+      "arg": "ptr[in,out, vfio_region_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_IOEVENTFD": {
+      "arg": "ptr[in, vfio_device_ioeventfd]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_PCI_HOT_RESET": {
+      "arg": "ptr[in, vfio_pci_hot_reset]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_SET_IRQS": {
+      "arg": "ptr[in, vfio_irq_set]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "vfio_device_info": "vfio_device_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_flags, int32]\n\tnum_regions\tint32\n\tnum_irqs\tint32\n\tcap_offset\tint32\n\tpad\tint32\n}",
+    "vfio_region_info": "vfio_region_info {\n\targsz\tint32\n\tflags\tflags[vfio_region_info_flags, int32]\n\tindex\tint32\n\tcap_offset\tint32\n\tsize\tint64\n\toffset\tint64\n}",
+    "vfio_device_ioeventfd": "vfio_device_ioeventfd {\n\targsz\tint32\n\tflags\tflags[vfio_device_ioeventfd_flags, int32]\n\toffset\tint64\n\tdata\tint64\n\tfd\tint32\n\treserved\tint32\n}",
+    "vfio_pci_hot_reset_info": "vfio_pci_hot_reset_info {\n\targsz\tint32\n\tflags\tflags[vfio_pci_hot_reset_flags, int32]\n\tcount\tlen[devices, int32]\n\tdevices\tptr[inout, array[vfio_pci_dependent_device]]\n}",
+    "vfio_pci_hot_reset": "vfio_pci_hot_reset {\n\targsz\tint32\n\tflags\tint32\n\tcount\tlen[group_fds, int32]\n\tgroup_fds\tptr[in, array[int32]]\n}",
+    "vfio_irq_set": "vfio_irq_set {\n\targsz\tint32\n\tflags\tflags[vfio_irq_set_flags, int32]\n\tindex\tint32\n\tstart\tint32\n\tcount\tlen[data, int32]\n\tdata\tarray[int8]\n}",
+    "vfio_irq_info": "vfio_irq_info {\n\targsz\tint32\n\tflags\tflags[vfio_irq_info_flags, int32]\n\tindex\tint32\n\tcount\tint32\n}",
+    "vfio_device_flags": "vfio_device_flags = VFIO_DEVICE_FLAGS_RESET, VFIO_DEVICE_FLAGS_PCI, VFIO_DEVICE_FLAGS_PLATFORM, VFIO_DEVICE_FLAGS_AMBA, VFIO_DEVICE_FLAGS_CCW, VFIO_DEVICE_FLAGS_AP, VFIO_DEVICE_FLAGS_FSL_MC, VFIO_DEVICE_FLAGS_CAPS, VFIO_DEVICE_FLAGS_CDX",
+    "vfio_irq_info_flags": "vfio_irq_info_flags = VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_INFO_MASKABLE, VFIO_IRQ_INFO_AUTOMASKED, VFIO_IRQ_INFO_NORESIZE",
+    "vfio_pci_hot_reset_flags": "vfio_pci_hot_reset_flags = VFIO_PCI_HOT_RESET_FLAG_DEV_ID, VFIO_PCI_HOT_RESET_FLAG_DEV_ID_OWNED",
+    "vfio_region_info_flags": "vfio_region_info_flags = VFIO_REGION_INFO_FLAG_READ, VFIO_REGION_INFO_FLAG_WRITE, VFIO_REGION_INFO_FLAG_MMAP, VFIO_REGION_INFO_FLAG_CAPS",
+    "vfio_device_ioeventfd_flags": "vfio_device_ioeventfd_flags = VFIO_DEVICE_IOEVENTFD_8, VFIO_DEVICE_IOEVENTFD_16, VFIO_DEVICE_IOEVENTFD_32, VFIO_DEVICE_IOEVENTFD_64",
+    "vfio_irq_set_flags": "vfio_irq_set_flags = VFIO_IRQ_SET_DATA_NONE, VFIO_IRQ_SET_DATA_BOOL, VFIO_IRQ_SET_DATA_EVENTFD, VFIO_IRQ_SET_ACTION_MASK, VFIO_IRQ_SET_ACTION_UNMASK, VFIO_IRQ_SET_ACTION_TRIGGER",
+    "vfio_pci_dependent_device": "vfio_pci_dependent_device {\n\tgroup_id\tint32\n\tsegment\tint16\n\tbus\tint8\n\tdevfn\tint8\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_vfio": "syz_open_dev$KGPT_vfio(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_vfio",
+    "ioctl$KGPT_VFIO_DEVICE_GET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_INFO(fd fd_vfio, cmd const[VFIO_DEVICE_GET_INFO], arg ptr[out, vfio_device_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO(fd fd_vfio, cmd const[VFIO_DEVICE_GET_IRQ_INFO], arg ptr[inout, vfio_irq_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_PCI_HOT_RESET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_PCI_HOT_RESET_INFO(fd fd_vfio, cmd const[VFIO_DEVICE_GET_PCI_HOT_RESET_INFO], arg ptr[inout, vfio_pci_hot_reset_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO(fd fd_vfio, cmd const[VFIO_DEVICE_GET_REGION_INFO], arg ptr[inout, vfio_region_info])",
+    "ioctl$KGPT_VFIO_DEVICE_IOEVENTFD": "ioctl$KGPT_VFIO_DEVICE_IOEVENTFD(fd fd_vfio, cmd const[VFIO_DEVICE_IOEVENTFD], arg ptr[in, vfio_device_ioeventfd])",
+    "ioctl$KGPT_VFIO_DEVICE_PCI_HOT_RESET": "ioctl$KGPT_VFIO_DEVICE_PCI_HOT_RESET(fd fd_vfio, cmd const[VFIO_DEVICE_PCI_HOT_RESET], arg ptr[in, vfio_pci_hot_reset])",
+    "ioctl$KGPT_VFIO_DEVICE_RESET": "ioctl$KGPT_VFIO_DEVICE_RESET(fd fd_vfio, cmd const[VFIO_DEVICE_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_SET_IRQS": "ioctl$KGPT_VFIO_DEVICE_SET_IRQS(fd fd_vfio, cmd const[VFIO_DEVICE_SET_IRQS], arg ptr[in, vfio_irq_set])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_vfio"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ppp_ldisc#drivers_net_ppp_ppp_async.c:363.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ppp_ldisc#drivers_net_ppp_ppp_async.c:363.json
@@ -1,0 +1,457 @@
+{
+  "open": {
+    "filename": "/dev/pts/#",
+    "fd_name": "fd_ppp",
+    "spec": "syz_open_dev$KGPT_ppp(dev ptr[in, string[\"/dev/pts/#\"]], id proc[0, 1], flags flags[open_flags]) fd_ppp"
+  },
+  "resources": {
+    "fd_ppp": {
+      "type": "fd",
+      "spec": "resource fd_ppp[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/ppp/ppp_async.c:363",
+  "ioctls": {
+    "TIOCSETN": {
+      "arg": "ptr[in, sgttyb]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "PPPIOCGCHAN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (put_user(ppp_channel_index(&ap->chan), p))"
+        ]
+      }
+    },
+    "PPPIOCGUNIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (put_user(ppp_unit_number(&ap->chan), p))"
+        ]
+      }
+    },
+    "TCFLSH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "n_tty_ioctl_helper"
+        ],
+        "type": [],
+        "usage": [
+          "err = n_tty_ioctl_helper(tty, cmd, arg);"
+        ]
+      }
+    },
+    "FIONREAD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "val = 0;",
+          "if (put_user(val, p))"
+        ]
+      }
+    },
+    "TIOCGETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return get_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCSETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return set_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCGETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCGLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETSF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETSW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCGETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TCGETS2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios2"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios2 __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TCSETSF2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT);"
+        ]
+      }
+    },
+    "TCSETSW2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT);"
+        ]
+      }
+    },
+    "TCSETS2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, 0);"
+        ]
+      }
+    },
+    "TCGETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_termio"
+        ],
+        "type": [],
+        "usage": [
+          "return get_termio(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETAF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETAW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TIOCGLCKTRMIOS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios_locked",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "copy_termios_locked(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TIOCSLCKTRMIOS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios_locked",
+          "user_termios_to_kernel_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "copy_termios_locked(real_tty, &kterm);",
+          "if (user_termios_to_kernel_termios(&kterm, (struct termios __user *) arg))"
+        ]
+      }
+    },
+    "TIOCGSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "ret = put_user((kterm.c_cflag & CLOCAL) ? 1 : 0, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCSSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user",
+          "tty_change_softcar"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(arg, (unsigned int __user *) arg))",
+          "return tty_change_softcar(real_tty, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_ppp": "syz_open_dev$KGPT_ppp(dev ptr[in, string[\"/dev/pts/#\"]], id proc[0, 1], flags flags[open_flags]) fd_ppp"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_ppp"
+  ],
+  "includes": [
+    "arch/powerpc/include/uapi/asm/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/preview_v4l2_core_ops#drivers_media_platform_ti_omap3isp_isppreview.c:2106.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/preview_v4l2_core_ops#drivers_media_platform_ti_omap3isp_isppreview.c:2106.json
@@ -1,0 +1,53 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_isppreview",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_isppreview"
+  },
+  "resources": {
+    "fd_isppreview": {
+      "type": "fd",
+      "spec": "resource fd_isppreview[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/platform/ti/omap3isp/isppreview.c:2106",
+  "ioctls": {
+    "VIDIOC_OMAP3ISP_PRV_CFG": {
+      "arg": "ptr[in, omap3isp_prev_update_config]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "omap3isp_prev_update_config": "omap3isp_prev_update_config {\n\tupdate\tint32\n\tflag\tint32\n\tshading_shift\tint32\n\tluma\t ptr[in, omap3isp_prev_luma]\n\thmed\t ptr[in, omap3isp_prev_hmed]\n\tcfa\t ptr[in, omap3isp_prev_cfa]\n\tcsup\t ptr[in, omap3isp_prev_csup]\n\twbal\t ptr[in, omap3isp_prev_wbal]\n\tblkadj\t ptr[in, omap3isp_prev_blkadj]\n\trgb2rgb\t ptr[in, omap3isp_prev_rgbtorgb]\n\tcsc\t ptr[in, omap3isp_prev_csc]\n\tyclimit\t ptr[in, omap3isp_prev_yclimit]\n\tdcor\t ptr[in, omap3isp_prev_dcor]\n\tnf\t ptr[in, omap3isp_prev_nf]\n\tgamma\t ptr[in, omap3isp_prev_gtables]\n}",
+    "omap3isp_prev_luma": "omap3isp_prev_luma {\n\ttable\tarray[int32, OMAP3ISP_PREV_YENH_TBL_SIZE]\n}",
+    "omap3isp_prev_hmed": "omap3isp_prev_hmed {\n\todddist\tint8\n\tevendist\tint8\n\tthres\tint8\n}",
+    "omap3isp_prev_csup": "omap3isp_prev_csup {\n\tgain\tint8\n\tthres\tint8\n\thypf_en\tint8\n}",
+    "omap3isp_prev_wbal": "omap3isp_prev_wbal {\n\tdgain\tint16\n\tcoef3\tint8\n\tcoef2\tint8\n\tcoef1\tint8\n\tcoef0\tint8\n}",
+    "omap3isp_prev_blkadj": "omap3isp_prev_blkadj {\n\tred\tint8\n\tgreen\tint8\n\tblue\tint8\n}",
+    "omap3isp_prev_rgbtorgb": "omap3isp_prev_rgbtorgb {\n\tmatrix\tarray[array[int16, OMAP3ISP_RGB_MAX], OMAP3ISP_RGB_MAX]\n\toffset\tarray[int16, OMAP3ISP_RGB_MAX]\n}",
+    "omap3isp_prev_csc": "omap3isp_prev_csc {\n\tmatrix\tarray[array[int16, OMAP3ISP_RGB_MAX], OMAP3ISP_RGB_MAX]\n\toffset\tarray[int16, OMAP3ISP_RGB_MAX]\n}",
+    "omap3isp_prev_yclimit": "omap3isp_prev_yclimit {\n\tminC\tint8\n\tmaxC\tint8\n\tminY\tint8\n\tmaxY\tint8\n}",
+    "omap3isp_prev_dcor": "omap3isp_prev_dcor {\n\tcouplet_mode_en\tint8\n\tdetect_correct\tarray[int32, OMAP3ISP_PREV_DETECT_CORRECT_CHANNELS]\n}",
+    "omap3isp_prev_nf": "omap3isp_prev_nf {\n\tspread\tint8\n\ttable\tarray[int32, OMAP3ISP_PREV_NF_TBL_SIZE]\n}",
+    "omap3isp_prev_gtables": "omap3isp_prev_gtables {\n\tred\tarray[int32, OMAP3ISP_PREV_GAMMA_TBL_SIZE]\n\tgreen\tarray[int32, OMAP3ISP_PREV_GAMMA_TBL_SIZE]\n\tblue\tarray[int32, OMAP3ISP_PREV_GAMMA_TBL_SIZE]\n}",
+    "omap3isp_prev_cfa": "omap3isp_prev_cfa {\n\tformat\tint32\n\tgradthrs_vert\tint8\n\tgradthrs_horz\tint8\n\ttable\tarray[array[int32, OMAP3ISP_PREV_CFA_BLK_SIZE_CONST], 4]\n}",
+    "OMAP3ISP_PREV_CFA_BLK_SIZE_CONST": "define OMAP3ISP_PREV_CFA_BLK_SIZE_CONST 4"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_isppreview",
+    "ioctl$KGPT_VIDIOC_OMAP3ISP_PRV_CFG": "ioctl$KGPT_VIDIOC_OMAP3ISP_PRV_CFG(fd fd_isppreview, cmd const[VIDIOC_OMAP3ISP_PRV_CFG], arg ptr[in, omap3isp_prev_update_config])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "uapi/linux/omap3isp.h"
+  ],
+  "unused_types": {
+    "omap3isp_cfa_fmt": "omap3isp_cfa_fmt = OMAP3ISP_CFAFMT_BAYER, OMAP3ISP_CFAFMT_SONYVGA, OMAP3ISP_CFAFMT_RGBFOVEON, OMAP3ISP_CFAFMT_DNSPL, OMAP3ISP_CFAFMT_HONEYCOMB, OMAP3ISP_CFAFMT_RRGGBBFOVEON"
+  },
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/proto#drivers_net_wan_hdlc_cisco.c:296.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/proto#drivers_net_wan_hdlc_cisco.c:296.json
@@ -1,0 +1,45 @@
+{
+  "open": {
+    "filename": "/dev/net/tun",
+    "fd_name": "fd_hdlc_cisco",
+    "spec": "openat$KGPT_net_tun(fd const[AT_FDCWD], file ptr[in, string[\"/dev/net/tun\"]], flags flags[open_flags], mode const[0]) fd_hdlc_cisco"
+  },
+  "resources": {
+    "fd_hdlc_cisco": {
+      "type": "fd",
+      "spec": "resource fd_hdlc_cisco[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/wan/hdlc_cisco.c:296",
+  "ioctls": {
+    "IF_GET_PROTO": {
+      "arg": "ptr[out, cisco_proto]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IF_PROTO_CISCO": {
+      "arg": "ptr[in, cisco_proto]",
+      "arg_name_in_usage": "cisco_s",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_net_tun": "openat$KGPT_net_tun(fd const[AT_FDCWD], file ptr[in, string[\"/dev/net/tun\"]], flags flags[open_flags], mode const[0]) fd_hdlc_cisco",
+    "ioctl$KGPT_IF_GET_PROTO": "ioctl$KGPT_IF_GET_PROTO(fd fd_hdlc_cisco, cmd const[IF_GET_PROTO], arg ptr[out, cisco_proto])",
+    "ioctl$KGPT_IF_PROTO_CISCO": "ioctl$KGPT_IF_PROTO_CISCO(fd fd_hdlc_cisco, cmd const[IF_PROTO_CISCO], arg ptr[in, cisco_proto])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_net_tun"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/if.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "cisco_proto": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/proto#drivers_net_wan_hdlc_fr.c:1174.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/proto#drivers_net_wan_hdlc_fr.c:1174.json
@@ -1,0 +1,70 @@
+{
+  "open": {
+    "filename": "/dev/net/tun",
+    "fd_name": "fd_hdlc_fr",
+    "spec": "openat$KGPT_net_tun(fd const[AT_FDCWD], file ptr[in, string[\"/dev/net/tun\"]], flags flags[open_flags], mode const[0]) fd_hdlc_fr"
+  },
+  "resources": {
+    "fd_hdlc_fr": {
+      "type": "fd",
+      "spec": "resource fd_hdlc_fr[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/wan/hdlc_fr.c:1174",
+  "ioctls": {
+    "IF_GET_PROTO": {
+      "arg": "ptr[out, fr_proto]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IF_PROTO_FR": {
+      "arg": "ptr[in, fr_proto]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IF_PROTO_FR_ADD_PVC": {
+      "arg": "ptr[in, fr_proto_pvc]",
+      "arg_name_in_usage": "ifs->ifs_ifsu.fr_pvc",
+      "arg_inference": null
+    },
+    "IF_PROTO_FR_DEL_PVC": {
+      "arg": "ptr[in, fr_proto_pvc]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IF_PROTO_FR_ADD_ETH_PVC": {
+      "arg": "ptr[in, fr_proto_pvc]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IF_PROTO_FR_DEL_ETH_PVC": {
+      "arg": "ptr[in, fr_proto_pvc]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_net_tun": "openat$KGPT_net_tun(fd const[AT_FDCWD], file ptr[in, string[\"/dev/net/tun\"]], flags flags[open_flags], mode const[0]) fd_hdlc_fr",
+    "ioctl$KGPT_IF_GET_PROTO": "ioctl$KGPT_IF_GET_PROTO(fd fd_hdlc_fr, cmd const[IF_GET_PROTO], arg ptr[out, fr_proto])",
+    "ioctl$KGPT_IF_PROTO_FR": "ioctl$KGPT_IF_PROTO_FR(fd fd_hdlc_fr, cmd const[IF_PROTO_FR], arg ptr[in, fr_proto])",
+    "ioctl$KGPT_IF_PROTO_FR_ADD_PVC": "ioctl$KGPT_IF_PROTO_FR_ADD_PVC(fd fd_hdlc_fr, cmd const[IF_PROTO_FR_ADD_PVC], arg ptr[in, fr_proto_pvc])",
+    "ioctl$KGPT_IF_PROTO_FR_DEL_PVC": "ioctl$KGPT_IF_PROTO_FR_DEL_PVC(fd fd_hdlc_fr, cmd const[IF_PROTO_FR_DEL_PVC], arg ptr[in, fr_proto_pvc])",
+    "ioctl$KGPT_IF_PROTO_FR_ADD_ETH_PVC": "ioctl$KGPT_IF_PROTO_FR_ADD_ETH_PVC(fd fd_hdlc_fr, cmd const[IF_PROTO_FR_ADD_ETH_PVC], arg ptr[in, fr_proto_pvc])",
+    "ioctl$KGPT_IF_PROTO_FR_DEL_ETH_PVC": "ioctl$KGPT_IF_PROTO_FR_DEL_ETH_PVC(fd fd_hdlc_fr, cmd const[IF_PROTO_FR_DEL_ETH_PVC], arg ptr[in, fr_proto_pvc])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_net_tun"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/if.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "fr_proto": "EXISTING",
+    "fr_proto_pvc": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/proto#drivers_net_wan_hdlc_raw.c:29.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/proto#drivers_net_wan_hdlc_raw.c:29.json
@@ -1,0 +1,45 @@
+{
+  "open": {
+    "filename": "/dev/net/tun",
+    "fd_name": "fd_hdlc_raw",
+    "spec": "openat$KGPT_net_tun(fd const[AT_FDCWD], file ptr[in, string[\"/dev/net/tun\"]], flags flags[open_flags], mode const[0]) fd_hdlc_raw"
+  },
+  "resources": {
+    "fd_hdlc_raw": {
+      "type": "fd",
+      "spec": "resource fd_hdlc_raw[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/wan/hdlc_raw.c:29",
+  "ioctls": {
+    "IF_GET_PROTO": {
+      "arg": "ptr[out, raw_hdlc_proto]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IF_PROTO_HDLC": {
+      "arg": "ptr[in, raw_hdlc_proto]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_net_tun": "openat$KGPT_net_tun(fd const[AT_FDCWD], file ptr[in, string[\"/dev/net/tun\"]], flags flags[open_flags], mode const[0]) fd_hdlc_raw",
+    "ioctl$KGPT_IF_GET_PROTO": "ioctl$KGPT_IF_GET_PROTO(fd fd_hdlc_raw, cmd const[IF_GET_PROTO], arg ptr[out, raw_hdlc_proto])",
+    "ioctl$KGPT_IF_PROTO_HDLC": "ioctl$KGPT_IF_PROTO_HDLC(fd fd_hdlc_raw, cmd const[IF_PROTO_HDLC], arg ptr[in, raw_hdlc_proto])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_net_tun"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/if.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "raw_hdlc_proto": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/proto#drivers_net_wan_hdlc_raw_eth.c:43.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/proto#drivers_net_wan_hdlc_raw_eth.c:43.json
@@ -1,0 +1,45 @@
+{
+  "open": {
+    "filename": "/dev/net/tun",
+    "fd_name": "fd_hdlc_raw_eth",
+    "spec": "openat$KGPT_tap(fd const[AT_FDCWD], file ptr[in, string[\"/dev/net/tun\"]], flags flags[open_flags], mode const[0]) fd_hdlc_raw_eth"
+  },
+  "resources": {
+    "fd_hdlc_raw_eth": {
+      "type": "fd",
+      "spec": "resource fd_hdlc_raw_eth[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/wan/hdlc_raw_eth.c:43",
+  "ioctls": {
+    "IF_GET_PROTO": {
+      "arg": "ptr[out, raw_hdlc_proto]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IF_PROTO_HDLC_ETH": {
+      "arg": "ptr[in, raw_hdlc_proto]",
+      "arg_name_in_usage": "raw_s",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_tap": "openat$KGPT_tap(fd const[AT_FDCWD], file ptr[in, string[\"/dev/net/tun\"]], flags flags[open_flags], mode const[0]) fd_hdlc_raw_eth",
+    "ioctl$KGPT_IF_GET_PROTO": "ioctl$KGPT_IF_GET_PROTO(fd fd_hdlc_raw_eth, cmd const[IF_GET_PROTO], arg ptr[out, raw_hdlc_proto])",
+    "ioctl$KGPT_IF_PROTO_HDLC_ETH": "ioctl$KGPT_IF_PROTO_HDLC_ETH(fd fd_hdlc_raw_eth, cmd const[IF_PROTO_HDLC_ETH], arg ptr[in, raw_hdlc_proto])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_tap"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/if.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "raw_hdlc_proto": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/proto#drivers_net_wan_hdlc_x25.c:268.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/proto#drivers_net_wan_hdlc_x25.c:268.json
@@ -1,0 +1,45 @@
+{
+  "open": {
+    "filename": "/dev/net/tun",
+    "fd_name": "fd_hdlc_x25",
+    "spec": "openat$KGPT_net_tun(fd const[AT_FDCWD], file ptr[in, string[\"/dev/net/tun\"]], flags flags[open_flags], mode const[0]) fd_hdlc_x25"
+  },
+  "resources": {
+    "fd_hdlc_x25": {
+      "type": "fd",
+      "spec": "resource fd_hdlc_x25[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/wan/hdlc_x25.c:268",
+  "ioctls": {
+    "IF_GET_PROTO": {
+      "arg": "ptr[out, x25_hdlc_proto]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "IF_PROTO_X25": {
+      "arg": "ptr[in, x25_hdlc_proto]",
+      "arg_name_in_usage": "x25_s",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "x25_hdlc_proto": "x25_hdlc_proto {\n\tdce\tint16\n\tmodulo\tint32\n\twindow\tint32\n\tt1\tint32\n\tt2\tint32\n\tn2\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_net_tun": "openat$KGPT_net_tun(fd const[AT_FDCWD], file ptr[in, string[\"/dev/net/tun\"]], flags flags[open_flags], mode const[0]) fd_hdlc_x25",
+    "ioctl$KGPT_IF_GET_PROTO": "ioctl$KGPT_IF_GET_PROTO(fd fd_hdlc_x25, cmd const[IF_GET_PROTO], arg ptr[out, x25_hdlc_proto])",
+    "ioctl$KGPT_IF_PROTO_X25": "ioctl$KGPT_IF_PROTO_X25(fd fd_hdlc_x25, cmd const[IF_PROTO_X25], arg ptr[in, x25_hdlc_proto])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_net_tun"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/if.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ptm_unix98_ops#drivers_tty_pty.c:745.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ptm_unix98_ops#drivers_tty_pty.c:745.json
@@ -1,0 +1,113 @@
+{
+  "open": {
+    "filename": "/dev/ptmx",
+    "fd_name": "fd_ptmx",
+    "spec": "openat$KGPT_ptmx(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ptmx\"]], flags flags[open_flags], mode const[0]) fd_ptmx"
+  },
+  "resources": {
+    "fd_ptmx": {
+      "type": "fd",
+      "spec": "resource fd_ptmx[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/tty/pty.c:745",
+  "ioctls": {
+    "TIOCGPTN": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "TIOCSPTLCK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "pty_set_lock"
+        ],
+        "type": [],
+        "usage": [
+          "return pty_set_lock(tty, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCGPTLCK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "pty_get_lock"
+        ],
+        "type": [],
+        "usage": [
+          "return pty_get_lock(tty, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCPKT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "pty_set_pktmode"
+        ],
+        "type": [],
+        "usage": [
+          "return pty_set_pktmode(tty, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCGPKT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "pty_get_pktmode"
+        ],
+        "type": [],
+        "usage": [
+          "return pty_get_pktmode(tty, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCSIG": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "pty_signal"
+        ],
+        "type": [],
+        "usage": [
+          "return pty_signal(tty, (int) arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_ptmx": "openat$KGPT_ptmx(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ptmx\"]], flags flags[open_flags], mode const[0]) fd_ptmx",
+    "ioctl$KGPT_TIOCGPTN": "ioctl$KGPT_TIOCGPTN(fd fd_ptmx, cmd const[TIOCGPTN], arg ptr[out, int32])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_ptmx"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ptp_clock_ops#drivers_ptp_ptp_clock.c:158.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ptp_clock_ops#drivers_ptp_ptp_clock.c:158.json
@@ -1,0 +1,306 @@
+{
+  "open": {
+    "filename": "/dev/ptp#",
+    "fd_name": "fd_ptp",
+    "spec": "syz_open_dev$KGPT_ptp(dev ptr[in, string[\"/dev/ptp#\"]], id proc[0, 1], flags flags[open_flags]) fd_ptp"
+  },
+  "resources": {
+    "fd_ptp": {
+      "type": "fd",
+      "spec": "resource fd_ptp[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/ptp/ptp_clock.c:158",
+  "ioctls": {
+    "PTP_MASK_CLEAR_ALL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "PTP_CLOCK_GETCAPS2": {
+      "arg": "ptr[out, ptp_clock_caps]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "PTP_ENABLE_PPS2": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "PTP_SYS_OFFSET_PRECISE2": {
+      "arg": "ptr[out, ptp_sys_offset_precise]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "PTP_SYS_OFFSET_EXTENDED2": {
+      "arg": "ptr[in, ptp_sys_offset_extended]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "PTP_SYS_OFFSET2": {
+      "arg": "ptr[in, ptp_sys_offset]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "PTP_MASK_EN_SINGLE": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "copy_from_user"
+        ],
+        "type": [
+          "int32"
+        ],
+        "usage": [
+          "if (copy_from_user(&i, (void __user *)arg, sizeof(i)))"
+        ]
+      }
+    }
+  },
+  "types": {
+    "ptp_clock_caps": "ptp_clock_caps {\n\tmax_adj\tint32\n\tn_alarm\tint32\n\tn_ext_ts\tint32\n\tn_per_out\tint32\n\tpps\tint32\n\tn_pins\tint32\n\tcross_timestamping\tint32\n\tadjust_phase\tint32\n\tmax_phase_adj\tint32\n\trsv\tarray[int32, 11]\n}",
+    "ptp_sys_offset_precise": "ptp_sys_offset_precise {\n\tdevice\tptp_clock_time\n\tsys_realtime\tptp_clock_time\n\tsys_monoraw\tptp_clock_time\n\trsv\tarray[int32, 4]\n}"
+  },
+  "existing_ioctls": {
+    "PTP_CLOCK_GETCAPS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "ptp_clock_caps"
+        ],
+        "usage": [
+          "if (copy_to_user((void __user *)arg, &caps, sizeof(caps)))"
+        ]
+      }
+    },
+    "PTP_EXTTS_REQUEST": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user"
+        ],
+        "type": [
+          "ptp_clock_request"
+        ],
+        "usage": [
+          "if (copy_from_user(&req.extts, (void __user *)arg, sizeof(req.extts)))"
+        ]
+      }
+    },
+    "PTP_EXTTS_REQUEST2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user"
+        ],
+        "type": [
+          "ptp_clock_request"
+        ],
+        "usage": [
+          "if (copy_from_user(&req.extts, (void __user *)arg, sizeof(req.extts)))"
+        ]
+      }
+    },
+    "PTP_PEROUT_REQUEST": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user"
+        ],
+        "type": [
+          "ptp_clock_request"
+        ],
+        "usage": [
+          "if (copy_from_user(&req.perout, (void __user *)arg, sizeof(req.perout)))"
+        ]
+      }
+    },
+    "PTP_PEROUT_REQUEST2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user"
+        ],
+        "type": [
+          "ptp_clock_request"
+        ],
+        "usage": [
+          "if (copy_from_user(&req.perout, (void __user *)arg, sizeof(req.perout)))"
+        ]
+      }
+    },
+    "PTP_ENABLE_PPS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "enable = arg ? 1 : 0;"
+        ]
+      }
+    },
+    "PTP_SYS_OFFSET_PRECISE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_to_user"
+        ],
+        "type": [
+          "ptp_sys_offset_precise"
+        ],
+        "usage": [
+          "if (copy_to_user((void __user *)arg, &precise_offset, sizeof(precise_offset)))"
+        ]
+      }
+    },
+    "PTP_SYS_OFFSET_EXTENDED": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "memdup_user"
+        ],
+        "type": [
+          "ptp_sys_offset_extended"
+        ],
+        "usage": [
+          "extoff = memdup_user((void __user *)arg, sizeof(*extoff));"
+        ]
+      }
+    },
+    "PTP_SYS_OFFSET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "memdup_user"
+        ],
+        "type": [
+          "ptp_sys_offset"
+        ],
+        "usage": [
+          "sysoff = memdup_user((void __user *)arg, sizeof(*sysoff));"
+        ]
+      }
+    },
+    "PTP_PIN_GETFUNC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user"
+        ],
+        "type": [
+          "ptp_pin_desc"
+        ],
+        "usage": [
+          "if (copy_from_user(&pd, (void __user *)arg, sizeof(pd)))"
+        ]
+      }
+    },
+    "PTP_PIN_GETFUNC2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user"
+        ],
+        "type": [
+          "ptp_pin_desc"
+        ],
+        "usage": [
+          "if (copy_from_user(&pd, (void __user *)arg, sizeof(pd)))"
+        ]
+      }
+    },
+    "PTP_PIN_SETFUNC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user"
+        ],
+        "type": [
+          "ptp_pin_desc"
+        ],
+        "usage": [
+          "if (copy_from_user(&pd, (void __user *)arg, sizeof(pd)))"
+        ]
+      }
+    },
+    "PTP_PIN_SETFUNC2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user"
+        ],
+        "type": [
+          "ptp_pin_desc"
+        ],
+        "usage": [
+          "if (copy_from_user(&pd, (void __user *)arg, sizeof(pd)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_ptp": "syz_open_dev$KGPT_ptp(dev ptr[in, string[\"/dev/ptp#\"]], id proc[0, 1], flags flags[open_flags]) fd_ptp",
+    "ioctl$KGPT_PTP_MASK_CLEAR_ALL": "ioctl$KGPT_PTP_MASK_CLEAR_ALL(fd fd_ptp, cmd const[PTP_MASK_CLEAR_ALL], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_PTP_CLOCK_GETCAPS2": "ioctl$KGPT_PTP_CLOCK_GETCAPS2(fd fd_ptp, cmd const[PTP_CLOCK_GETCAPS2], arg ptr[out, ptp_clock_caps])",
+    "ioctl$KGPT_PTP_ENABLE_PPS2": "ioctl$KGPT_PTP_ENABLE_PPS2(fd fd_ptp, cmd const[PTP_ENABLE_PPS2], arg intptr)",
+    "ioctl$KGPT_PTP_SYS_OFFSET_PRECISE2": "ioctl$KGPT_PTP_SYS_OFFSET_PRECISE2(fd fd_ptp, cmd const[PTP_SYS_OFFSET_PRECISE2], arg ptr[out, ptp_sys_offset_precise])",
+    "ioctl$KGPT_PTP_SYS_OFFSET_EXTENDED2": "ioctl$KGPT_PTP_SYS_OFFSET_EXTENDED2(fd fd_ptp, cmd const[PTP_SYS_OFFSET_EXTENDED2], arg ptr[in, ptp_sys_offset_extended])",
+    "ioctl$KGPT_PTP_SYS_OFFSET2": "ioctl$KGPT_PTP_SYS_OFFSET2(fd fd_ptp, cmd const[PTP_SYS_OFFSET2], arg ptr[in, ptp_sys_offset])",
+    "ioctl$KGPT_PTP_MASK_EN_SINGLE": "ioctl$KGPT_PTP_MASK_EN_SINGLE(fd fd_ptp, cmd const[PTP_MASK_EN_SINGLE], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_ptp"
+  ],
+  "includes": [
+    "uapi/linux/ptp_clock.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "ptp_sys_offset_extended": "EXISTING",
+    "ptp_sys_offset": "EXISTING",
+    "int32": "PRIMITIVE",
+    "ptp_clock_time": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/random_fops#drivers_char_random.c:1541.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/random_fops#drivers_char_random.c:1541.json
@@ -1,0 +1,88 @@
+{
+  "open": {
+    "filename": "/dev/random",
+    "fd_name": "fd_random",
+    "spec": "openat$KGPT_random(fd const[AT_FDCWD], file ptr[in, string[\"/dev/random\"]], flags flags[open_flags], mode const[0]) fd_random"
+  },
+  "resources": {
+    "fd_random": {
+      "type": "fd",
+      "spec": "resource fd_random[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/char/random.c:1541",
+  "ioctls": {
+    "RNDRESEEDCRNG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "RNDGETENTCNT": {
+      "arg": "ptr[inout, int]",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": null
+    },
+    "RNDADDTOENTCNT": {
+      "arg": "ptr[in, int]",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": null
+    },
+    "RNDADDENTROPY": {
+      "arg": "ptr[in, rnd_add_entropy]",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "write_pool_user",
+          "credit_init_bits"
+        ],
+        "type": [
+          "rnd_add_entropy"
+        ],
+        "usage": [
+          "struct iov_iter iter;",
+          "struct iovec iov;",
+          "ssize_t ret;",
+          "int len;",
+          "if (get_user(ent_count, p++))",
+          "if (get_user(len, p++))",
+          "ret = import_single_range(ITER_SOURCE, p, len, &iov, &iter);",
+          "ret = write_pool_user(&iter);",
+          "credit_init_bits(ent_count);"
+        ]
+      }
+    },
+    "RNDZAPENTCNT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "RNDCLEARPOOL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_random": "openat$KGPT_random(fd const[AT_FDCWD], file ptr[in, string[\"/dev/random\"]], flags flags[open_flags], mode const[0]) fd_random",
+    "ioctl$KGPT_RNDRESEEDCRNG": "ioctl$KGPT_RNDRESEEDCRNG(fd fd_random, cmd const[RNDRESEEDCRNG], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_random"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/random.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/raw_fops#drivers_usb_gadget_legacy_raw_gadget.c:1362.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/raw_fops#drivers_usb_gadget_legacy_raw_gadget.c:1362.json
@@ -1,0 +1,139 @@
+{
+  "open": {
+    "filename": "/dev/raw-gadget",
+    "fd_name": "fd_raw_gadget",
+    "spec": "openat$KGPT_raw_gadget(fd const[AT_FDCWD], file ptr[in, string[\"/dev/raw-gadget\"]], flags const[O_RDWR], mode const[0]) fd_raw_gadget"
+  },
+  "resources": {
+    "fd_raw_gadget": {
+      "type": "fd",
+      "spec": "resource fd_raw_gadget[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/usb/gadget/legacy/raw_gadget.c:1362",
+  "ioctls": {
+    "USB_RAW_IOCTL_INIT": {
+      "arg": "ptr[in, usb_raw_init]",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_RUN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EVENT_FETCH": {
+      "arg": "ptr[inout, usb_raw_event]",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EP0_WRITE": {
+      "arg": "ptr[in, usb_raw_ep_io]",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EP0_READ": {
+      "arg": "ptr[inout, usb_raw_ep_io]",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EP_ENABLE": {
+      "arg": "ptr[in, usb_endpoint_descriptor]",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EP_DISABLE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EP_WRITE": {
+      "arg": "ptr[in, usb_raw_ep_io]",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EP_READ": {
+      "arg": "ptr[inout, usb_raw_ep_io]",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_CONFIGURE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_VBUS_DRAW": {
+      "arg": "intptr",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EPS_INFO": {
+      "arg": "ptr[out, usb_raw_eps_info]",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EP0_STALL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EP_SET_HALT": {
+      "arg": "intptr",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EP_CLEAR_HALT": {
+      "arg": "intptr",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    },
+    "USB_RAW_IOCTL_EP_SET_WEDGE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "value",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "usb_raw_init": "usb_raw_init {\n\tdriver_name\tarray[int8, UDC_NAME_LENGTH_MAX]\n\tdevice_name\tarray[int8, UDC_NAME_LENGTH_MAX]\n\tspeed\tint8\n}",
+    "usb_raw_event": "usb_raw_event {\n\ttype\tint32\n\tlength\tint32\n\tdata\tarray[int8]\n}",
+    "usb_raw_ep_io": "usb_raw_ep_io {\n\tep\tint16\n\tflags\tint16\n\tlength\tint32\n\tdata\tarray[int8]\n}",
+    "usb_raw_eps_info": "usb_raw_eps_info {\n\teps\tarray[usb_raw_ep_info, USB_RAW_EPS_NUM_MAX]\n}",
+    "usb_raw_ep_info": "usb_raw_ep_info {\n\tname\tarray[int8, USB_RAW_EP_NAME_MAX]\n\taddr\tint32\n\tcaps\tusb_raw_ep_caps\n\tlimits\tusb_raw_ep_limits\n}",
+    "usb_raw_ep_caps": "usb_raw_ep_caps {\n\ttype_control\tint32:1\n\ttype_iso\tint32:1\n\ttype_bulk\tint32:1\n\ttype_int\tint32:1\n\tdir_in\tint32:1\n\tdir_out\tint32:1\n}",
+    "usb_raw_ep_limits": "usb_raw_ep_limits {\n\tmaxpacket_limit\tint16\n\tmax_streams\tint16\n\treserved\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_raw_gadget": "openat$KGPT_raw_gadget(fd const[AT_FDCWD], file ptr[in, string[\"/dev/raw-gadget\"]], flags const[O_RDWR], mode const[0]) fd_raw_gadget",
+    "ioctl$KGPT_USB_RAW_IOCTL_INIT": "ioctl$KGPT_USB_RAW_IOCTL_INIT(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_INIT], arg ptr[in, usb_raw_init])",
+    "ioctl$KGPT_USB_RAW_IOCTL_RUN": "ioctl$KGPT_USB_RAW_IOCTL_RUN(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_RUN], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_USB_RAW_IOCTL_EVENT_FETCH": "ioctl$KGPT_USB_RAW_IOCTL_EVENT_FETCH(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EVENT_FETCH], arg ptr[inout, usb_raw_event])",
+    "ioctl$KGPT_USB_RAW_IOCTL_EP0_WRITE": "ioctl$KGPT_USB_RAW_IOCTL_EP0_WRITE(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EP0_WRITE], arg ptr[in, usb_raw_ep_io])",
+    "ioctl$KGPT_USB_RAW_IOCTL_EP0_READ": "ioctl$KGPT_USB_RAW_IOCTL_EP0_READ(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EP0_READ], arg ptr[inout, usb_raw_ep_io])",
+    "ioctl$KGPT_USB_RAW_IOCTL_EP_ENABLE": "ioctl$KGPT_USB_RAW_IOCTL_EP_ENABLE(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EP_ENABLE], arg ptr[in, usb_endpoint_descriptor])",
+    "ioctl$KGPT_USB_RAW_IOCTL_EP_DISABLE": "ioctl$KGPT_USB_RAW_IOCTL_EP_DISABLE(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EP_DISABLE], arg intptr)",
+    "ioctl$KGPT_USB_RAW_IOCTL_EP_WRITE": "ioctl$KGPT_USB_RAW_IOCTL_EP_WRITE(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EP_WRITE], arg ptr[in, usb_raw_ep_io])",
+    "ioctl$KGPT_USB_RAW_IOCTL_EP_READ": "ioctl$KGPT_USB_RAW_IOCTL_EP_READ(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EP_READ], arg ptr[inout, usb_raw_ep_io])",
+    "ioctl$KGPT_USB_RAW_IOCTL_CONFIGURE": "ioctl$KGPT_USB_RAW_IOCTL_CONFIGURE(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_CONFIGURE], arg intptr)",
+    "ioctl$KGPT_USB_RAW_IOCTL_VBUS_DRAW": "ioctl$KGPT_USB_RAW_IOCTL_VBUS_DRAW(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_VBUS_DRAW], arg intptr)",
+    "ioctl$KGPT_USB_RAW_IOCTL_EPS_INFO": "ioctl$KGPT_USB_RAW_IOCTL_EPS_INFO(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EPS_INFO], arg ptr[out, usb_raw_eps_info])",
+    "ioctl$KGPT_USB_RAW_IOCTL_EP0_STALL": "ioctl$KGPT_USB_RAW_IOCTL_EP0_STALL(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EP0_STALL], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_USB_RAW_IOCTL_EP_SET_HALT": "ioctl$KGPT_USB_RAW_IOCTL_EP_SET_HALT(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EP_SET_HALT], arg intptr)",
+    "ioctl$KGPT_USB_RAW_IOCTL_EP_CLEAR_HALT": "ioctl$KGPT_USB_RAW_IOCTL_EP_CLEAR_HALT(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EP_CLEAR_HALT], arg intptr)",
+    "ioctl$KGPT_USB_RAW_IOCTL_EP_SET_WEDGE": "ioctl$KGPT_USB_RAW_IOCTL_EP_SET_WEDGE(fd fd_raw_gadget, cmd const[USB_RAW_IOCTL_EP_SET_WEDGE], arg intptr)"
+  },
+  "init_syscalls": [
+    "openat$KGPT_raw_gadget"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/usb/raw_gadget.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "usb_endpoint_descriptor": "EXISTING",
+    "UDC_NAME_LENGTH_MAX": "UNFOUND_MACRO"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/rfkill_fops#net_rfkill_core.c:1392.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/rfkill_fops#net_rfkill_core.c:1392.json
@@ -1,0 +1,56 @@
+{
+  "open": {
+    "filename": "/dev/rfkill",
+    "fd_name": "fd_rfkill",
+    "spec": "openat$KGPT_rfkill(fd const[AT_FDCWD], file ptr[in, string[\"/dev/rfkill\"]], flags flags[open_flags], mode const[0]) fd_rfkill"
+  },
+  "resources": {
+    "fd_rfkill": {
+      "type": "fd",
+      "spec": "resource fd_rfkill[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/rfkill/core.c:1392",
+  "ioctls": {
+    "RFKILL_IOC_NOINPUT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "RFKILL_IOC_MAX_SIZE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user"
+        ],
+        "type": [
+          "__u32"
+        ],
+        "usage": [
+          "if (get_user(size, (__u32 __user *)arg))",
+          "data->max_size = size;"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_rfkill": "openat$KGPT_rfkill(fd const[AT_FDCWD], file ptr[in, string[\"/dev/rfkill\"]], flags flags[open_flags], mode const[0]) fd_rfkill",
+    "ioctl$KGPT_RFKILL_IOC_NOINPUT": "ioctl$KGPT_RFKILL_IOC_NOINPUT(fd fd_rfkill, cmd const[RFKILL_IOC_NOINPUT], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_rfkill"
+  ],
+  "includes": [
+    "uapi/linux/rfkill.h",
+    "uapi/linux/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/riocm_cdev_fops#drivers_rapidio_rio_cm.c:1931.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/riocm_cdev_fops#drivers_rapidio_rio_cm.c:1931.json
@@ -1,0 +1,121 @@
+{
+  "open": {
+    "filename": "/dev/rio_cm",
+    "fd_name": "fd_rio_cm",
+    "spec": "openat$KGPT_rio_cm(fd const[AT_FDCWD], file ptr[in, string[\"/dev/rio_cm\"]], flags flags[open_flags], mode const[0]) fd_rio_cm"
+  },
+  "resources": {
+    "fd_rio_cm": {
+      "type": "fd",
+      "spec": "resource fd_rio_cm[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/rapidio/rio_cm.c:1931",
+  "ioctls": {
+    "RIO_CM_EP_GET_LIST_SIZE": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "RIO_CM_EP_GET_LIST": {
+      "arg": "ptr[inout, rio_cm_ep_list]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "RIO_CM_CHAN_CREATE": {
+      "arg": "ptr[inout, rio_cm_channel]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "cm_chan_create"
+        ],
+        "type": [
+          "u16 __user *"
+        ],
+        "usage": [
+          "u16 __user *p = arg;\n\tif (get_user(ch_num, p))\n\t\treturn -EFAULT;\n\t...\n\treturn put_user(ch_num, p);"
+        ]
+      }
+    },
+    "RIO_CM_CHAN_CLOSE": {
+      "arg": "ptr[in, int16]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "RIO_CM_CHAN_BIND": {
+      "arg": "ptr[in, rio_cm_channel]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "RIO_CM_CHAN_LISTEN": {
+      "arg": "ptr[in, int16]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "RIO_CM_CHAN_ACCEPT": {
+      "arg": "ptr[inout, rio_cm_accept]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "RIO_CM_CHAN_CONNECT": {
+      "arg": "ptr[in, rio_cm_channel]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "RIO_CM_CHAN_SEND": {
+      "arg": "ptr[in, rio_cm_msg]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "RIO_CM_CHAN_RECEIVE": {
+      "arg": "ptr[inout, rio_cm_msg]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "cm_chan_msg_rcv"
+        ],
+        "type": [],
+        "usage": [
+          "struct rio_cm_msg msg;\n\tif (copy_from_user(&msg, arg, sizeof(msg)))\n\t\treturn -EFAULT;\n\t/* ... */\n\tif (copy_to_user((void __user *)(uintptr_t)msg.msg, buf, msg_size))\n\t\tret = -EFAULT;"
+        ]
+      }
+    },
+    "RIO_CM_MPORT_GET_LIST": {
+      "arg": "ptr[inout, rio_cm_mport_get_list]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "rio_cm_ep_list": "type rio_cm_ep_list ptr[in, array[int8]]",
+    "rio_cm_channel": "rio_cm_channel {\n\tid\tint16\n\tremote_channel\tint16\n\tremote_destid\tint16\n\tmport_id\tint8\n}",
+    "rio_cm_accept": "rio_cm_accept {\n\tch_num\tint16\n\tpad0\tconst[0, int16]\n\twait_to\tint32\n}",
+    "rio_cm_msg": "rio_cm_msg {\n\tch_num\tint16\n\tsize\tint16\n\trxto\tint32\n\tmsg\tint64\n}",
+    "rio_cm_mport_get_list": "type rio_cm_mport_get_list ptr[in, array[int8]]"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_rio_cm": "openat$KGPT_rio_cm(fd const[AT_FDCWD], file ptr[in, string[\"/dev/rio_cm\"]], flags flags[open_flags], mode const[0]) fd_rio_cm",
+    "ioctl$KGPT_RIO_CM_EP_GET_LIST_SIZE": "ioctl$KGPT_RIO_CM_EP_GET_LIST_SIZE(fd fd_rio_cm, cmd const[RIO_CM_EP_GET_LIST_SIZE], arg ptr[out, int32])",
+    "ioctl$KGPT_RIO_CM_EP_GET_LIST": "ioctl$KGPT_RIO_CM_EP_GET_LIST(fd fd_rio_cm, cmd const[RIO_CM_EP_GET_LIST], arg ptr[inout, rio_cm_ep_list])",
+    "ioctl$KGPT_RIO_CM_CHAN_CREATE": "ioctl$KGPT_RIO_CM_CHAN_CREATE(fd fd_rio_cm, cmd const[RIO_CM_CHAN_CREATE], arg ptr[inout, rio_cm_channel])",
+    "ioctl$KGPT_RIO_CM_CHAN_CLOSE": "ioctl$KGPT_RIO_CM_CHAN_CLOSE(fd fd_rio_cm, cmd const[RIO_CM_CHAN_CLOSE], arg ptr[in, int16])",
+    "ioctl$KGPT_RIO_CM_CHAN_BIND": "ioctl$KGPT_RIO_CM_CHAN_BIND(fd fd_rio_cm, cmd const[RIO_CM_CHAN_BIND], arg ptr[in, rio_cm_channel])",
+    "ioctl$KGPT_RIO_CM_CHAN_LISTEN": "ioctl$KGPT_RIO_CM_CHAN_LISTEN(fd fd_rio_cm, cmd const[RIO_CM_CHAN_LISTEN], arg ptr[in, int16])",
+    "ioctl$KGPT_RIO_CM_CHAN_ACCEPT": "ioctl$KGPT_RIO_CM_CHAN_ACCEPT(fd fd_rio_cm, cmd const[RIO_CM_CHAN_ACCEPT], arg ptr[inout, rio_cm_accept])",
+    "ioctl$KGPT_RIO_CM_CHAN_CONNECT": "ioctl$KGPT_RIO_CM_CHAN_CONNECT(fd fd_rio_cm, cmd const[RIO_CM_CHAN_CONNECT], arg ptr[in, rio_cm_channel])",
+    "ioctl$KGPT_RIO_CM_CHAN_SEND": "ioctl$KGPT_RIO_CM_CHAN_SEND(fd fd_rio_cm, cmd const[RIO_CM_CHAN_SEND], arg ptr[in, rio_cm_msg])",
+    "ioctl$KGPT_RIO_CM_CHAN_RECEIVE": "ioctl$KGPT_RIO_CM_CHAN_RECEIVE(fd fd_rio_cm, cmd const[RIO_CM_CHAN_RECEIVE], arg ptr[inout, rio_cm_msg])",
+    "ioctl$KGPT_RIO_CM_MPORT_GET_LIST": "ioctl$KGPT_RIO_CM_MPORT_GET_LIST(fd fd_rio_cm, cmd const[RIO_CM_MPORT_GET_LIST], arg ptr[inout, rio_cm_mport_get_list])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_rio_cm"
+  ],
+  "includes": [
+    "uapi/linux/rio_cm_cdev.h",
+    "uapi/linux/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/rtc_dev_fops#drivers_rtc_dev.c:524.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/rtc_dev_fops#drivers_rtc_dev.c:524.json
@@ -1,0 +1,219 @@
+{
+  "open": {
+    "filename": "/dev/rtc#",
+    "fd_name": "fd_rtc",
+    "spec": "syz_open_dev$KGPT_rtc(dev ptr[in, string[\"/dev/rtc#\"]], id proc[0, 1], flags flags[open_flags]) fd_rtc"
+  },
+  "resources": {
+    "fd_rtc": {
+      "type": "fd",
+      "spec": "resource fd_rtc[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/rtc/dev.c:524",
+  "ioctls": {
+    "RTC_PARAM_GET": {
+      "arg": "ptr[inout, rtc_param]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "RTC_PARAM_SET": {
+      "arg": "ptr[in, rtc_param]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "rtc_param": "rtc_param {\n\tparam\tint64\n\tuvalue\tint64\n\tsvalue\tint64\n\tptr\tint64\n\tindex\tint32\n\t__pad\tint32\n}"
+  },
+  "existing_ioctls": {
+    "RTC_ALM_READ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "rtc_read_alarm",
+          "copy_to_user"
+        ],
+        "type": [
+          "rtc_time"
+        ],
+        "usage": [
+          "err = rtc_read_alarm(rtc, &alarm);",
+          "if (copy_to_user(uarg, &alarm.time, sizeof(tm)))"
+        ]
+      }
+    },
+    "RTC_ALM_SET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "rtc_set_alarm"
+        ],
+        "type": [
+          "rtc_time"
+        ],
+        "usage": [
+          "if (copy_from_user(&alarm.time, uarg, sizeof(tm)))",
+          "return rtc_set_alarm(rtc, &alarm);"
+        ]
+      }
+    },
+    "RTC_RD_TIME": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "rtc_read_time",
+          "copy_to_user"
+        ],
+        "type": [
+          "rtc_time"
+        ],
+        "usage": [
+          "err = rtc_read_time(rtc, &tm);",
+          "if (copy_to_user(uarg, &tm, sizeof(tm)))"
+        ]
+      }
+    },
+    "RTC_SET_TIME": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "rtc_set_time"
+        ],
+        "type": [
+          "rtc_time"
+        ],
+        "usage": [
+          "if (copy_from_user(&tm, uarg, sizeof(tm)))",
+          "return rtc_set_time(rtc, &tm);"
+        ]
+      }
+    },
+    "RTC_PIE_ON": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "RTC_PIE_OFF": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "RTC_AIE_ON": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "RTC_AIE_OFF": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "RTC_UIE_ON": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "RTC_UIE_OFF": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "RTC_IRQP_SET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "rtc_irq_set_freq"
+        ],
+        "type": [],
+        "usage": [
+          "err = rtc_irq_set_freq(rtc, arg);"
+        ]
+      }
+    },
+    "RTC_IRQP_READ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "err = put_user(rtc->irq_freq, (unsigned long __user *)uarg);"
+        ]
+      }
+    },
+    "RTC_WKALM_SET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "rtc_set_alarm"
+        ],
+        "type": [
+          "rtc_wkalrm"
+        ],
+        "usage": [
+          "if (copy_from_user(&alarm, uarg, sizeof(alarm)))",
+          "return rtc_set_alarm(rtc, &alarm);"
+        ]
+      }
+    },
+    "RTC_WKALM_RD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "rtc_read_alarm",
+          "copy_to_user"
+        ],
+        "type": [
+          "rtc_wkalrm"
+        ],
+        "usage": [
+          "err = rtc_read_alarm(rtc, &alarm);",
+          "if (copy_to_user(uarg, &alarm, sizeof(alarm)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_rtc": "syz_open_dev$KGPT_rtc(dev ptr[in, string[\"/dev/rtc#\"]], id proc[0, 1], flags flags[open_flags]) fd_rtc",
+    "ioctl$KGPT_RTC_PARAM_GET": "ioctl$KGPT_RTC_PARAM_GET(fd fd_rtc, cmd const[RTC_PARAM_GET], arg ptr[inout, rtc_param])",
+    "ioctl$KGPT_RTC_PARAM_SET": "ioctl$KGPT_RTC_PARAM_SET(fd fd_rtc, cmd const[RTC_PARAM_SET], arg ptr[in, rtc_param])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_rtc"
+  ],
+  "includes": [
+    "uapi/linux/rtc.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/serport_ldisc#drivers_input_serio_serport.c:273.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/serport_ldisc#drivers_input_serio_serport.c:273.json
@@ -1,0 +1,36 @@
+{
+  "open": {
+    "filename": "/dev/ttyS#",
+    "fd_name": "fd_serport",
+    "spec": "syz_open_dev$KGPT_serport(dev ptr[in, string[\"/dev/ttyS#\"]], id proc[0, 1], flags flags[open_flags]) fd_serport"
+  },
+  "resources": {
+    "fd_serport": {
+      "type": "fd",
+      "spec": "resource fd_serport[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/input/serio/serport.c:273",
+  "ioctls": {
+    "SPIOCSTYPE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "type",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_serport": "syz_open_dev$KGPT_serport(dev ptr[in, string[\"/dev/ttyS#\"]], id proc[0, 1], flags flags[open_flags]) fd_serport",
+    "ioctl$KGPT_SPIOCSTYPE": "ioctl$KGPT_SPIOCSTYPE(fd fd_serport, cmd const[SPIOCSTYPE], arg intptr)"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_serport"
+  ],
+  "includes": [
+    "uapi/linux/serio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/sg_fops#drivers_scsi_sg.c:1413.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/sg_fops#drivers_scsi_sg.c:1413.json
@@ -1,0 +1,251 @@
+{
+  "open": {
+    "filename": "/dev/sg#",
+    "fd_name": "fd_sg",
+    "spec": "syz_open_dev$KGPT_sg(dev ptr[in, string[\"/dev/sg#\"]], id proc[0, 1], flags flags[open_flags]) fd_sg"
+  },
+  "resources": {
+    "fd_sg": {
+      "type": "fd",
+      "spec": "resource fd_sg[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/scsi/sg.c:1413",
+  "ioctls": {
+    "SG_SET_FORCE_LOW_DMA": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_TRANSFORM": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "SG_IO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_new_write",
+          "wait_event_interruptible",
+          "srp_done",
+          "sg_new_read"
+        ],
+        "type": [],
+        "usage": [
+          "result = sg_new_write(sfp, filp, p, SZ_SG_IO_HDR, 1, read_only, 1, &srp);",
+          "result = wait_event_interruptible(sfp->read_wait, srp_done(sfp, srp));",
+          "result = sg_new_read(sfp, p, SZ_SG_IO_HDR, srp);"
+        ]
+      }
+    },
+    "SG_SET_TIMEOUT": {
+      "arg": "int",
+      "arg_name_in_usage": [
+        "val"
+      ],
+      "arg_inference": null
+    },
+    "SG_GET_TIMEOUT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_LOW_DMA": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_SCSI_ID": {
+      "arg": "sg_scsi_id_t",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": null
+    },
+    "SG_SET_FORCE_PACK_ID": {
+      "arg": "int",
+      "arg_name_in_usage": [
+        "val"
+      ],
+      "arg_inference": null
+    },
+    "SG_GET_PACK_ID": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_NUM_WAITING": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_SG_TABLESIZE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_SET_RESERVED_SIZE": {
+      "arg": "int",
+      "arg_name_in_usage": [
+        "val"
+      ],
+      "arg_inference": null
+    },
+    "SG_GET_RESERVED_SIZE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_SET_COMMAND_Q": {
+      "arg": "int",
+      "arg_name_in_usage": [
+        "val"
+      ],
+      "arg_inference": null
+    },
+    "SG_GET_COMMAND_Q": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_SET_KEEP_ORPHAN": {
+      "arg": "int",
+      "arg_name_in_usage": [
+        "val"
+      ],
+      "arg_inference": null
+    },
+    "SG_GET_KEEP_ORPHAN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_NEXT_CMD_LEN": {
+      "arg": "int",
+      "arg_name_in_usage": [
+        "val"
+      ],
+      "arg_inference": null
+    },
+    "SG_GET_VERSION_NUM": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_ACCESS_COUNT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_REQUEST_TABLE": {
+      "arg": "sg_req_info_t",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": null
+    },
+    "SG_EMULATED_HOST": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_SEND_COMMAND": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_ioctl(sdp->device, filp->f_mode & FMODE_WRITE, cmd_in, p);"
+        ]
+      }
+    },
+    "SG_SET_DEBUG": {
+      "arg": "int",
+      "arg_name_in_usage": [
+        "val"
+      ],
+      "arg_inference": null
+    },
+    "BLKSECTGET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "BLKTRACESETUP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "blk_trace_setup"
+        ],
+        "type": [],
+        "usage": [
+          "return blk_trace_setup(sdp->device->request_queue, sdp->name, MKDEV(SCSI_GENERIC_MAJOR, sdp->index), NULL, p);"
+        ]
+      }
+    },
+    "BLKTRACESTART": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "BLKTRACESTOP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "BLKTRACETEARDOWN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_GET_IDLUN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_GET_BUS_NUMBER": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_PROBE_HOST": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_SCSI_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sg": "syz_open_dev$KGPT_sg(dev ptr[in, string[\"/dev/sg#\"]], id proc[0, 1], flags flags[open_flags]) fd_sg",
+    "ioctl$KGPT_SG_SET_FORCE_LOW_DMA": "ioctl$KGPT_SG_SET_FORCE_LOW_DMA(fd fd_sg, cmd const[SG_SET_FORCE_LOW_DMA], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SG_GET_TRANSFORM": "ioctl$KGPT_SG_GET_TRANSFORM(fd fd_sg, cmd const[SG_GET_TRANSFORM], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sg"
+  ],
+  "includes": [
+    "scsi/sg.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/si4713_subdev_core_ops#drivers_media_radio_si4713_si4713.c:1399.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/si4713_subdev_core_ops#drivers_media_radio_si4713_si4713.c:1399.json
@@ -1,0 +1,38 @@
+{
+  "open": {
+    "filename": "/dev/radio#",
+    "fd_name": "fd_si4713",
+    "spec": "syz_open_dev$KGPT_si4713(dev ptr[in, string[\"/dev/radio#\"]], id proc[0, 1], flags flags[open_flags]) fd_si4713"
+  },
+  "resources": {
+    "fd_si4713": {
+      "type": "fd",
+      "spec": "resource fd_si4713[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/radio/si4713/si4713.c:1399",
+  "ioctls": {
+    "SI4713_IOC_MEASURE_RNL": {
+      "arg": "ptr[in,out, si4713_rnl]",
+      "arg_name_in_usage": "rnl",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "si4713_rnl": "si4713_rnl {\n\tindex\tint32\n\tfrequency\tint32\n\trnl\tint32\n\treserved\tarray[int32, 4]\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_si4713": "syz_open_dev$KGPT_si4713(dev ptr[in, string[\"/dev/radio#\"]], id proc[0, 1], flags flags[open_flags]) fd_si4713",
+    "ioctl$KGPT_SI4713_IOC_MEASURE_RNL": "ioctl$KGPT_SI4713_IOC_MEASURE_RNL(fd fd_si4713, cmd const[SI4713_IOC_MEASURE_RNL], arg ptr[inout, si4713_rnl])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_si4713"
+  ],
+  "includes": [
+    "linux/platform_data/media/si4713.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/slcan_ldisc#drivers_net_can_slcan_slcan-core.c:906.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/slcan_ldisc#drivers_net_can_slcan_slcan-core.c:906.json
@@ -1,0 +1,300 @@
+{
+  "open": {
+    "filename": "/dev/ttyS#",
+    "fd_name": "fd_slcan",
+    "spec": "syz_open_dev$KGPT_ttyS(dev ptr[in, string[\"/dev/ttyS#\"]], id proc[0, 1], flags flags[open_flags]) fd_slcan"
+  },
+  "resources": {
+    "fd_slcan": {
+      "type": "fd",
+      "spec": "resource fd_slcan[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/can/slcan/slcan-core.c:906",
+  "ioctls": {
+    "SIOCGIFNAME": {
+      "arg": "ptr[out, string]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "TIOCSETN": {
+      "arg": "ptr[in, sgttyb]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "SIOCSIFHWADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCGETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return get_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCSETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return set_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCGETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCGLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETSF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETSW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCGETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))\n\t\tret = -EFAULT;"
+        ]
+      }
+    },
+    "TCGETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_termio"
+        ],
+        "type": [],
+        "usage": [
+          "return get_termio(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETAF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETAW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TIOCGSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_termios",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "ret = put_user((kterm.c_cflag & CLOCAL) ? 1 : 0, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCSSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user",
+          "tty_change_softcar"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(arg, (unsigned int __user *) arg))\n\t\treturn -EFAULT;",
+          "return tty_change_softcar(real_tty, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_ttyS": "syz_open_dev$KGPT_ttyS(dev ptr[in, string[\"/dev/ttyS#\"]], id proc[0, 1], flags flags[open_flags]) fd_slcan",
+    "ioctl$KGPT_SIOCGIFNAME": "ioctl$KGPT_SIOCGIFNAME(fd fd_slcan, cmd const[SIOCGIFNAME], arg ptr[out, string])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_ttyS"
+  ],
+  "includes": [
+    "uapi/linux/sockios.h",
+    "arch/powerpc/include/uapi/asm/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_compr_file_ops#sound_core_compress_offload.c:1045.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_compr_file_ops#sound_core_compress_offload.c:1045.json
@@ -1,0 +1,151 @@
+{
+  "open": {
+    "filename": "/dev/snd/comprC#D#",
+    "fd_name": "fd_snd_compr",
+    "spec": "syz_open_dev$KGPT_snd_compr(dev ptr[in, string[\"/dev/snd/comprC#D#\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_compr"
+  },
+  "resources": {
+    "fd_snd_compr": {
+      "type": "fd",
+      "spec": "resource fd_snd_compr[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/core/compress_offload.c:1045",
+  "ioctls": {
+    "SNDRV_COMPRESS_IOCTL_VERSION": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_PAUSE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_RESUME": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_START": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_STOP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_DRAIN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_PARTIAL_DRAIN": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_NEXT_TRACK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_GET_CAPS": {
+      "arg": "ptr[out, snd_compr_caps]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_GET_CODEC_CAPS": {
+      "arg": "ptr[out, snd_compr_codec_caps]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_SET_PARAMS": {
+      "arg": "ptr[in, snd_compr_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_GET_PARAMS": {
+      "arg": "ptr[out, snd_codec]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_SET_METADATA": {
+      "arg": "ptr[in, snd_compr_metadata]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_GET_METADATA": {
+      "arg": "ptr[inout, snd_compr_metadata]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_TSTAMP": {
+      "arg": "ptr[out, snd_compr_tstamp]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_COMPRESS_AVAIL": {
+      "arg": "ptr[out, snd_compr_avail]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "snd_compr_caps": "snd_compr_caps {\n\tnum_codecs\tint32\n\tdirection\tint32\n\tmin_fragment_size\tint32\n\tmax_fragment_size\tint32\n\tmin_fragments\tint32\n\tmax_fragments\tint32\n\tcodecs\tarray[int32, MAX_NUM_CODECS]\n\treserved\tarray[int32, 11]\n}",
+    "snd_compr_codec_caps": "snd_compr_codec_caps {\n\tcodec\tint32\n\tnum_descriptors\tint32\n\tdescriptor\tarray[snd_codec_desc, MAX_NUM_CODEC_DESCRIPTORS]\n}",
+    "snd_compr_params": "snd_compr_params {\n\tbuffer\tsnd_compressed_buffer\n\tcodec\tsnd_codec\n\tno_wake_mode\tint8\n}",
+    "snd_codec": "snd_codec {\n\tid\tint32\n\tch_in\tint32\n\tch_out\tint32\n\tsample_rate\tint32\n\tbit_rate\tint32\n\trate_control\tint32\n\tprofile\tint32\n\tlevel\tint32\n\tch_mode\tint32\n\tformat\tint32\n\talign\tint32\n\toptions\tsnd_codec_options\n\treserved\tarray[int32, 3]\n}",
+    "snd_compr_metadata": "snd_compr_metadata {\n\tkey\tint32\n\tvalue\tarray[int32, 8]\n}",
+    "snd_compr_tstamp": "snd_compr_tstamp {\n\tbyte_offset\tint32\n\tcopied_total\tint32\n\tpcm_frames\tint32\n\tpcm_io_frames\tint32\n\tsampling_rate\tint32\n}",
+    "snd_compr_avail": "snd_compr_avail {\n\tavail\tint64\n\ttstamp\tsnd_compr_tstamp\n}",
+    "snd_codec_desc": "snd_codec_desc {\n\tmax_ch\tint32\n\tsample_rates\tarray[int32, MAX_NUM_SAMPLE_RATES]\n\tnum_sample_rates\tint32\n\tbit_rate\tarray[int32, MAX_NUM_BITRATES]\n\tnum_bitrates\tint32\n\trate_control\tint32\n\tprofiles\tint32\n\tmodes\tint32\n\tformats\tint32\n\tmin_buffer\tint32\n\treserved\tarray[int32, 15]\n}",
+    "snd_compressed_buffer": "snd_compressed_buffer {\n\tfragment_size\tint32\n\tfragments\tint32\n}",
+    "snd_codec_options": "snd_codec_options [\n\twma\tsnd_enc_wma\n\tvorbis\tsnd_enc_vorbis\n\treal\tsnd_enc_real\n\tflac\tsnd_enc_flac\n\tgeneric\tsnd_enc_generic\n\tflac_d\tsnd_dec_flac\n\twma_d\tsnd_dec_wma\n\talac_d\tsnd_dec_alac\n\tape_d\tsnd_dec_ape\n]",
+    "snd_enc_wma": "snd_enc_wma {\n\tsuper_block_align\tint32\n}",
+    "snd_enc_vorbis": "snd_enc_vorbis {\n\tquality\tint32\n\tmanaged\tint32\n\tmax_bit_rate\tint32\n\tmin_bit_rate\tint32\n\tdownmix\tint32\n}",
+    "snd_enc_real": "snd_enc_real {\n\tquant_bits\tint32\n\tstart_region\tint32\n\tnum_regions\tint32\n}",
+    "snd_enc_flac": "snd_enc_flac {\n\tnum\tint32\n\tgain\tint32\n}",
+    "snd_enc_generic": "snd_enc_generic {\n\tbw\tint32\n\treserved\tarray[int32, 15]\n}",
+    "snd_dec_flac": "snd_dec_flac {\n\tsample_size\tint16\n\tmin_blk_size\tint16\n\tmax_blk_size\tint16\n\tmin_frame_size\tint16\n\tmax_frame_size\tint16\n\treserved\tint16\n}",
+    "snd_dec_wma": "snd_dec_wma {\n\tencoder_option\tint32\n\tadv_encoder_option\tint32\n\tadv_encoder_option2\tint32\n\treserved\tint32\n}",
+    "snd_dec_alac": "snd_dec_alac {\n\tframe_length\tint32\n\tcompatible_version\tint8\n\tpb\tint8\n\tmb\tint8\n\tkb\tint8\n\tmax_run\tint32\n\tmax_frame_bytes\tint32\n}",
+    "snd_dec_ape": "snd_dec_ape {\n\tcompatible_version\tint16\n\tcompression_level\tint16\n\tformat_flags\tint32\n\tblocks_per_frame\tint32\n\tfinal_frame_blocks\tint32\n\ttotal_frames\tint32\n\tseek_table_present\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_snd_compr": "syz_open_dev$KGPT_snd_compr(dev ptr[in, string[\"/dev/snd/comprC#D#\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_compr",
+    "ioctl$KGPT_SNDRV_COMPRESS_IOCTL_VERSION": "ioctl$KGPT_SNDRV_COMPRESS_IOCTL_VERSION(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_IOCTL_VERSION], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_COMPRESS_PAUSE": "ioctl$KGPT_SNDRV_COMPRESS_PAUSE(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_PAUSE], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_COMPRESS_RESUME": "ioctl$KGPT_SNDRV_COMPRESS_RESUME(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_RESUME], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_COMPRESS_START": "ioctl$KGPT_SNDRV_COMPRESS_START(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_START], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_COMPRESS_STOP": "ioctl$KGPT_SNDRV_COMPRESS_STOP(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_STOP], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_COMPRESS_DRAIN": "ioctl$KGPT_SNDRV_COMPRESS_DRAIN(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_DRAIN], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_COMPRESS_PARTIAL_DRAIN": "ioctl$KGPT_SNDRV_COMPRESS_PARTIAL_DRAIN(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_PARTIAL_DRAIN], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_COMPRESS_NEXT_TRACK": "ioctl$KGPT_SNDRV_COMPRESS_NEXT_TRACK(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_NEXT_TRACK], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_COMPRESS_GET_CAPS": "ioctl$KGPT_SNDRV_COMPRESS_GET_CAPS(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_GET_CAPS], arg ptr[out, snd_compr_caps])",
+    "ioctl$KGPT_SNDRV_COMPRESS_GET_CODEC_CAPS": "ioctl$KGPT_SNDRV_COMPRESS_GET_CODEC_CAPS(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_GET_CODEC_CAPS], arg ptr[out, snd_compr_codec_caps])",
+    "ioctl$KGPT_SNDRV_COMPRESS_SET_PARAMS": "ioctl$KGPT_SNDRV_COMPRESS_SET_PARAMS(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_SET_PARAMS], arg ptr[in, snd_compr_params])",
+    "ioctl$KGPT_SNDRV_COMPRESS_GET_PARAMS": "ioctl$KGPT_SNDRV_COMPRESS_GET_PARAMS(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_GET_PARAMS], arg ptr[out, snd_codec])",
+    "ioctl$KGPT_SNDRV_COMPRESS_SET_METADATA": "ioctl$KGPT_SNDRV_COMPRESS_SET_METADATA(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_SET_METADATA], arg ptr[in, snd_compr_metadata])",
+    "ioctl$KGPT_SNDRV_COMPRESS_GET_METADATA": "ioctl$KGPT_SNDRV_COMPRESS_GET_METADATA(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_GET_METADATA], arg ptr[inout, snd_compr_metadata])",
+    "ioctl$KGPT_SNDRV_COMPRESS_TSTAMP": "ioctl$KGPT_SNDRV_COMPRESS_TSTAMP(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_TSTAMP], arg ptr[out, snd_compr_tstamp])",
+    "ioctl$KGPT_SNDRV_COMPRESS_AVAIL": "ioctl$KGPT_SNDRV_COMPRESS_AVAIL(fd fd_snd_compr, cmd const[SNDRV_COMPRESS_AVAIL], arg ptr[out, snd_compr_avail])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_snd_compr"
+  ],
+  "includes": [
+    "uapi/sound/compress_params.h",
+    "uapi/sound/compress_offload.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "MAX_NUM_CODECS": "UNFOUND_MACRO",
+    "MAX_NUM_SAMPLE_RATES": "UNFOUND_MACRO",
+    "MAX_NUM_BITRATES": "UNFOUND_MACRO"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_ctl_f_ops#sound_core_control.c:2369.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_ctl_f_ops#sound_core_control.c:2369.json
@@ -1,0 +1,267 @@
+{
+  "open": {
+    "filename": "/dev/snd/controlC#",
+    "fd_name": "fd_snd_ctl",
+    "spec": "syz_open_dev$KGPT_snd_control(dev ptr[in, string[\"/dev/snd/controlC#\"]], id proc[0, 31], flags flags[open_flags]) fd_snd_ctl"
+  },
+  "resources": {
+    "fd_snd_ctl": {
+      "type": "fd",
+      "spec": "resource fd_snd_ctl[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/core/control.c:2369",
+  "ioctls": {
+    "SNDRV_CTL_IOCTL_POWER": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "SNDRV_CTL_IOCTL_PVERSION": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [
+        "ip"
+      ],
+      "arg_inference": null
+    },
+    "SNDRV_CTL_IOCTL_CARD_INFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_card_info"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_card_info(card, ctl, cmd, argp);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_ELEM_LIST": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_elem_list_user"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_elem_list_user(card, argp);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_ELEM_INFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_elem_info_user"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_elem_info_user(ctl, argp);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_ELEM_READ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_elem_read_user"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_elem_read_user(card, argp);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_ELEM_WRITE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_elem_write_user"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_elem_write_user(ctl, argp);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_ELEM_LOCK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_elem_lock"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_elem_lock(ctl, argp);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_ELEM_UNLOCK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_elem_unlock"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_elem_unlock(ctl, argp);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_ELEM_ADD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_elem_add_user"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_elem_add_user(ctl, argp, 0);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_ELEM_REPLACE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_elem_add_user"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_elem_add_user(ctl, argp, 1);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_ELEM_REMOVE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_elem_remove"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_elem_remove(ctl, argp);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_SUBSCRIBE_EVENTS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "ip"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_subscribe_events"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_ctl_subscribe_events(ctl, ip);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_TLV_READ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_tlv_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "down_read(&ctl->card->controls_rwsem);",
+          "err = snd_ctl_tlv_ioctl(ctl, argp, SNDRV_CTL_TLV_OP_READ);",
+          "up_read(&ctl->card->controls_rwsem);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_TLV_WRITE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_tlv_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "down_write(&ctl->card->controls_rwsem);",
+          "err = snd_ctl_tlv_ioctl(ctl, argp, SNDRV_CTL_TLV_OP_WRITE);",
+          "up_write(&ctl->card->controls_rwsem);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_TLV_COMMAND": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_ctl_tlv_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "down_write(&ctl->card->controls_rwsem);",
+          "err = snd_ctl_tlv_ioctl(ctl, argp, SNDRV_CTL_TLV_OP_CMD);",
+          "up_write(&ctl->card->controls_rwsem);"
+        ]
+      }
+    },
+    "SNDRV_CTL_IOCTL_POWER_STATE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [
+        "ip"
+      ],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_snd_control": "syz_open_dev$KGPT_snd_control(dev ptr[in, string[\"/dev/snd/controlC#\"]], id proc[0, 31], flags flags[open_flags]) fd_snd_ctl",
+    "ioctl$KGPT_SNDRV_CTL_IOCTL_POWER": "ioctl$KGPT_SNDRV_CTL_IOCTL_POWER(fd fd_snd_ctl, cmd const[SNDRV_CTL_IOCTL_POWER], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_snd_control"
+  ],
+  "includes": [
+    "uapi/sound/asound.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_dw_hdmi_ops#drivers_gpu_drm_bridge_synopsys_dw-hdmi-ahb-audio.c:509.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_dw_hdmi_ops#drivers_gpu_drm_bridge_synopsys_dw-hdmi-ahb-audio.c:509.json
@@ -1,0 +1,50 @@
+{
+  "open": {
+    "filename": "/dev/snd/pcmC#D#p",
+    "fd_name": "fd_snd_pcm",
+    "spec": "syz_open_dev$KGPT_snd_pcm(dev ptr[in, string[\"/dev/snd/pcmC#D#p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm"
+  },
+  "resources": {
+    "fd_snd_pcm": {
+      "type": "fd",
+      "spec": "resource fd_snd_pcm[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/gpu/drm/bridge/synopsys/dw-hdmi-ahb-audio.c:509",
+  "ioctls": {
+    "SNDRV_PCM_IOCTL1_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_CHANNEL_INFO": {
+      "arg": "ptr[in,out, snd_pcm_channel_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_FIFO_SIZE": {
+      "arg": "ptr[inout, snd_pcm_hw_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "snd_pcm_channel_info": "snd_pcm_channel_info {\n\tchannel\tint32\n\toffset\tint64\n\tfirst\tint32\n\tstep\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_snd_pcm": "syz_open_dev$KGPT_snd_pcm(dev ptr[in, string[\"/dev/snd/pcmC#D#p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET": "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO": "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_CHANNEL_INFO], arg ptr[inout, snd_pcm_channel_info])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE": "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_FIFO_SIZE], arg ptr[inout, snd_pcm_hw_params])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_snd_pcm"
+  ],
+  "includes": [
+    "sound/pcm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_hdsp_capture_ops#sound_pci_rme9652_hdsp.c:4929.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_hdsp_capture_ops#sound_pci_rme9652_hdsp.c:4929.json
@@ -1,0 +1,50 @@
+{
+  "open": {
+    "filename": "/dev/snd/pcmC#D0c",
+    "fd_name": "fd_hdsp_pcm_capture",
+    "spec": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0c\"]], id proc[0, 1], flags flags[open_flags]) fd_hdsp_pcm_capture"
+  },
+  "resources": {
+    "fd_hdsp_pcm_capture": {
+      "type": "fd",
+      "spec": "resource fd_hdsp_pcm_capture[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/pci/rme9652/hdsp.c:4929",
+  "ioctls": {
+    "SNDRV_PCM_IOCTL1_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_CHANNEL_INFO": {
+      "arg": "ptr[in,out, snd_pcm_channel_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_FIFO_SIZE": {
+      "arg": "ptr[inout, snd_pcm_hw_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "snd_pcm_channel_info": "snd_pcm_channel_info {\n\tchannel\tint32\n\toffset\tint64\n\tfirst\tint32\n\tstep\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sndpcm": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0c\"]], id proc[0, 1], flags flags[open_flags]) fd_hdsp_pcm_capture",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET": "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET(fd fd_hdsp_pcm_capture, cmd const[SNDRV_PCM_IOCTL1_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO": "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO(fd fd_hdsp_pcm_capture, cmd const[SNDRV_PCM_IOCTL1_CHANNEL_INFO], arg ptr[inout, snd_pcm_channel_info])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE": "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE(fd fd_hdsp_pcm_capture, cmd const[SNDRV_PCM_IOCTL1_FIFO_SIZE], arg ptr[inout, snd_pcm_hw_params])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sndpcm"
+  ],
+  "includes": [
+    "sound/pcm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_hdsp_playback_ops#sound_pci_rme9652_hdsp.c:4917.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_hdsp_playback_ops#sound_pci_rme9652_hdsp.c:4917.json
@@ -1,0 +1,50 @@
+{
+  "open": {
+    "filename": "/dev/snd/pcmC#D0p",
+    "fd_name": "fd_snd_pcm",
+    "spec": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm"
+  },
+  "resources": {
+    "fd_snd_pcm": {
+      "type": "fd",
+      "spec": "resource fd_snd_pcm[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/pci/rme9652/hdsp.c:4917",
+  "ioctls": {
+    "SNDRV_PCM_IOCTL1_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_CHANNEL_INFO": {
+      "arg": "ptr[in,out, snd_pcm_channel_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_FIFO_SIZE": {
+      "arg": "ptr[inout, snd_pcm_hw_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "snd_pcm_channel_info": "snd_pcm_channel_info {\n\tchannel\tint32\n\toffset\tint64\n\tfirst\tint32\n\tstep\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sndpcm": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET": "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO": "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_CHANNEL_INFO], arg ptr[inout, snd_pcm_channel_info])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE": "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_FIFO_SIZE], arg ptr[inout, snd_pcm_hw_params])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sndpcm"
+  ],
+  "includes": [
+    "sound/pcm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_hdspm_ops#sound_pci_rme9652_hdspm.c:6352.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_hdspm_ops#sound_pci_rme9652_hdspm.c:6352.json
@@ -1,0 +1,60 @@
+{
+  "open": {
+    "filename": "/dev/snd/pcmC#D0#",
+    "fd_name": "fd_hdspm_pcm",
+    "spec": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0#\"]], id proc[0, 1], flags flags[open_flags]) fd_hdspm_pcm"
+  },
+  "resources": {
+    "fd_hdspm_pcm": {
+      "type": "fd",
+      "spec": "resource fd_hdspm_pcm[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/pci/rme9652/hdspm.c:6352",
+  "ioctls": {
+    "SNDRV_PCM_IOCTL1_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_CHANNEL_INFO": {
+      "arg": "ptr[in,out, snd_pcm_channel_info]",
+      "arg_name_in_usage": "info",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_FIFO_SIZE": {
+      "arg": "ptr[inout, snd_pcm_hw_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "snd_pcm_lib_ioctl_fifo_size"
+        ],
+        "type": [
+          "snd_pcm_hw_params"
+        ],
+        "usage": [
+          "return snd_pcm_lib_ioctl_fifo_size(substream, arg);"
+        ]
+      }
+    }
+  },
+  "types": {
+    "snd_pcm_channel_info": "snd_pcm_channel_info {\n\tchannel\tint32\n\toffset\tint64\n\tfirst\tint32\n\tstep\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sndpcm": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0#\"]], id proc[0, 1], flags flags[open_flags]) fd_hdspm_pcm",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET": "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET(fd fd_hdspm_pcm, cmd const[SNDRV_PCM_IOCTL1_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO": "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO(fd fd_hdspm_pcm, cmd const[SNDRV_PCM_IOCTL1_CHANNEL_INFO], arg ptr[inout, snd_pcm_channel_info])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE": "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE(fd fd_hdspm_pcm, cmd const[SNDRV_PCM_IOCTL1_FIFO_SIZE], arg ptr[inout, snd_pcm_hw_params])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sndpcm"
+  ],
+  "includes": [
+    "sound/pcm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_korg1212_capture_ops#sound_pci_korg1212_korg1212.c:1674.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_korg1212_capture_ops#sound_pci_korg1212_korg1212.c:1674.json
@@ -1,0 +1,62 @@
+{
+  "open": {
+    "filename": "/dev/snd/pcmC#D0c",
+    "fd_name": "fd_snd_pcm",
+    "spec": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0c\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm"
+  },
+  "resources": {
+    "fd_snd_pcm": {
+      "type": "fd",
+      "spec": "resource fd_snd_pcm[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/pci/korg1212/korg1212.c:1674",
+  "ioctls": {
+    "SNDRV_PCM_IOCTL1_CHANNEL_INFO": {
+      "arg": "ptr[in, snd_pcm_channel_info]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_FIFO_SIZE": {
+      "arg": "ptr[inout, snd_pcm_hw_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "snd_pcm_lib_ioctl_fifo_size"
+        ],
+        "type": [
+          "snd_pcm_hw_params"
+        ],
+        "usage": [
+          "struct snd_pcm_hw_params *params = arg;\n\tparams->fifo_size = substream->runtime->hw.fifo_size;"
+        ]
+      }
+    }
+  },
+  "types": {
+    "snd_pcm_channel_info": "snd_pcm_channel_info {\n\tchannel\tint32\n\toffset\tint64\n\tfirst\tint32\n\tstep\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sndpcm": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0c\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO": "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_CHANNEL_INFO], arg ptr[in, snd_pcm_channel_info])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET": "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE": "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_FIFO_SIZE], arg ptr[inout, snd_pcm_hw_params])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sndpcm"
+  ],
+  "includes": [
+    "sound/pcm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "snd_pcm_hw_params": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_korg1212_playback_ops#sound_pci_korg1212_korg1212.c:1662.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_korg1212_playback_ops#sound_pci_korg1212_korg1212.c:1662.json
@@ -1,0 +1,62 @@
+{
+  "open": {
+    "filename": "/dev/snd/pcmC#D0p",
+    "fd_name": "fd_snd_pcm",
+    "spec": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm"
+  },
+  "resources": {
+    "fd_snd_pcm": {
+      "type": "fd",
+      "spec": "resource fd_snd_pcm[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/pci/korg1212/korg1212.c:1662",
+  "ioctls": {
+    "SNDRV_PCM_IOCTL1_CHANNEL_INFO": {
+      "arg": "ptr[in, snd_pcm_channel_info]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_FIFO_SIZE": {
+      "arg": "ptr[inout, snd_pcm_hw_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "snd_pcm_lib_ioctl_fifo_size"
+        ],
+        "type": [
+          "snd_pcm_hw_params"
+        ],
+        "usage": [
+          "struct snd_pcm_hw_params *params = arg;\n\tparams->fifo_size = substream->runtime->hw.fifo_size;"
+        ]
+      }
+    }
+  },
+  "types": {
+    "snd_pcm_channel_info": "snd_pcm_channel_info {\n\tchannel\tint32\n\toffset\tint64\n\tfirst\tint32\n\tstep\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sndpcm": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO": "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_CHANNEL_INFO], arg ptr[in, snd_pcm_channel_info])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET": "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE": "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_FIFO_SIZE], arg ptr[inout, snd_pcm_hw_params])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sndpcm"
+  ],
+  "includes": [
+    "sound/pcm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "snd_pcm_hw_params": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_mixer_oss_f_ops#sound_core_oss_mixer_oss.c:424.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_mixer_oss_f_ops#sound_core_oss_mixer_oss.c:424.json
@@ -1,0 +1,228 @@
+{
+  "open": {
+    "filename": "/dev/mixer#",
+    "fd_name": "fd_mixer_oss",
+    "spec": "syz_open_dev$KGPT_mixer_oss(dev ptr[in, string[\"/dev/mixer#\"]], id proc[0, 1], flags flags[open_flags]) fd_mixer_oss"
+  },
+  "resources": {
+    "fd_mixer_oss": {
+      "type": "fd",
+      "spec": "resource fd_mixer_oss[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/core/oss/mixer_oss.c:424",
+  "ioctls": {
+    "SIOC_IN": {
+      "arg": "ptr[inout, int32]",
+      "arg_name_in_usage": "p",
+      "arg_inference": {
+        "function": [
+          "snd_mixer_oss_set_volume",
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (get_user(tmp, p))\n\t\t\t\treturn -EFAULT;",
+          "tmp = snd_mixer_oss_set_volume(fmixer, cmd & 0xff, tmp);",
+          "if (tmp < 0)\n\t\t\t\treturn tmp;",
+          "return put_user(tmp, p);"
+        ]
+      }
+    },
+    "SIOC_OUT": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "SOUND_MIXER_INFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_mixer_oss_info"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_mixer_oss_info(fmixer, argp);"
+        ]
+      }
+    },
+    "SOUND_OLD_MIXER_INFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_mixer_oss_info_obsolete"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_mixer_oss_info_obsolete(fmixer, argp);"
+        ]
+      }
+    },
+    "SOUND_MIXER_WRITE_RECSRC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_mixer_oss_set_recsrc",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(tmp, p))\n\t\t\t\treturn -EFAULT;",
+          "tmp = snd_mixer_oss_set_recsrc(fmixer, tmp);",
+          "if (tmp < 0)\n\t\t\t\treturn tmp;",
+          "return put_user(tmp, p);"
+        ]
+      }
+    },
+    "OSS_GETVERSION": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "return put_user(SNDRV_OSS_VERSION, p);"
+        ]
+      }
+    },
+    "OSS_ALSAEMULVER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "return put_user(1, p);"
+        ]
+      }
+    },
+    "SOUND_MIXER_READ_DEVMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_mixer_oss_devmask",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "tmp = snd_mixer_oss_devmask(fmixer);",
+          "if (tmp < 0)\n\t\t\t\treturn tmp;",
+          "return put_user(tmp, p);"
+        ]
+      }
+    },
+    "SOUND_MIXER_READ_STEREODEVS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_mixer_oss_stereodevs",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "tmp = snd_mixer_oss_stereodevs(fmixer);",
+          "if (tmp < 0)\n\t\t\t\treturn tmp;",
+          "return put_user(tmp, p);"
+        ]
+      }
+    },
+    "SOUND_MIXER_READ_RECMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_mixer_oss_recmask",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "tmp = snd_mixer_oss_recmask(fmixer);",
+          "if (tmp < 0)\n\t\t\t\treturn tmp;",
+          "return put_user(tmp, p);"
+        ]
+      }
+    },
+    "SOUND_MIXER_READ_CAPS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_mixer_oss_caps",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "tmp = snd_mixer_oss_caps(fmixer);",
+          "if (tmp < 0)\n\t\t\t\treturn tmp;",
+          "return put_user(tmp, p);"
+        ]
+      }
+    },
+    "SOUND_MIXER_READ_RECSRC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_mixer_oss_get_recsrc",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "tmp = snd_mixer_oss_get_recsrc(fmixer);",
+          "if (tmp < 0)\n\t\t\t\treturn tmp;",
+          "return put_user(tmp, p);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_mixer_oss": "syz_open_dev$KGPT_mixer_oss(dev ptr[in, string[\"/dev/mixer#\"]], id proc[0, 1], flags flags[open_flags]) fd_mixer_oss",
+    "ioctl$KGPT_SIOC_IN": "ioctl$KGPT_SIOC_IN(fd fd_mixer_oss, cmd const[SIOC_IN], arg ptr[inout, int32])",
+    "ioctl$KGPT_SIOC_OUT": "ioctl$KGPT_SIOC_OUT(fd fd_mixer_oss, cmd const[SIOC_OUT], arg ptr[out, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_mixer_oss"
+  ],
+  "includes": [
+    "uapi/linux/soundcard.h"
+  ],
+  "unused_types": {
+    "int": "PRIMITIVE"
+  },
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_pcm_oss_f_reg#sound_core_oss_pcm_oss.c:3122.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_pcm_oss_f_reg#sound_core_oss_pcm_oss.c:3122.json
@@ -1,0 +1,457 @@
+{
+  "open": {
+    "filename": "/dev/dsp#",
+    "fd_name": "fd_snd_pcm_oss",
+    "spec": "syz_open_dev$KGPT_snd_pcm_oss(dev ptr[in, string[\"/dev/dsp#\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm_oss"
+  },
+  "resources": {
+    "fd_snd_pcm_oss": {
+      "type": "fd",
+      "spec": "resource fd_snd_pcm_oss[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/core/oss/pcm_oss.c:3122",
+  "ioctls": {
+    "SOUND_PCM_WRITE_FILTER": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SOUND_PCM_READ_FILTER": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDCTL_DSP_SETSYNCRO": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDCTL_DSP_PROFILE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDCTL_DSP_MAPINBUF": {
+      "arg": "ptr[in, buffmem_desc]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDCTL_DSP_MAPOUTBUF": {
+      "arg": "ptr[in, buffmem_desc]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "buffmem_desc": "buffmem_desc {\n\tbuffer\t ptr[in, array[int32]]\n\tsize\tint32\n}"
+  },
+  "existing_ioctls": {
+    "OSS_GETVERSION": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "return put_user(SNDRV_OSS_VERSION, p);"
+        ]
+      }
+    },
+    "OSS_ALSAEMULVER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "return put_user(1, p);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDCTL_DSP_SYNC": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDCTL_DSP_SPEED": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_set_rate",
+          "put_user",
+          "get_user"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(res, p)) return -EFAULT;",
+          "res = snd_pcm_oss_set_rate(pcm_oss_file, res);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SOUND_PCM_READ_RATE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_rate",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "res = snd_pcm_oss_get_rate(pcm_oss_file);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_STEREO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_set_channels",
+          "put_user",
+          "get_user"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(res, p)) return -EFAULT;",
+          "res = snd_pcm_oss_set_channels(pcm_oss_file, res);",
+          "return put_user(--res, p);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_GETBLKSIZE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_block_size",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "res = snd_pcm_oss_get_block_size(pcm_oss_file);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_SETFMT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_set_format",
+          "put_user",
+          "get_user"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(res, p)) return -EFAULT;",
+          "res = snd_pcm_oss_set_format(pcm_oss_file, res);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SOUND_PCM_READ_BITS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_format",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "res = snd_pcm_oss_get_format(pcm_oss_file);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_CHANNELS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_set_channels",
+          "put_user",
+          "get_user"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(res, p)) return -EFAULT;",
+          "res = snd_pcm_oss_set_channels(pcm_oss_file, res);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SOUND_PCM_READ_CHANNELS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_channels",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "res = snd_pcm_oss_get_channels(pcm_oss_file);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_POST": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDCTL_DSP_SUBDIVIDE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_set_subdivide",
+          "put_user",
+          "get_user"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(res, p)) return -EFAULT;",
+          "res = snd_pcm_oss_set_subdivide(pcm_oss_file, res);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_SETFRAGMENT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_set_fragment",
+          "get_user"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(res, p)) return -EFAULT;",
+          "return snd_pcm_oss_set_fragment(pcm_oss_file, res);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_GETFMTS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_formats",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "res = snd_pcm_oss_get_formats(pcm_oss_file);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_GETOSPACE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_space"
+        ],
+        "type": [
+          "audio_buf_info"
+        ],
+        "usage": [
+          "return snd_pcm_oss_get_space(pcm_oss_file, SNDRV_PCM_STREAM_PLAYBACK, (struct audio_buf_info __user *) arg);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_GETISPACE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_space"
+        ],
+        "type": [
+          "audio_buf_info"
+        ],
+        "usage": [
+          "return snd_pcm_oss_get_space(pcm_oss_file, SNDRV_PCM_STREAM_CAPTURE, (struct audio_buf_info __user *) arg);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_NONBLOCK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDCTL_DSP_GETCAPS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_caps",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "res = snd_pcm_oss_get_caps(pcm_oss_file);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_GETTRIGGER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_trigger",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "res = snd_pcm_oss_get_trigger(pcm_oss_file);",
+          "return put_user(res, p);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_SETTRIGGER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_set_trigger",
+          "get_user"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(res, p)) return -EFAULT;",
+          "return snd_pcm_oss_set_trigger(pcm_oss_file, res);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_GETIPTR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_ptr"
+        ],
+        "type": [
+          "count_info"
+        ],
+        "usage": [
+          "return snd_pcm_oss_get_ptr(pcm_oss_file, SNDRV_PCM_STREAM_CAPTURE, (struct count_info __user *) arg);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_GETOPTR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_ptr"
+        ],
+        "type": [
+          "count_info"
+        ],
+        "usage": [
+          "return snd_pcm_oss_get_ptr(pcm_oss_file, SNDRV_PCM_STREAM_PLAYBACK, (struct count_info __user *) arg);"
+        ]
+      }
+    },
+    "SNDCTL_DSP_SETDUPLEX": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDCTL_DSP_GETODELAY": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_pcm_oss_get_odelay",
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "res = snd_pcm_oss_get_odelay(pcm_oss_file);",
+          "return put_user(res, p);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_snd_pcm_oss": "syz_open_dev$KGPT_snd_pcm_oss(dev ptr[in, string[\"/dev/dsp#\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm_oss",
+    "ioctl$KGPT_SOUND_PCM_WRITE_FILTER": "ioctl$KGPT_SOUND_PCM_WRITE_FILTER(fd fd_snd_pcm_oss, cmd const[SOUND_PCM_WRITE_FILTER], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SOUND_PCM_READ_FILTER": "ioctl$KGPT_SOUND_PCM_READ_FILTER(fd fd_snd_pcm_oss, cmd const[SOUND_PCM_READ_FILTER], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDCTL_DSP_SETSYNCRO": "ioctl$KGPT_SNDCTL_DSP_SETSYNCRO(fd fd_snd_pcm_oss, cmd const[SNDCTL_DSP_SETSYNCRO], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDCTL_DSP_PROFILE": "ioctl$KGPT_SNDCTL_DSP_PROFILE(fd fd_snd_pcm_oss, cmd const[SNDCTL_DSP_PROFILE], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDCTL_DSP_MAPINBUF": "ioctl$KGPT_SNDCTL_DSP_MAPINBUF(fd fd_snd_pcm_oss, cmd const[SNDCTL_DSP_MAPINBUF], arg ptr[in, buffmem_desc])",
+    "ioctl$KGPT_SNDCTL_DSP_MAPOUTBUF": "ioctl$KGPT_SNDCTL_DSP_MAPOUTBUF(fd fd_snd_pcm_oss, cmd const[SNDCTL_DSP_MAPOUTBUF], arg ptr[in, buffmem_desc])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_snd_pcm_oss"
+  ],
+  "includes": [
+    "uapi/linux/soundcard.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_pcmtst_capture_ops#sound_drivers_pcmtest.c:526.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_pcmtst_capture_ops#sound_drivers_pcmtest.c:526.json
@@ -1,0 +1,60 @@
+{
+  "open": {
+    "filename": "/dev/snd/pcmC#D#p",
+    "fd_name": "fd_snd_pcm",
+    "spec": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D#p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm"
+  },
+  "resources": {
+    "fd_snd_pcm": {
+      "type": "fd",
+      "spec": "resource fd_snd_pcm[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/drivers/pcmtest.c:526",
+  "ioctls": {
+    "SNDRV_PCM_IOCTL1_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_CHANNEL_INFO": {
+      "arg": "ptr[in,out, snd_pcm_channel_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_FIFO_SIZE": {
+      "arg": "ptr[inout, snd_pcm_hw_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "snd_pcm_lib_ioctl_fifo_size"
+        ],
+        "type": [
+          "snd_pcm_hw_params"
+        ],
+        "usage": [
+          "struct snd_pcm_hw_params *params = arg;\n\tparams->fifo_size = substream->runtime->hw.fifo_size;"
+        ]
+      }
+    }
+  },
+  "types": {
+    "snd_pcm_channel_info": "snd_pcm_channel_info {\n\tchannel\tint32\n\toffset\tint64\n\tfirst\tint32\n\tstep\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sndpcm": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D#p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET": "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO": "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_CHANNEL_INFO], arg ptr[inout, snd_pcm_channel_info])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE": "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_FIFO_SIZE], arg ptr[inout, snd_pcm_hw_params])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sndpcm"
+  ],
+  "includes": [
+    "sound/pcm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_pcmtst_playback_ops#sound_drivers_pcmtest.c:515.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_pcmtst_playback_ops#sound_drivers_pcmtest.c:515.json
@@ -1,0 +1,60 @@
+{
+  "open": {
+    "filename": "/dev/snd/pcmC0D0p",
+    "fd_name": "fd_snd_pcm",
+    "spec": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC0D0p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm"
+  },
+  "resources": {
+    "fd_snd_pcm": {
+      "type": "fd",
+      "spec": "resource fd_snd_pcm[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/drivers/pcmtest.c:515",
+  "ioctls": {
+    "SNDRV_PCM_IOCTL1_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_CHANNEL_INFO": {
+      "arg": "ptr[in,out, snd_pcm_channel_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_FIFO_SIZE": {
+      "arg": "ptr[inout, snd_pcm_hw_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": {
+        "function": [
+          "snd_pcm_lib_ioctl_fifo_size"
+        ],
+        "type": [
+          "snd_pcm_hw_params"
+        ],
+        "usage": [
+          "struct snd_pcm_hw_params *params = arg;\n\tparams->fifo_size = substream->runtime->hw.fifo_size;"
+        ]
+      }
+    }
+  },
+  "types": {
+    "snd_pcm_channel_info": "snd_pcm_channel_info {\n\tchannel\tint32\n\toffset\tint64\n\tfirst\tint32\n\tstep\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sndpcm": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC0D0p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET": "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO": "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_CHANNEL_INFO], arg ptr[inout, snd_pcm_channel_info])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE": "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_FIFO_SIZE], arg ptr[inout, snd_pcm_hw_params])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sndpcm"
+  ],
+  "includes": [
+    "sound/pcm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_rawmidi_f_ops#sound_core_rawmidi.c:1845.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_rawmidi_f_ops#sound_core_rawmidi.c:1845.json
@@ -1,0 +1,166 @@
+{
+  "open": {
+    "filename": "/dev/snd/midiC#D#",
+    "fd_name": "fd_snd_rawmidi",
+    "spec": "syz_open_dev$KGPT_snd_rawmidi(dev ptr[in, string[\"/dev/snd/midiC#D#\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_rawmidi"
+  },
+  "resources": {
+    "fd_snd_rawmidi": {
+      "type": "fd",
+      "spec": "resource fd_snd_rawmidi[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/core/rawmidi.c:1845",
+  "ioctls": {
+    "SNDRV_RAWMIDI_IOCTL_USER_PVERSION": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "SNDRV_RAWMIDI_IOCTL_PVERSION": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "return put_user(SNDRV_RAWMIDI_VERSION, (int __user *)argp) ? -EFAULT : 0;"
+        ]
+      }
+    },
+    "SNDRV_RAWMIDI_IOCTL_INFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "info"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_rawmidi_info_user"
+        ],
+        "type": [
+          "snd_rawmidi_info"
+        ],
+        "usage": [
+          "int stream;",
+          "struct snd_rawmidi_info __user *info = argp;",
+          "if (get_user(stream, &info->stream))",
+          "return snd_rawmidi_info_user(rfile->input, info);",
+          "return snd_rawmidi_info_user(rfile->output, info);"
+        ]
+      }
+    },
+    "SNDRV_RAWMIDI_IOCTL_PARAMS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "params"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_rawmidi_output_params",
+          "snd_rawmidi_input_params"
+        ],
+        "type": [
+          "snd_rawmidi_params"
+        ],
+        "usage": [
+          "struct snd_rawmidi_params params;",
+          "if (copy_from_user(&params, argp, sizeof(struct snd_rawmidi_params)))",
+          "return snd_rawmidi_output_params(rfile->output, &params);",
+          "return snd_rawmidi_input_params(rfile->input, &params);"
+        ]
+      }
+    },
+    "SNDRV_RAWMIDI_IOCTL_STATUS32": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_rawmidi_ioctl_status32"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_rawmidi_ioctl_status32(rfile, argp);"
+        ]
+      }
+    },
+    "SNDRV_RAWMIDI_IOCTL_STATUS64": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_rawmidi_ioctl_status64"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_rawmidi_ioctl_status64(rfile, argp);"
+        ]
+      }
+    },
+    "SNDRV_RAWMIDI_IOCTL_DROP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "val"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_rawmidi_drop_output"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "int val;",
+          "if (get_user(val, (int __user *) argp))",
+          "return snd_rawmidi_drop_output(rfile->output);"
+        ]
+      }
+    },
+    "SNDRV_RAWMIDI_IOCTL_DRAIN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "val"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_rawmidi_drain_output",
+          "snd_rawmidi_drain_input"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "int val;",
+          "if (get_user(val, (int __user *) argp))",
+          "return snd_rawmidi_drain_output(rfile->output);",
+          "return snd_rawmidi_drain_input(rfile->input);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_snd_rawmidi": "syz_open_dev$KGPT_snd_rawmidi(dev ptr[in, string[\"/dev/snd/midiC#D#\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_rawmidi",
+    "ioctl$KGPT_SNDRV_RAWMIDI_IOCTL_USER_PVERSION": "ioctl$KGPT_SNDRV_RAWMIDI_IOCTL_USER_PVERSION(fd fd_snd_rawmidi, cmd const[SNDRV_RAWMIDI_IOCTL_USER_PVERSION], arg ptr[out, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_snd_rawmidi"
+  ],
+  "includes": [
+    "uapi/sound/asound.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_rme9652_capture_ops#sound_pci_rme9652_rme9652.c:2345.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_rme9652_capture_ops#sound_pci_rme9652_rme9652.c:2345.json
@@ -1,0 +1,50 @@
+{
+  "open": {
+    "filename": "/dev/snd/pcmC#D0c",
+    "fd_name": "fd_snd_pcm_capture",
+    "spec": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0c\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm_capture"
+  },
+  "resources": {
+    "fd_snd_pcm_capture": {
+      "type": "fd",
+      "spec": "resource fd_snd_pcm_capture[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/pci/rme9652/rme9652.c:2345",
+  "ioctls": {
+    "SNDRV_PCM_IOCTL1_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_CHANNEL_INFO": {
+      "arg": "ptr[in,out, snd_pcm_channel_info]",
+      "arg_name_in_usage": "info",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_FIFO_SIZE": {
+      "arg": "ptr[inout, snd_pcm_hw_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "snd_pcm_channel_info": "snd_pcm_channel_info {\n\tchannel\tint32\n\toffset\tint64\n\tfirst\tint32\n\tstep\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sndpcm": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0c\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm_capture",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET": "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET(fd fd_snd_pcm_capture, cmd const[SNDRV_PCM_IOCTL1_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO": "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO(fd fd_snd_pcm_capture, cmd const[SNDRV_PCM_IOCTL1_CHANNEL_INFO], arg ptr[inout, snd_pcm_channel_info])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE": "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE(fd fd_snd_pcm_capture, cmd const[SNDRV_PCM_IOCTL1_FIFO_SIZE], arg ptr[inout, snd_pcm_hw_params])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sndpcm"
+  ],
+  "includes": [
+    "sound/pcm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_rme9652_playback_ops#sound_pci_rme9652_rme9652.c:2333.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_rme9652_playback_ops#sound_pci_rme9652_rme9652.c:2333.json
@@ -1,0 +1,50 @@
+{
+  "open": {
+    "filename": "/dev/snd/pcmC#D0p",
+    "fd_name": "fd_snd_pcm",
+    "spec": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm"
+  },
+  "resources": {
+    "fd_snd_pcm": {
+      "type": "fd",
+      "spec": "resource fd_snd_pcm[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/pci/rme9652/rme9652.c:2333",
+  "ioctls": {
+    "SNDRV_PCM_IOCTL1_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_CHANNEL_INFO": {
+      "arg": "ptr[in,out, snd_pcm_channel_info]",
+      "arg_name_in_usage": "info",
+      "arg_inference": null
+    },
+    "SNDRV_PCM_IOCTL1_FIFO_SIZE": {
+      "arg": "ptr[inout, snd_pcm_hw_params]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "snd_pcm_channel_info": "snd_pcm_channel_info {\n\tchannel\tint32\n\toffset\tint64\n\tfirst\tint32\n\tstep\tint32\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sndpcm": "syz_open_dev$KGPT_sndpcm(dev ptr[in, string[\"/dev/snd/pcmC#D0p\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_pcm",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET": "ioctl$KGPT_SNDRV_PCM_IOCTL1_RESET(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO": "ioctl$KGPT_SNDRV_PCM_IOCTL1_CHANNEL_INFO(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_CHANNEL_INFO], arg ptr[inout, snd_pcm_channel_info])",
+    "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE": "ioctl$KGPT_SNDRV_PCM_IOCTL1_FIFO_SIZE(fd fd_snd_pcm, cmd const[SNDRV_PCM_IOCTL1_FIFO_SIZE], arg ptr[inout, snd_pcm_hw_params])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sndpcm"
+  ],
+  "includes": [
+    "sound/pcm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_seq_f_ops#sound_core_seq_seq_clientmgr.c:2711.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_seq_f_ops#sound_core_seq_seq_clientmgr.c:2711.json
@@ -1,0 +1,173 @@
+{
+  "open": {
+    "filename": "/dev/snd/seq",
+    "fd_name": "fd_snd_seq",
+    "spec": "openat$KGPT_seq(fd const[AT_FDCWD], file ptr[in, string[\"/dev/snd/seq\"]], flags flags[open_flags], mode const[0]) fd_snd_seq"
+  },
+  "resources": {
+    "fd_snd_seq": {
+      "type": "fd",
+      "spec": "resource fd_snd_seq[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/core/seq/seq_clientmgr.c:2711",
+  "ioctls": {
+    "SNDRV_SEQ_IOCTL_RUNNING_INFO": {
+      "arg": "ptr[in, snd_seq_running_info]",
+      "arg_name_in_usage": "running_info",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_CLIENT_INFO": {
+      "arg": "ptr[inout, snd_seq_client_info]",
+      "arg_name_in_usage": "client_info",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_PORT_INFO": {
+      "arg": "ptr[inout, snd_seq_port_info]",
+      "arg_name_in_usage": "port_info",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_PORT_SUBSCRIBE": {
+      "arg": "ptr[in, snd_seq_port_subscribe]",
+      "arg_name_in_usage": "port_subscribe",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_QUEUE_INFO": {
+      "arg": "ptr[inout, snd_seq_queue_info]",
+      "arg_name_in_usage": "queue_info",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_QUEUE_STATUS": {
+      "arg": "ptr[out, snd_seq_queue_status]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_QUEUE_TEMPO": {
+      "arg": "ptr[in, snd_seq_queue_tempo]",
+      "arg_name_in_usage": "tempo",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_QUEUE_TIMER": {
+      "arg": "ptr[in, snd_seq_queue_timer]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_QUEUE_CLIENT": {
+      "arg": "ptr[in, snd_seq_queue_client]",
+      "arg_name_in_usage": "queue_client",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_CLIENT_POOL": {
+      "arg": "ptr[inout, snd_seq_client_pool]",
+      "arg_name_in_usage": "client_pool",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_GET_CLIENT_UMP_INFO": {
+      "arg": "ptr[inout, snd_seq_client_ump_info]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "SNDRV_SEQ_IOCTL_SET_CLIENT_UMP_INFO": {
+      "arg": "ptr[in, snd_seq_client_ump_info]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "snd_seq_client_ump_info": "snd_seq_client_ump_info {\n\tclient\tint32\n\ttype\tint32\n\tinfo\tarray[int8, 512]\n}"
+  },
+  "existing_ioctls": {
+    "SNDRV_SEQ_IOCTL_PVERSION": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "pversion"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "int pversion;"
+        ]
+      }
+    },
+    "SNDRV_SEQ_IOCTL_CLIENT_ID": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "client_id"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "int client_id;"
+        ]
+      }
+    },
+    "SNDRV_SEQ_IOCTL_SYSTEM_INFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "system_info"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "snd_seq_system_info"
+        ],
+        "usage": [
+          "struct snd_seq_system_info system_info;"
+        ]
+      }
+    },
+    "SNDRV_SEQ_IOCTL_REMOVE_EVENTS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "remove_events"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "snd_seq_remove_events"
+        ],
+        "usage": [
+          "struct snd_seq_remove_events remove_events;"
+        ]
+      }
+    },
+    "SNDRV_SEQ_IOCTL_QUERY_SUBS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "query_subs"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "snd_seq_query_subs"
+        ],
+        "usage": [
+          "struct snd_seq_query_subs query_subs;"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_seq": "openat$KGPT_seq(fd const[AT_FDCWD], file ptr[in, string[\"/dev/snd/seq\"]], flags flags[open_flags], mode const[0]) fd_snd_seq",
+    "ioctl$KGPT_SNDRV_SEQ_IOCTL_GET_CLIENT_UMP_INFO": "ioctl$KGPT_SNDRV_SEQ_IOCTL_GET_CLIENT_UMP_INFO(fd fd_snd_seq, cmd const[SNDRV_SEQ_IOCTL_GET_CLIENT_UMP_INFO], arg ptr[inout, snd_seq_client_ump_info])",
+    "ioctl$KGPT_SNDRV_SEQ_IOCTL_SET_CLIENT_UMP_INFO": "ioctl$KGPT_SNDRV_SEQ_IOCTL_SET_CLIENT_UMP_INFO(fd fd_snd_seq, cmd const[SNDRV_SEQ_IOCTL_SET_CLIENT_UMP_INFO], arg ptr[in, snd_seq_client_ump_info])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_seq"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/sound/asequencer.h"
+  ],
+  "unused_types": {
+    "snd_seq_queue_tempo": "snd_seq_queue_tempo {\n\tqueue\tint32\n\ttempo\tint32\n\tppq\tint32\n\tskew_value\tint32\n\tskew_base\tint32\n\treserved\tarray[int8, 24]\n}"
+  },
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_timer_f_ops#sound_core_timer.c:2282.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_timer_f_ops#sound_core_timer.c:2282.json
@@ -1,0 +1,229 @@
+{
+  "open": {
+    "filename": "/dev/snd/timer",
+    "fd_name": "fd_snd_timer",
+    "spec": "openat$KGPT_snd_timer(fd const[AT_FDCWD], file ptr[in, string[\"/dev/snd/timer\"]], flags flags[open_flags], mode const[0]) fd_snd_timer"
+  },
+  "resources": {
+    "fd_snd_timer": {
+      "type": "fd",
+      "spec": "resource fd_snd_timer[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/core/timer.c:2282",
+  "ioctls": {
+    "SNDRV_TIMER_IOCTL_START_OLD": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_TIMER_IOCTL_STOP_OLD": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_TIMER_IOCTL_CONTINUE_OLD": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_TIMER_IOCTL_PAUSE_OLD": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_TIMER_IOCTL_TREAD_OLD": {
+      "arg": "intptr",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "SNDRV_TIMER_IOCTL_TREAD64": {
+      "arg": "ptr[in, int]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "snd_timer_tread64": "snd_timer_tread64 {\n\tresolution\tint32\n\tticks\tint64\n\tccallback\tint32\n\tccount\tint32\n\tccount_frac\tint32\n\tlast_tstamp\ttimespec64\n\tevents\tarray[snd_timer_event, SND_TIMER_MAX_EVENTS]\n}",
+    "snd_timer_event": "snd_timer_event {\n\ttstamp\ttimespec64\n\tval\tint32\n}",
+    "timespec64": "timespec64 {\n\ttv_sec\tint64\n\ttv_nsec\tint64\n}",
+    "SND_TIMER_MAX_EVENTS": "define SND_TIMER_MAX_EVENTS 32"
+  },
+  "existing_ioctls": {
+    "SNDRV_TIMER_IOCTL_PVERSION": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_TIMER_IOCTL_NEXT_DEVICE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_timer_user_next_device"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_timer_user_next_device(argp);"
+        ]
+      }
+    },
+    "SNDRV_TIMER_IOCTL_GINFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_timer_user_ginfo"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_timer_user_ginfo(file, argp);"
+        ]
+      }
+    },
+    "SNDRV_TIMER_IOCTL_GPARAMS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_timer_user_gparams"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_timer_user_gparams(file, argp);"
+        ]
+      }
+    },
+    "SNDRV_TIMER_IOCTL_GSTATUS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_timer_user_gstatus"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_timer_user_gstatus(file, argp);"
+        ]
+      }
+    },
+    "SNDRV_TIMER_IOCTL_SELECT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_timer_user_tselect"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_timer_user_tselect(file, argp);"
+        ]
+      }
+    },
+    "SNDRV_TIMER_IOCTL_INFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_timer_user_info"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_timer_user_info(file, argp);"
+        ]
+      }
+    },
+    "SNDRV_TIMER_IOCTL_PARAMS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_timer_user_params"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_timer_user_params(file, argp);"
+        ]
+      }
+    },
+    "SNDRV_TIMER_IOCTL_STATUS32": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_timer_user_status32"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_timer_user_status32(file, argp);"
+        ]
+      }
+    },
+    "SNDRV_TIMER_IOCTL_STATUS64": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "snd_timer_user_status64"
+        ],
+        "type": [],
+        "usage": [
+          "return snd_timer_user_status64(file, argp);"
+        ]
+      }
+    },
+    "SNDRV_TIMER_IOCTL_START": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_TIMER_IOCTL_STOP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_TIMER_IOCTL_CONTINUE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SNDRV_TIMER_IOCTL_PAUSE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_snd_timer": "openat$KGPT_snd_timer(fd const[AT_FDCWD], file ptr[in, string[\"/dev/snd/timer\"]], flags flags[open_flags], mode const[0]) fd_snd_timer",
+    "ioctl$KGPT_SNDRV_TIMER_IOCTL_TREAD_OLD": "ioctl$KGPT_SNDRV_TIMER_IOCTL_TREAD_OLD(fd fd_snd_timer, cmd const[SNDRV_TIMER_IOCTL_TREAD_OLD], arg intptr)",
+    "ioctl$KGPT_SNDRV_TIMER_IOCTL_TREAD64": "ioctl$KGPT_SNDRV_TIMER_IOCTL_TREAD64(fd fd_snd_timer, cmd const[SNDRV_TIMER_IOCTL_TREAD64], arg ptr[in, snd_timer_tread64])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_snd_timer"
+  ],
+  "includes": [
+    "uapi/sound/asound.h",
+    "uapi/linux/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/snd_ump_rawmidi_ops#sound_core_ump.c:52.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/snd_ump_rawmidi_ops#sound_core_ump.c:52.json
@@ -1,0 +1,45 @@
+{
+  "open": {
+    "filename": "/dev/snd/midiC#D#",
+    "fd_name": "fd_snd_midi",
+    "spec": "syz_open_dev$KGPT_snd_midi(dev ptr[in, string[\"/dev/snd/midiC#D#\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_midi"
+  },
+  "resources": {
+    "fd_snd_midi": {
+      "type": "fd",
+      "spec": "resource fd_snd_midi[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/sound/core/ump.c:52",
+  "ioctls": {
+    "SNDRV_UMP_IOCTL_ENDPOINT_INFO": {
+      "arg": "ptr[out, snd_ump_endpoint_info]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "SNDRV_UMP_IOCTL_BLOCK_INFO": {
+      "arg": "ptr[inout, snd_ump_block_info]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "snd_ump_endpoint_info": "snd_ump_endpoint_info {\n\tcard\tint32\n\tdevice\tint32\n\tflags\tint32\n\tprotocol_caps\tint32\n\tprotocol\tint32\n\tnum_blocks\tint32\n\tversion\tint16\n\tfamily_id\tint16\n\tmodel_id\tint16\n\tmanufacturer_id\tint32\n\tsw_revision\tarray[int8, 4]\n\tpadding\tint16\n\tname\tarray[int8, 128]\n\tproduct_id\tarray[int8, 128]\n\treserved\tarray[int8, 32]\n}",
+    "snd_ump_block_info": "snd_ump_block_info {\n\tcard\tint32\n\tdevice\tint32\n\tblock_id\tint8\n\tdirection\tint8\n\tactive\tint8\n\tfirst_group\tint8\n\tnum_groups\tint8\n\tmidi_ci_version\tint8\n\tsysex8_streams\tint8\n\tui_hint\tint8\n\tflags\tint32\n\tname\tarray[int8, 128]\n\treserved\tarray[int8, 32]\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_snd_midi": "syz_open_dev$KGPT_snd_midi(dev ptr[in, string[\"/dev/snd/midiC#D#\"]], id proc[0, 1], flags flags[open_flags]) fd_snd_midi",
+    "ioctl$KGPT_SNDRV_UMP_IOCTL_ENDPOINT_INFO": "ioctl$KGPT_SNDRV_UMP_IOCTL_ENDPOINT_INFO(fd fd_snd_midi, cmd const[SNDRV_UMP_IOCTL_ENDPOINT_INFO], arg ptr[out, snd_ump_endpoint_info])",
+    "ioctl$KGPT_SNDRV_UMP_IOCTL_BLOCK_INFO": "ioctl$KGPT_SNDRV_UMP_IOCTL_BLOCK_INFO(fd fd_snd_midi, cmd const[SNDRV_UMP_IOCTL_BLOCK_INFO], arg ptr[inout, snd_ump_block_info])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_snd_midi"
+  ],
+  "includes": [
+    "uapi/sound/asound.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/sp_ldisc#drivers_net_hamradio_6pack.c:746.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/sp_ldisc#drivers_net_hamradio_6pack.c:746.json
@@ -1,0 +1,434 @@
+{
+  "open": {
+    "filename": "/dev/ptmx",
+    "fd_name": "fd_6pack",
+    "spec": "openat$KGPT_6pack(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ptmx\"]], flags flags[open_flags], mode const[0]) fd_6pack"
+  },
+  "resources": {
+    "fd_6pack": {
+      "type": "fd",
+      "spec": "resource fd_6pack[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/hamradio/6pack.c:746",
+  "ioctls": {
+    "SIOCGIFNAME": {
+      "arg": "ptr[out, string]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SIOCGIFENCAP": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SIOCSIFENCAP": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "TIOCSETN": {
+      "arg": "ptr[in, sgttyb]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "SIOCSIFHWADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "__dev_addr_set"
+        ],
+        "type": [],
+        "usage": [
+          "char addr[AX25_ADDR_LEN];",
+          "if (copy_from_user(&addr, (void __user *)arg, AX25_ADDR_LEN)) {",
+          "err = -EFAULT;",
+          "break;",
+          "}",
+          "netif_tx_lock_bh(dev);",
+          "__dev_addr_set(dev, &addr, AX25_ADDR_LEN);",
+          "netif_tx_unlock_bh(dev);",
+          "err = 0;"
+        ]
+      }
+    },
+    "TIOCGETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return get_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCSETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return set_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCGETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCGLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETSF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p,  TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETSW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCGETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "kernel_termios_to_user_termios",
+          "kernel_termios_to_user_termios_1"
+        ],
+        "type": [
+          "termios",
+          "termios2"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))",
+          "if (kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TCGETS2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios2"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios2 __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TCSETSF2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p,  TERMIOS_FLUSH | TERMIOS_WAIT);"
+        ]
+      }
+    },
+    "TCSETSW2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT);"
+        ]
+      }
+    },
+    "TCSETS2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, 0);"
+        ]
+      }
+    },
+    "TCGETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_termio"
+        ],
+        "type": [],
+        "usage": [
+          "return get_termio(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETAF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETAW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TIOCGLCKTRMIOS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "kernel_termios_to_user_termios",
+          "kernel_termios_to_user_termios_1"
+        ],
+        "type": [
+          "termios",
+          "termios2"
+        ],
+        "usage": [
+          "copy_termios_locked(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))",
+          "if (kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TIOCSLCKTRMIOS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "user_termios_to_kernel_termios",
+          "user_termios_to_kernel_termios_1"
+        ],
+        "type": [
+          "termios",
+          "termios2"
+        ],
+        "usage": [
+          "if (user_termios_to_kernel_termios(&kterm, (struct termios __user *) arg))",
+          "if (user_termios_to_kernel_termios_1(&kterm, (struct termios __user *) arg))"
+        ]
+      }
+    },
+    "TIOCGSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "ret = put_user((kterm.c_cflag & CLOCAL) ? 1 : 0, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCSSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_change_softcar"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_change_softcar(real_tty, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_6pack": "openat$KGPT_6pack(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ptmx\"]], flags flags[open_flags], mode const[0]) fd_6pack",
+    "ioctl$KGPT_SIOCGIFNAME": "ioctl$KGPT_SIOCGIFNAME(fd fd_6pack, cmd const[SIOCGIFNAME], arg ptr[out, string])",
+    "ioctl$KGPT_SIOCGIFENCAP": "ioctl$KGPT_SIOCGIFENCAP(fd fd_6pack, cmd const[SIOCGIFENCAP], arg ptr[out, int32])",
+    "ioctl$KGPT_SIOCSIFENCAP": "ioctl$KGPT_SIOCSIFENCAP(fd fd_6pack, cmd const[SIOCSIFENCAP], arg intptr)"
+  },
+  "init_syscalls": [
+    "openat$KGPT_6pack"
+  ],
+  "includes": [
+    "uapi/linux/sockios.h",
+    "uapi/linux/fcntl.h",
+    "arch/powerpc/include/uapi/asm/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/sr_bdops#drivers_scsi_sr.c:579.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/sr_bdops#drivers_scsi_sr.c:579.json
@@ -1,0 +1,739 @@
+{
+  "open": {
+    "filename": "/dev/sr#",
+    "fd_name": "fd_sr",
+    "spec": "syz_open_dev$KGPT_sr(dev ptr[in, string[\"/dev/sr#\"]], id proc[0, 1], flags flags[open_flags]) fd_sr"
+  },
+  "resources": {
+    "fd_sr": {
+      "type": "fd",
+      "spec": "resource fd_sr[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/scsi/sr.c:579",
+  "ioctls": {
+    "CDROM_SELECT_DISC": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "CDROM_DRIVE_STATUS": {
+      "arg": "intptr",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "DVD_AUTH": {
+      "arg": "ptr[inout, dvd_authinfo]",
+      "arg_name_in_usage": "userptr",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "CDROMCLOSETRAY": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CDROMEJECT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CDROMMULTISESSION": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_multisession"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_multisession(cdi, argp);"
+        ]
+      }
+    },
+    "CDROMEJECT_SW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_eject_sw"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_eject_sw(cdi, arg);"
+        ]
+      }
+    },
+    "CDROM_MEDIA_CHANGED": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_media_changed"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_media_changed(cdi, arg);"
+        ]
+      }
+    },
+    "CDROM_TIMED_MEDIA_CHANGE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_timed_media_change"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_timed_media_change(cdi, arg);"
+        ]
+      }
+    },
+    "CDROM_SET_OPTIONS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_set_options"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_set_options(cdi, arg);"
+        ]
+      }
+    },
+    "CDROM_CLEAR_OPTIONS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_clear_options"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_clear_options(cdi, arg);"
+        ]
+      }
+    },
+    "CDROM_SELECT_SPEED": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_select_speed"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_select_speed(cdi, arg);"
+        ]
+      }
+    },
+    "CDROMRESET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "bdev"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_reset"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_reset(cdi, bdev);"
+        ]
+      }
+    },
+    "CDROM_LOCKDOOR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_lock_door"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_lock_door(cdi, arg);"
+        ]
+      }
+    },
+    "CDROM_DEBUG": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_debug"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_debug(cdi, arg);"
+        ]
+      }
+    },
+    "CDROM_GET_CAPABILITY": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CDROM_GET_MCN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_get_mcn"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_get_mcn(cdi, argp);"
+        ]
+      }
+    },
+    "CDROM_DISC_STATUS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CDROM_CHANGER_NSLOTS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CDROMSUBCHNL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_get_subchnl"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_get_subchnl(cdi, argp);"
+        ]
+      }
+    },
+    "CDROMREADTOCHDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_read_tochdr"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_read_tochdr(cdi, argp);"
+        ]
+      }
+    },
+    "CDROMREADTOCENTRY": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_read_tocentry"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_read_tocentry(cdi, argp);"
+        ]
+      }
+    },
+    "CDROMPLAYMSF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_play_msf"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_play_msf(cdi, argp);"
+        ]
+      }
+    },
+    "CDROMPLAYTRKIND": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_play_trkind"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_play_trkind(cdi, argp);"
+        ]
+      }
+    },
+    "CDROMVOLCTRL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_volctrl"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_volctrl(cdi, argp);"
+        ]
+      }
+    },
+    "CDROMVOLREAD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdrom_ioctl_volread"
+        ],
+        "type": [],
+        "usage": [
+          "return cdrom_ioctl_volread(cdi, argp);"
+        ]
+      }
+    },
+    "CDROMSTART": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CDROMSTOP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CDROMPAUSE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "CDROMRESUME": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_VERSION_NUM": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_get_version"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_get_version(arg);"
+        ]
+      }
+    },
+    "SG_SET_TIMEOUT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_set_timeout"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_set_timeout(sdev, arg);"
+        ]
+      }
+    },
+    "SG_GET_TIMEOUT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SG_GET_RESERVED_SIZE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_get_reserved_size"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_get_reserved_size(sdev, arg);"
+        ]
+      }
+    },
+    "SG_SET_RESERVED_SIZE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_set_reserved_size"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_set_reserved_size(sdev, arg);"
+        ]
+      }
+    },
+    "SG_EMULATED_HOST": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_emulated_host"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_emulated_host(q, arg);"
+        ]
+      }
+    },
+    "SG_IO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl_sg_io"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_ioctl_sg_io(sdev, open_for_write, arg);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_SEND_COMMAND": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sg_scsi_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return sg_scsi_ioctl(q, open_for_write, arg);"
+        ]
+      }
+    },
+    "CDROM_SEND_PACKET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_cdrom_send_packet"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_cdrom_send_packet(sdev, open_for_write, arg);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_GET_IDLUN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_get_idlun"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_get_idlun(sdev, arg);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_GET_BUS_NUMBER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "return put_user(sdev->host->host_no, (int __user *)arg);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_PROBE_HOST": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "ioctl_probe"
+        ],
+        "type": [],
+        "usage": [
+          "return ioctl_probe(sdev->host, arg);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_DOORLOCK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_DOORUNLOCK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_TEST_UNIT_READY": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_START_UNIT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_STOP_UNIT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SCSI_IOCTL_GET_PCI": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl_get_pci"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_ioctl_get_pci(sdev, arg);"
+        ]
+      }
+    },
+    "SG_SCSI_RESET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl_reset"
+        ],
+        "type": [],
+        "usage": [
+          "return scsi_ioctl_reset(sdev, arg);"
+        ]
+      }
+    },
+    "CDROMREADRAW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "userptr"
+      ],
+      "arg_inference": {
+        "function": [
+          "mmc_ioctl_cdrom_read_data"
+        ],
+        "type": [],
+        "usage": [
+          "return mmc_ioctl_cdrom_read_data(cdi, userptr, &cgc, cmd);"
+        ]
+      }
+    },
+    "CDROMREADMODE1": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "userptr"
+      ],
+      "arg_inference": {
+        "function": [
+          "mmc_ioctl_cdrom_read_data"
+        ],
+        "type": [],
+        "usage": [
+          "return mmc_ioctl_cdrom_read_data(cdi, userptr, &cgc, cmd);"
+        ]
+      }
+    },
+    "CDROMREADMODE2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "userptr"
+      ],
+      "arg_inference": {
+        "function": [
+          "mmc_ioctl_cdrom_read_data"
+        ],
+        "type": [],
+        "usage": [
+          "return mmc_ioctl_cdrom_read_data(cdi, userptr, &cgc, cmd);"
+        ]
+      }
+    },
+    "CDROMREADAUDIO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "userptr"
+      ],
+      "arg_inference": {
+        "function": [
+          "mmc_ioctl_cdrom_read_audio"
+        ],
+        "type": [],
+        "usage": [
+          "return mmc_ioctl_cdrom_read_audio(cdi, userptr);"
+        ]
+      }
+    },
+    "CDROMPLAYBLK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "userptr"
+      ],
+      "arg_inference": {
+        "function": [
+          "mmc_ioctl_cdrom_play_blk"
+        ],
+        "type": [],
+        "usage": [
+          "return mmc_ioctl_cdrom_play_blk(cdi, userptr, &cgc);"
+        ]
+      }
+    },
+    "DVD_READ_STRUCT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "userptr"
+      ],
+      "arg_inference": {
+        "function": [
+          "mmc_ioctl_dvd_read_struct"
+        ],
+        "type": [],
+        "usage": [
+          "return mmc_ioctl_dvd_read_struct(cdi, userptr, &cgc);"
+        ]
+      }
+    },
+    "CDROM_NEXT_WRITABLE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "userptr"
+      ],
+      "arg_inference": {
+        "function": [
+          "mmc_ioctl_cdrom_next_writable"
+        ],
+        "type": [],
+        "usage": [
+          "return mmc_ioctl_cdrom_next_writable(cdi, userptr);"
+        ]
+      }
+    },
+    "CDROM_LAST_WRITTEN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "userptr"
+      ],
+      "arg_inference": {
+        "function": [
+          "mmc_ioctl_cdrom_last_written"
+        ],
+        "type": [],
+        "usage": [
+          "return mmc_ioctl_cdrom_last_written(cdi, userptr);"
+        ]
+      }
+    },
+    "CDROMGETSPINDOWN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "NULL"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdi->ops->audio_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return cdi->ops->audio_ioctl(cdi, cmd, NULL);"
+        ]
+      }
+    },
+    "CDROMSETSPINDOWN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "NULL"
+      ],
+      "arg_inference": {
+        "function": [
+          "cdi->ops->audio_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return cdi->ops->audio_ioctl(cdi, cmd, NULL);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_sr": "syz_open_dev$KGPT_sr(dev ptr[in, string[\"/dev/sr#\"]], id proc[0, 1], flags flags[open_flags]) fd_sr",
+    "ioctl$KGPT_CDROM_SELECT_DISC": "ioctl$KGPT_CDROM_SELECT_DISC(fd fd_sr, cmd const[CDROM_SELECT_DISC], arg intptr)",
+    "ioctl$KGPT_CDROM_DRIVE_STATUS": "ioctl$KGPT_CDROM_DRIVE_STATUS(fd fd_sr, cmd const[CDROM_DRIVE_STATUS], arg intptr)",
+    "ioctl$KGPT_DVD_AUTH": "ioctl$KGPT_DVD_AUTH(fd fd_sr, cmd const[DVD_AUTH], arg ptr[inout, dvd_authinfo])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_sr"
+  ],
+  "includes": [
+    "uapi/linux/cdrom.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "dvd_authinfo": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/st_fops#drivers_scsi_st.c:4146.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/st_fops#drivers_scsi_st.c:4146.json
@@ -1,0 +1,131 @@
+{
+  "open": {
+    "filename": "/dev/st#",
+    "fd_name": "fd_st",
+    "spec": "syz_open_dev$KGPT_st(dev ptr[in, string[\"/dev/st#\"]], id proc[0, 1], flags flags[open_flags]) fd_st"
+  },
+  "resources": {
+    "fd_st": {
+      "type": "fd",
+      "spec": "resource fd_st[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/scsi/st.c:4146",
+  "ioctls": {
+    "MTIOCTOP": {
+      "arg": "ptr[in, mtop]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "MTIOCGET": {
+      "arg": "ptr[out, mtget]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "MTIOCPOS": {
+      "arg": "ptr[out, mtpos]",
+      "arg_name_in_usage": "p",
+      "arg_inference": {
+        "function": [
+          "get_location",
+          "put_user_mtpos"
+        ],
+        "type": [
+          "mtpos"
+        ],
+        "usage": [
+          "struct mtpos mt_pos;",
+          "if (_IOC_SIZE(cmd_in) != sizeof(struct mtpos)) { ... }",
+          "if ((i = get_location(STp, &blk, &bt, 0)) < 0) { ... }",
+          "retval = put_user_mtpos(p, &mt_pos);"
+        ]
+      }
+    }
+  },
+  "types": {
+    "mtop": "mtop {\n\tmt_op\tint16\n\tmt_count\tint32\n}",
+    "mtget": "mtget {\n\tmt_type\tint64\n\tmt_resid\tint64\n\tmt_dsreg\tint64\n\tmt_gstat\tint64\n\tmt_erreg\tint64\n\tmt_fileno\tint64\n\tmt_blkno\tint64\n}",
+    "mtpos": "mtpos {\n\tmt_blkno\tint64\n}"
+  },
+  "existing_ioctls": {
+    "SG_IO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "retval = scsi_ioctl(STp->device, file->f_mode & FMODE_WRITE, cmd_in, p);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_SEND_COMMAND": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "retval = scsi_ioctl(STp->device, file->f_mode & FMODE_WRITE, cmd_in, p);"
+        ]
+      }
+    },
+    "CDROM_SEND_PACKET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "retval = scsi_ioctl(STp->device, file->f_mode & FMODE_WRITE, cmd_in, p);"
+        ]
+      }
+    },
+    "SCSI_IOCTL_STOP_UNIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "scsi_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "retval = scsi_ioctl(STp->device, file->f_mode & FMODE_WRITE, cmd_in, p);",
+          "if (!retval && cmd_in == SCSI_IOCTL_STOP_UNIT) { ... }"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_st": "syz_open_dev$KGPT_st(dev ptr[in, string[\"/dev/st#\"]], id proc[0, 1], flags flags[open_flags]) fd_st",
+    "ioctl$KGPT_MTIOCTOP": "ioctl$KGPT_MTIOCTOP(fd fd_st, cmd const[MTIOCTOP], arg ptr[in, mtop])",
+    "ioctl$KGPT_MTIOCGET": "ioctl$KGPT_MTIOCGET(fd fd_st, cmd const[MTIOCGET], arg ptr[out, mtget])",
+    "ioctl$KGPT_MTIOCPOS": "ioctl$KGPT_MTIOCPOS(fd fd_st, cmd const[MTIOCPOS], arg ptr[out, mtpos])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_st"
+  ],
+  "includes": [
+    "drivers/scsi/st_options.h",
+    "uapi/linux/mtio.h"
+  ],
+  "unused_types": {
+    "__kernel_daddr_t": "UNFOUND"
+  },
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/sync_ops#drivers_net_ppp_ppp_synctty.c:99.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/sync_ops#drivers_net_ppp_ppp_synctty.c:99.json
@@ -1,0 +1,128 @@
+{
+  "open": {
+    "filename": "/dev/ppp",
+    "fd_name": "fd_ppp",
+    "spec": "openat$KGPT_ppp(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ppp\"]], flags flags[open_flags], mode const[0]) fd_ppp"
+  },
+  "resources": {
+    "fd_ppp": {
+      "type": "fd",
+      "spec": "resource fd_ppp[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/net/ppp/ppp_synctty.c:99",
+  "ioctls": {
+    "PPPIOCGASYNCMAP": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "PPPIOCSASYNCMAP": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "PPPIOCGRASYNCMAP": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "PPPIOCSRASYNCMAP": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "PPPIOCGXASYNCMAP": {
+      "arg": "ptr[out, array[u32, 8]]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "PPPIOCSXASYNCMAP": {
+      "arg": "ptr[in, array[u32, 8]]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "PPPIOCGFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (put_user(val, (int __user *) argp))"
+        ]
+      }
+    },
+    "PPPIOCSFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (get_user(val, (int __user *) argp))"
+        ]
+      }
+    },
+    "PPPIOCGMRU": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (put_user(ap->mru, (int __user *) argp))"
+        ]
+      }
+    },
+    "PPPIOCSMRU": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (get_user(val, (int __user *) argp))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_ppp": "openat$KGPT_ppp(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ppp\"]], flags flags[open_flags], mode const[0]) fd_ppp",
+    "ioctl$KGPT_PPPIOCGASYNCMAP": "ioctl$KGPT_PPPIOCGASYNCMAP(fd fd_ppp, cmd const[PPPIOCGASYNCMAP], arg ptr[out, int32])",
+    "ioctl$KGPT_PPPIOCSASYNCMAP": "ioctl$KGPT_PPPIOCSASYNCMAP(fd fd_ppp, cmd const[PPPIOCSASYNCMAP], arg ptr[in, int32])",
+    "ioctl$KGPT_PPPIOCGRASYNCMAP": "ioctl$KGPT_PPPIOCGRASYNCMAP(fd fd_ppp, cmd const[PPPIOCGRASYNCMAP], arg ptr[out, int32])",
+    "ioctl$KGPT_PPPIOCSRASYNCMAP": "ioctl$KGPT_PPPIOCSRASYNCMAP(fd fd_ppp, cmd const[PPPIOCSRASYNCMAP], arg ptr[in, int32])",
+    "ioctl$KGPT_PPPIOCGXASYNCMAP": "ioctl$KGPT_PPPIOCGXASYNCMAP(fd fd_ppp, cmd const[PPPIOCGXASYNCMAP], arg ptr[out, array[int32, 8]])",
+    "ioctl$KGPT_PPPIOCSXASYNCMAP": "ioctl$KGPT_PPPIOCSXASYNCMAP(fd fd_ppp, cmd const[PPPIOCSXASYNCMAP], arg ptr[in, array[int32, 8]])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_ppp"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/ppp-ioctl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/tty_fops#drivers_tty_tty_io.c:464.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/tty_fops#drivers_tty_tty_io.c:464.json
@@ -1,0 +1,389 @@
+{
+  "open": {
+    "filename": "/dev/tty#",
+    "fd_name": "fd_tty",
+    "spec": "syz_open_dev$KGPT_tty(dev ptr[in, string[\"/dev/tty#\"]], id proc[0, 1], flags flags[open_flags]) fd_tty"
+  },
+  "resources": {
+    "fd_tty": {
+      "type": "fd",
+      "spec": "resource fd_tty[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/tty/tty_io.c:464",
+  "ioctls": {
+    "TIOCGEXCL": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "TIOCSTI": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocsti"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocsti(tty, p);"
+        ]
+      }
+    },
+    "TIOCGWINSZ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocgwinsz"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocgwinsz(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSWINSZ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocswinsz"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocswinsz(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCCONS": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCEXCL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCNXCL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCGETD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocgetd"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocgetd(tty, p);"
+        ]
+      }
+    },
+    "TIOCSETD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocsetd"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocsetd(tty, p);"
+        ]
+      }
+    },
+    "TIOCVHANGUP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCGDEV": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "unsigned int"
+        ],
+        "usage": [
+          "unsigned int ret = new_encode_dev(tty_devnum(real_tty));\nreturn put_user(ret, (unsigned int __user *)p);"
+        ]
+      }
+    },
+    "TIOCSBRK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCCBRK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TCSBRK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "send_break"
+        ],
+        "type": [],
+        "usage": [
+          "if (!arg)\nreturn send_break(tty, 250);"
+        ]
+      }
+    },
+    "TCSBRKP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "send_break"
+        ],
+        "type": [],
+        "usage": [
+          "return send_break(tty, arg ? arg*100 : 250);"
+        ]
+      }
+    },
+    "TIOCMGET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocmget"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocmget(tty, p);"
+        ]
+      }
+    },
+    "TIOCMSET": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocmset"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocmset(tty, cmd, p);"
+        ]
+      }
+    },
+    "TIOCMBIC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocmset"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocmset(tty, cmd, p);"
+        ]
+      }
+    },
+    "TIOCMBIS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocmset"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocmset(tty, cmd, p);"
+        ]
+      }
+    },
+    "TIOCGICOUNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocgicount"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocgicount(tty, p);"
+        ]
+      }
+    },
+    "TCFLSH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_buffer_flush"
+        ],
+        "type": [],
+        "usage": [
+          "switch (arg) {\ncase TCIFLUSH:\ncase TCIOFLUSH:\ntty_buffer_flush(tty, NULL);\nbreak;\n}"
+        ]
+      }
+    },
+    "TIOCSSERIAL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocsserial"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocsserial(tty, p);"
+        ]
+      }
+    },
+    "TIOCGSERIAL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_tiocgserial"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_tiocgserial(tty, p);"
+        ]
+      }
+    },
+    "TIOCGPTPEER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "ptm_open_peer"
+        ],
+        "type": [],
+        "usage": [
+          "return ptm_open_peer(file, tty, (int)arg);"
+        ]
+      }
+    },
+    "TIOCNOTTY": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCSCTTY": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocsctty"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocsctty(real_tty, file, arg);"
+        ]
+      }
+    },
+    "TIOCGPGRP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocgpgrp"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocgpgrp(tty, real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSPGRP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocspgrp"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocspgrp(tty, real_tty, p);"
+        ]
+      }
+    },
+    "TIOCGSID": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "tiocgsid"
+        ],
+        "type": [],
+        "usage": [
+          "return tiocgsid(tty, real_tty, p);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_tty": "syz_open_dev$KGPT_tty(dev ptr[in, string[\"/dev/tty#\"]], id proc[0, 1], flags flags[open_flags]) fd_tty",
+    "ioctl$KGPT_TIOCGEXCL": "ioctl$KGPT_TIOCGEXCL(fd fd_tty, cmd const[TIOCGEXCL], arg ptr[out, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_tty"
+  ],
+  "includes": [
+    "uapi/asm-generic/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/tty_ldisc_packet#drivers_tty_n_gsm.c:4034.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/tty_ldisc_packet#drivers_tty_n_gsm.c:4034.json
@@ -1,0 +1,478 @@
+{
+  "open": {
+    "filename": "/dev/ptmx",
+    "fd_name": "fd_tty",
+    "spec": "openat$KGPT_ptmx(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ptmx\"]], flags flags[open_flags], mode const[0]) fd_tty"
+  },
+  "resources": {
+    "fd_tty": {
+      "type": "fd",
+      "spec": "resource fd_tty[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/tty/n_gsm.c:4034",
+  "ioctls": {
+    "GSMIOC_GETCONF": {
+      "arg": "ptr[out, gsm_config]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "GSMIOC_SETCONF": {
+      "arg": "ptr[in, gsm_config]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "GSMIOC_GETFIRST": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "GSMIOC_GETCONF_EXT": {
+      "arg": "ptr[out, gsm_config_ext]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "GSMIOC_SETCONF_EXT": {
+      "arg": "ptr[in, gsm_config_ext]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "GSMIOC_GETCONF_DLCI": {
+      "arg": "ptr[inout, gsm_dlci_config]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "GSMIOC_SETCONF_DLCI": {
+      "arg": "ptr[in, gsm_dlci_config]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "TIOCSETN": {
+      "arg": "ptr[in, sgttyb]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "gsm_config": "gsm_config {\n\tadaption\tint32\n\tencapsulation\tint32\n\tinitiator\tint32\n\tt1\tint32\n\tt2\tint32\n\tt3\tint32\n\tn2\tint32\n\tmru\tint32\n\tmtu\tint32\n\tk\tint32\n\ti\tint32\n\tunused\tarray[int32, 8]\n}",
+    "gsm_config_ext": "gsm_config_ext {\n\tkeep_alive\tint32\n\twait_config\tint32\n\tflags\tint32\n\treserved\tarray[int32, 5]\n}",
+    "gsm_dlci_config": "gsm_dlci_config {\n\tchannel\tint32\n\tadaption\tint32\n\tmtu\tint32\n\tpriority\tint32\n\ti\tint32\n\tk\tint32\n\tflags\tint32\n\treserved\tarray[int32, 7]\n}"
+  },
+  "existing_ioctls": {
+    "TCXONC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_check_change",
+          "__stop_tty",
+          "__start_tty",
+          "tty_send_xchar"
+        ],
+        "type": [],
+        "usage": [
+          "switch (arg) {",
+          "case TCOOFF:",
+          "case TCOON:",
+          "case TCIOFF:",
+          "case TCION:",
+          "default:"
+        ]
+      }
+    },
+    "TCFLSH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_check_change",
+          "__tty_perform_flush"
+        ],
+        "type": [],
+        "usage": [
+          "return __tty_perform_flush(tty, arg);"
+        ]
+      }
+    },
+    "TIOCGETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return get_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCSETP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_sgttyb"
+        ],
+        "type": [
+          "sgttyb"
+        ],
+        "usage": [
+          "return set_sgttyb(real_tty, (struct sgttyb __user *) arg);"
+        ]
+      }
+    },
+    "TIOCGETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSETC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_tchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_tchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCGLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return get_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TIOCSLTC": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_ltchars"
+        ],
+        "type": [],
+        "usage": [
+          "return set_ltchars(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETSF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETSW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCSETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_OLD);"
+        ]
+      }
+    },
+    "TCGETS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "kernel_termios_to_user_termios",
+          "kernel_termios_to_user_termios_1"
+        ],
+        "type": [
+          "termios",
+          "termios2"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))",
+          "if (kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TCGETS2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "kernel_termios_to_user_termios"
+        ],
+        "type": [
+          "termios2"
+        ],
+        "usage": [
+          "copy_termios(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios2 __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TCSETSF2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT);"
+        ]
+      }
+    },
+    "TCSETSW2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT);"
+        ]
+      }
+    },
+    "TCSETS2": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, 0);"
+        ]
+      }
+    },
+    "TCGETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_termio"
+        ],
+        "type": [],
+        "usage": [
+          "return get_termio(real_tty, p);"
+        ]
+      }
+    },
+    "TCSETAF": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_FLUSH | TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETAW": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_WAIT | TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TCSETA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "set_termios"
+        ],
+        "type": [],
+        "usage": [
+          "return set_termios(real_tty, p, TERMIOS_TERMIO);"
+        ]
+      }
+    },
+    "TIOCGLCKTRMIOS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "kernel_termios_to_user_termios",
+          "kernel_termios_to_user_termios_1"
+        ],
+        "type": [
+          "termios",
+          "termios2"
+        ],
+        "usage": [
+          "copy_termios_locked(real_tty, &kterm);",
+          "if (kernel_termios_to_user_termios((struct termios __user *)arg, &kterm))",
+          "if (kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))"
+        ]
+      }
+    },
+    "TIOCSLCKTRMIOS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "user_termios_to_kernel_termios",
+          "user_termios_to_kernel_termios_1"
+        ],
+        "type": [
+          "termios",
+          "termios2"
+        ],
+        "usage": [
+          "copy_termios_locked(real_tty, &kterm);",
+          "if (user_termios_to_kernel_termios(&kterm, (struct termios __user *) arg))",
+          "if (user_termios_to_kernel_termios_1(&kterm, (struct termios __user *) arg))"
+        ]
+      }
+    },
+    "TIOCGSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "ret = put_user((kterm.c_cflag & CLOCAL) ? 1 : 0, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCSSOFTCAR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "tty_change_softcar"
+        ],
+        "type": [],
+        "usage": [
+          "return tty_change_softcar(real_tty, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_ptmx": "openat$KGPT_ptmx(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ptmx\"]], flags flags[open_flags], mode const[0]) fd_tty",
+    "ioctl$KGPT_GSMIOC_GETCONF": "ioctl$KGPT_GSMIOC_GETCONF(fd fd_tty, cmd const[GSMIOC_GETCONF], arg ptr[out, gsm_config])",
+    "ioctl$KGPT_GSMIOC_SETCONF": "ioctl$KGPT_GSMIOC_SETCONF(fd fd_tty, cmd const[GSMIOC_SETCONF], arg ptr[in, gsm_config])",
+    "ioctl$KGPT_GSMIOC_GETFIRST": "ioctl$KGPT_GSMIOC_GETFIRST(fd fd_tty, cmd const[GSMIOC_GETFIRST], arg ptr[out, int32])",
+    "ioctl$KGPT_GSMIOC_GETCONF_EXT": "ioctl$KGPT_GSMIOC_GETCONF_EXT(fd fd_tty, cmd const[GSMIOC_GETCONF_EXT], arg ptr[out, gsm_config_ext])",
+    "ioctl$KGPT_GSMIOC_SETCONF_EXT": "ioctl$KGPT_GSMIOC_SETCONF_EXT(fd fd_tty, cmd const[GSMIOC_SETCONF_EXT], arg ptr[in, gsm_config_ext])",
+    "ioctl$KGPT_GSMIOC_GETCONF_DLCI": "ioctl$KGPT_GSMIOC_GETCONF_DLCI(fd fd_tty, cmd const[GSMIOC_GETCONF_DLCI], arg ptr[inout, gsm_dlci_config])",
+    "ioctl$KGPT_GSMIOC_SETCONF_DLCI": "ioctl$KGPT_GSMIOC_SETCONF_DLCI(fd fd_tty, cmd const[GSMIOC_SETCONF_DLCI], arg ptr[in, gsm_dlci_config])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_ptmx"
+  ],
+  "includes": [
+    "uapi/linux/gsmmux.h",
+    "uapi/linux/fcntl.h",
+    "arch/powerpc/include/uapi/asm/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/uart_ops#drivers_tty_serial_serial_core.c:2699.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/uart_ops#drivers_tty_serial_serial_core.c:2699.json
@@ -1,0 +1,127 @@
+{
+  "open": {
+    "filename": "/dev/ttyS#",
+    "fd_name": "fd_uart",
+    "spec": "syz_open_dev$KGPT_ttyS(dev ptr[in, string[\"/dev/ttyS#\"]], id proc[0, 1], flags flags[open_flags]) fd_uart"
+  },
+  "resources": {
+    "fd_uart": {
+      "type": "fd",
+      "spec": "resource fd_uart[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/tty/serial/serial_core.c:2699",
+  "ioctls": {
+    "TIOCSERCONFIG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "TIOCMIWAIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uart_wait_modem_status"
+        ],
+        "type": [],
+        "usage": [
+          "ret = uart_wait_modem_status(state, arg);"
+        ]
+      }
+    },
+    "TIOCSERGETLSR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uart_get_lsr_info"
+        ],
+        "type": [],
+        "usage": [
+          "ret = uart_get_lsr_info(tty, state, uarg);"
+        ]
+      }
+    },
+    "TIOCGRS485": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uart_get_rs485_config"
+        ],
+        "type": [],
+        "usage": [
+          "ret = uart_get_rs485_config(uport, uarg);"
+        ]
+      }
+    },
+    "TIOCSRS485": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uart_set_rs485_config"
+        ],
+        "type": [],
+        "usage": [
+          "ret = uart_set_rs485_config(tty, uport, uarg);"
+        ]
+      }
+    },
+    "TIOCSISO7816": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uart_set_iso7816_config"
+        ],
+        "type": [],
+        "usage": [
+          "ret = uart_set_iso7816_config(state->uart_port, uarg);"
+        ]
+      }
+    },
+    "TIOCGISO7816": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "uarg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uart_get_iso7816_config"
+        ],
+        "type": [],
+        "usage": [
+          "ret = uart_get_iso7816_config(state->uart_port, uarg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_ttyS": "syz_open_dev$KGPT_ttyS(dev ptr[in, string[\"/dev/ttyS#\"]], id proc[0, 1], flags flags[open_flags]) fd_uart",
+    "ioctl$KGPT_TIOCSERCONFIG": "ioctl$KGPT_TIOCSERCONFIG(fd fd_uart, cmd const[TIOCSERCONFIG], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_ttyS"
+  ],
+  "includes": [
+    "uapi/asm-generic/ioctls.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ubi_cdev_operations#drivers_mtd_ubi_cdev.c:1096.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ubi_cdev_operations#drivers_mtd_ubi_cdev.c:1096.json
@@ -1,0 +1,72 @@
+{
+  "open": {
+    "filename": "/dev/ubi#_#",
+    "fd_name": "fd_ubi",
+    "spec": "syz_open_dev$KGPT_ubi(dev ptr[in, string[\"/dev/ubi#_#\"]], id proc[0, 1], volid proc[0, 1], flags flags[open_flags]) fd_ubi"
+  },
+  "resources": {
+    "fd_ubi": {
+      "type": "fd",
+      "spec": "resource fd_ubi[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/mtd/ubi/cdev.c:1096",
+  "ioctls": {
+    "UBI_IOCMKVOL": {
+      "arg": "ptr[in, ubi_mkvol_req]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCRMVOL": {
+      "arg": "intptr",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCRSVOL": {
+      "arg": "ptr[in, ubi_rsvol_req]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCRNVOL": {
+      "arg": "ptr[in, ubi_rnvol_req]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCRPEB": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCSPEB": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "ubi_rsvol_req": "ubi_rsvol_req {\n\tbytes\tint64\n\tvol_id\tint32\n}",
+    "ubi_rnvol_req": "ubi_rnvol_req {\n\tcount\tint32\n\tpadding1\tarray[int8, 12]\n\tents\tarray[ubi_rnvol_req_entry, UBI_MAX_RNVOL]\n}",
+    "ubi_mkvol_req": "ubi_mkvol_req {\n\tvol_id\tint32\n\talignment\tint32\n\tbytes\tint64\n\tvol_type\tint8\n\tflags\tint8\n\tname_len\tint16\n\tpadding2\tarray[int8, 4]\n\tname\tarray[int8, UBI_MAX_VOLUME_NAME_ADD_ONE]\n}",
+    "ubi_rnvol_req_entry": "type ubi_rnvol_req_entry ptr[in, array[int8]]",
+    "UBI_MAX_VOLUME_NAME_ADD_ONE": "define UBI_MAX_VOLUME_NAME_ADD_ONE 128"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_ubi": "syz_open_dev$KGPT_ubi(dev ptr[in, string[\"/dev/ubi#_#\"]], id proc[0, 1], volid proc[0, 1], flags flags[open_flags]) fd_ubi",
+    "ioctl$KGPT_UBI_IOCMKVOL": "ioctl$KGPT_UBI_IOCMKVOL(fd fd_ubi, cmd const[UBI_IOCMKVOL], arg ptr[in, ubi_mkvol_req])",
+    "ioctl$KGPT_UBI_IOCRMVOL": "ioctl$KGPT_UBI_IOCRMVOL(fd fd_ubi, cmd const[UBI_IOCRMVOL], arg intptr)",
+    "ioctl$KGPT_UBI_IOCRSVOL": "ioctl$KGPT_UBI_IOCRSVOL(fd fd_ubi, cmd const[UBI_IOCRSVOL], arg ptr[in, ubi_rsvol_req])",
+    "ioctl$KGPT_UBI_IOCRNVOL": "ioctl$KGPT_UBI_IOCRNVOL(fd fd_ubi, cmd const[UBI_IOCRNVOL], arg ptr[in, ubi_rnvol_req])",
+    "ioctl$KGPT_UBI_IOCRPEB": "ioctl$KGPT_UBI_IOCRPEB(fd fd_ubi, cmd const[UBI_IOCRPEB], arg ptr[in, int32])",
+    "ioctl$KGPT_UBI_IOCSPEB": "ioctl$KGPT_UBI_IOCSPEB(fd fd_ubi, cmd const[UBI_IOCSPEB], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_ubi"
+  ],
+  "includes": [
+    "uapi/mtd/ubi-user.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ubi_ctrl_cdev_operations#drivers_mtd_ubi_cdev.c:1104.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ubi_ctrl_cdev_operations#drivers_mtd_ubi_cdev.c:1104.json
@@ -1,0 +1,46 @@
+{
+  "open": {
+    "filename": "/dev/ubi_ctrl",
+    "fd_name": "fd_ubi_ctrl",
+    "spec": "openat$KGPT_ubi_ctrl(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ubi_ctrl\"]], flags const[O_RDWR], mode const[0]) fd_ubi_ctrl"
+  },
+  "resources": {
+    "fd_ubi_ctrl": {
+      "type": "fd",
+      "spec": "resource fd_ubi_ctrl[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/mtd/ubi/cdev.c:1104",
+  "ioctls": {
+    "UBI_IOCATT": {
+      "arg": "ptr[in, ubi_attach_req]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCDET": {
+      "arg": "intptr",
+      "arg_name_in_usage": "ubi_num",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "ubi_attach_req": "ubi_attach_req {\n\tubi_num\tint32\n\tmtd_num\tint32\n\tvid_hdr_offset\tint32\n\tmax_beb_per1024\tint16\n\tdisable_fm\tint8\n\tneed_resv_pool\tint8\n\tpadding\tarray[int8, 8]\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_ubi_ctrl": "openat$KGPT_ubi_ctrl(fd const[AT_FDCWD], file ptr[in, string[\"/dev/ubi_ctrl\"]], flags const[O_RDWR], mode const[0]) fd_ubi_ctrl",
+    "ioctl$KGPT_UBI_IOCATT": "ioctl$KGPT_UBI_IOCATT(fd fd_ubi_ctrl, cmd const[UBI_IOCATT], arg ptr[in, ubi_attach_req])",
+    "ioctl$KGPT_UBI_IOCDET": "ioctl$KGPT_UBI_IOCDET(fd fd_ubi_ctrl, cmd const[UBI_IOCDET], arg intptr)"
+  },
+  "init_syscalls": [
+    "openat$KGPT_ubi_ctrl"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/mtd/ubi-user.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/ubi_vol_cdev_operations#drivers_mtd_ubi_cdev.c:1083.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/ubi_vol_cdev_operations#drivers_mtd_ubi_cdev.c:1083.json
@@ -1,0 +1,88 @@
+{
+  "open": {
+    "filename": "/dev/ubi#_#",
+    "fd_name": "fd_ubi_vol",
+    "spec": "syz_open_dev$KGPT_ubi(dev ptr[in, string[\"/dev/ubi#_#\"]], id proc[0, 1], vol_id proc[0, 1], flags flags[open_flags]) fd_ubi_vol"
+  },
+  "resources": {
+    "fd_ubi_vol": {
+      "type": "fd",
+      "spec": "resource fd_ubi_vol[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/mtd/ubi/cdev.c:1083",
+  "ioctls": {
+    "UBI_IOCVOLCRBLK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "UBI_IOCVOLRMBLK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "UBI_IOCVOLUP": {
+      "arg": "ptr[in, int64]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCEBCH": {
+      "arg": "ptr[in, ubi_leb_change_req]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCEBER": {
+      "arg": "intptr",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCEBMAP": {
+      "arg": "ptr[in, ubi_map_req]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCEBUNMAP": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "UBI_IOCEBISMAP": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "UBI_IOCSETVOLPROP": {
+      "arg": "ptr[in, ubi_set_vol_prop_req]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "ubi_leb_change_req": "ubi_leb_change_req {\n\tlnum\tint32\n\tbytes\tint32\n\tdtype\tint8\n\tpadding\tarray[int8, 7]\n}",
+    "ubi_map_req": "ubi_map_req {\n\tlnum\tint32\n\tdtype\tint8\n\tpadding\tarray[int8, 3]\n}",
+    "ubi_set_vol_prop_req": "ubi_set_vol_prop_req {\n\tproperty\tint8\n\tpadding\tarray[int8, 7]\n\tvalue\tint64\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_ubi": "syz_open_dev$KGPT_ubi(dev ptr[in, string[\"/dev/ubi#_#\"]], id proc[0, 1], vol_id proc[0, 1], flags flags[open_flags]) fd_ubi_vol",
+    "ioctl$KGPT_UBI_IOCVOLCRBLK": "ioctl$KGPT_UBI_IOCVOLCRBLK(fd fd_ubi_vol, cmd const[UBI_IOCVOLCRBLK], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_UBI_IOCVOLRMBLK": "ioctl$KGPT_UBI_IOCVOLRMBLK(fd fd_ubi_vol, cmd const[UBI_IOCVOLRMBLK], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_UBI_IOCVOLUP": "ioctl$KGPT_UBI_IOCVOLUP(fd fd_ubi_vol, cmd const[UBI_IOCVOLUP], arg ptr[in, int64])",
+    "ioctl$KGPT_UBI_IOCEBCH": "ioctl$KGPT_UBI_IOCEBCH(fd fd_ubi_vol, cmd const[UBI_IOCEBCH], arg ptr[in, ubi_leb_change_req])",
+    "ioctl$KGPT_UBI_IOCEBER": "ioctl$KGPT_UBI_IOCEBER(fd fd_ubi_vol, cmd const[UBI_IOCEBER], arg intptr)",
+    "ioctl$KGPT_UBI_IOCEBMAP": "ioctl$KGPT_UBI_IOCEBMAP(fd fd_ubi_vol, cmd const[UBI_IOCEBMAP], arg ptr[in, ubi_map_req])",
+    "ioctl$KGPT_UBI_IOCEBUNMAP": "ioctl$KGPT_UBI_IOCEBUNMAP(fd fd_ubi_vol, cmd const[UBI_IOCEBUNMAP], arg ptr[in, int32])",
+    "ioctl$KGPT_UBI_IOCEBISMAP": "ioctl$KGPT_UBI_IOCEBISMAP(fd fd_ubi_vol, cmd const[UBI_IOCEBISMAP], arg ptr[in, int32])",
+    "ioctl$KGPT_UBI_IOCSETVOLPROP": "ioctl$KGPT_UBI_IOCSETVOLPROP(fd fd_ubi_vol, cmd const[UBI_IOCSETVOLPROP], arg ptr[in, ubi_set_vol_prop_req])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_ubi"
+  ],
+  "includes": [
+    "uapi/mtd/ubi-user.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/uinput_fops#drivers_input_misc_uinput.c:1110.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/uinput_fops#drivers_input_misc_uinput.c:1110.json
@@ -1,0 +1,311 @@
+{
+  "open": {
+    "filename": "/dev/uinput",
+    "fd_name": "fd_uinput",
+    "spec": "openat$KGPT_uinput(fd const[AT_FDCWD], file ptr[in, string[\"/dev/uinput\"]], flags const[O_RDWR], mode const[0]) fd_uinput"
+  },
+  "resources": {
+    "fd_uinput": {
+      "type": "fd",
+      "spec": "resource fd_uinput[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/input/misc/uinput.c:1110",
+  "ioctls": {
+    "UI_GET_SYSNAME": {
+      "arg": "ptr[out, array[int8]]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "UI_GET_VERSION": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "UI_DEV_CREATE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "UI_DEV_DESTROY": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "UI_DEV_SETUP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_dev_setup"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_dev_setup(udev, p);"
+        ]
+      }
+    },
+    "UI_SET_EVBIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_set_bit"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_set_bit(arg, evbit, EV_MAX);"
+        ]
+      }
+    },
+    "UI_SET_KEYBIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_set_bit"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_set_bit(arg, keybit, KEY_MAX);"
+        ]
+      }
+    },
+    "UI_SET_RELBIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_set_bit"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_set_bit(arg, relbit, REL_MAX);"
+        ]
+      }
+    },
+    "UI_SET_ABSBIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_set_bit"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_set_bit(arg, absbit, ABS_MAX);"
+        ]
+      }
+    },
+    "UI_SET_MSCBIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_set_bit"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_set_bit(arg, mscbit, MSC_MAX);"
+        ]
+      }
+    },
+    "UI_SET_LEDBIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_set_bit"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_set_bit(arg, ledbit, LED_MAX);"
+        ]
+      }
+    },
+    "UI_SET_SNDBIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_set_bit"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_set_bit(arg, sndbit, SND_MAX);"
+        ]
+      }
+    },
+    "UI_SET_FFBIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_set_bit"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_set_bit(arg, ffbit, FF_MAX);"
+        ]
+      }
+    },
+    "UI_SET_SWBIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_set_bit"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_set_bit(arg, swbit, SW_MAX);"
+        ]
+      }
+    },
+    "UI_SET_PROPBIT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_set_bit"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_set_bit(arg, propbit, INPUT_PROP_MAX);"
+        ]
+      }
+    },
+    "UI_SET_PHYS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "phys = strndup_user(p, 1024);"
+        ]
+      }
+    },
+    "UI_BEGIN_FF_UPLOAD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_ff_upload_from_user",
+          "uinput_ff_upload_to_user"
+        ],
+        "type": [
+          "uinput_ff_upload"
+        ],
+        "usage": [
+          "retval = uinput_ff_upload_from_user(p, &ff_up);",
+          "retval = uinput_ff_upload_to_user(p, &ff_up);"
+        ]
+      }
+    },
+    "UI_BEGIN_FF_ERASE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "uinput_ff_erase"
+        ],
+        "usage": [
+          "if (copy_from_user(&ff_erase, p, sizeof(ff_erase))) {"
+        ]
+      }
+    },
+    "UI_END_FF_UPLOAD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_ff_upload_from_user"
+        ],
+        "type": [
+          "uinput_ff_upload"
+        ],
+        "usage": [
+          "retval = uinput_ff_upload_from_user(p, &ff_up);"
+        ]
+      }
+    },
+    "UI_END_FF_ERASE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "uinput_ff_erase"
+        ],
+        "usage": [
+          "if (copy_from_user(&ff_erase, p, sizeof(ff_erase))) {"
+        ]
+      }
+    },
+    "UI_ABS_SETUP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "uinput_abs_setup"
+        ],
+        "type": [],
+        "usage": [
+          "retval = uinput_abs_setup(udev, p, size);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_uinput": "openat$KGPT_uinput(fd const[AT_FDCWD], file ptr[in, string[\"/dev/uinput\"]], flags const[O_RDWR], mode const[0]) fd_uinput"
+  },
+  "init_syscalls": [
+    "openat$KGPT_uinput"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/urandom_fops#drivers_char_random.c:1553.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/urandom_fops#drivers_char_random.c:1553.json
@@ -1,0 +1,88 @@
+{
+  "open": {
+    "filename": "/dev/urandom",
+    "fd_name": "fd_urandom",
+    "spec": "openat$KGPT_urandom(fd const[AT_FDCWD], file ptr[in, string[\"/dev/urandom\"]], flags flags[open_flags], mode const[0]) fd_urandom"
+  },
+  "resources": {
+    "fd_urandom": {
+      "type": "fd",
+      "spec": "resource fd_urandom[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/char/random.c:1553",
+  "ioctls": {
+    "RNDRESEEDCRNG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "RNDGETENTCNT": {
+      "arg": "ptr[inout, int]",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": null
+    },
+    "RNDADDTOENTCNT": {
+      "arg": "ptr[in, int]",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": null
+    },
+    "RNDADDENTROPY": {
+      "arg": "ptr[in, rnd_add_entropy]",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "write_pool_user",
+          "credit_init_bits"
+        ],
+        "type": [
+          "rnd_add_entropy"
+        ],
+        "usage": [
+          "struct iov_iter iter;",
+          "struct iovec iov;",
+          "ssize_t ret;",
+          "int len;",
+          "if (get_user(ent_count, p++))",
+          "if (get_user(len, p++))",
+          "ret = import_single_range(ITER_SOURCE, p, len, &iov, &iter);",
+          "ret = write_pool_user(&iter);",
+          "credit_init_bits(ent_count);"
+        ]
+      }
+    },
+    "RNDZAPENTCNT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "RNDCLEARPOOL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_urandom": "openat$KGPT_urandom(fd const[AT_FDCWD], file ptr[in, string[\"/dev/urandom\"]], flags flags[open_flags], mode const[0]) fd_urandom",
+    "ioctl$KGPT_RNDRESEEDCRNG": "ioctl$KGPT_RNDRESEEDCRNG(fd fd_urandom, cmd const[RNDRESEEDCRNG], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_urandom"
+  ],
+  "includes": [
+    "uapi/linux/fcntl.h",
+    "uapi/linux/random.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/usbdev_file_operations#drivers_usb_core_devio.c:2846.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/usbdev_file_operations#drivers_usb_core_devio.c:2846.json
@@ -1,0 +1,450 @@
+{
+  "open": {
+    "filename": "/dev/bus/usb/###/###",
+    "fd_name": "fd_usbdev",
+    "spec": "syz_open_dev$KGPT_usbdev(dev ptr[in, string[\"/dev/bus/usb/###/###\"]], id proc[0, 1], flags flags[open_flags]) fd_usbdev"
+  },
+  "resources": {
+    "fd_usbdev": {
+      "type": "fd",
+      "spec": "resource fd_usbdev[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/usb/core/devio.c:2846",
+  "ioctls": {
+    "USBDEVFS_REAPURB32": {
+      "arg": "ptr[out, intptr]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "USBDEVFS_REAPURBNDELAY32": {
+      "arg": "ptr[out, intptr]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "USBDEVFS_CONTROL32": {
+      "arg": "ptr[in, usbdevfs_ctrltransfer32]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "USBDEVFS_BULK32": {
+      "arg": "ptr[in, usbdevfs_bulktransfer32]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "USBDEVFS_DISCSIGNAL32": {
+      "arg": "ptr[in, usbdevfs_disconnectsignal32]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "USBDEVFS_SUBMITURB32": {
+      "arg": "ptr[in, usbdevfs_urb32]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "USBDEVFS_IOCTL32": {
+      "arg": "ptr[in, usbdevfs_ioctl32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "USBDEVFS_CONNINFO_EX": {
+      "arg": "ptr[out, usbdevfs_conninfo_ex]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "USBDEVFS_REAPURB": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_reapurb"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_reapurb(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_REAPURBNDELAY": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_reapurbnonblock"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_reapurbnonblock(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_CONTROL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_control"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_control(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_BULK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_bulk"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_bulk(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_RESETEP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_resetep"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_resetep(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "USBDEVFS_CLEAR_HALT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_clearhalt"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_clearhalt(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_GETDRIVER": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_getdriver"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_getdriver(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_CONNECTINFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_connectinfo"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_connectinfo(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_SETINTERFACE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_setintf"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_setintf(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_SETCONFIGURATION": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_setconfig"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_setconfig(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_SUBMITURB": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_submiturb"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_submiturb(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_DISCARDURB": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_unlinkurb"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_unlinkurb(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_DISCSIGNAL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_disconnectsignal"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_disconnectsignal(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_CLAIMINTERFACE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_claiminterface"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_claiminterface(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_RELEASEINTERFACE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_releaseinterface"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_releaseinterface(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_IOCTL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_ioctl_default"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_ioctl_default(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_CLAIM_PORT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_claim_port"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_claim_port(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_RELEASE_PORT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_release_port"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_release_port(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_GET_CAPABILITIES": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_get_capabilities"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_get_capabilities(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_DISCONNECT_CLAIM": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_disconnect_claim"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_disconnect_claim(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_ALLOC_STREAMS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_alloc_streams"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_alloc_streams(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_FREE_STREAMS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_free_streams"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_free_streams(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_DROP_PRIVILEGES": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "proc_drop_privileges"
+        ],
+        "type": [],
+        "usage": [
+          "ret = proc_drop_privileges(ps, p);"
+        ]
+      }
+    },
+    "USBDEVFS_GET_SPEED": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "USBDEVFS_FORBID_SUSPEND": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "USBDEVFS_ALLOW_SUSPEND": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "USBDEVFS_WAIT_FOR_RESUME": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_usbdev": "syz_open_dev$KGPT_usbdev(dev ptr[in, string[\"/dev/bus/usb/###/###\"]], id proc[0, 1], flags flags[open_flags]) fd_usbdev",
+    "ioctl$KGPT_USBDEVFS_REAPURB32": "ioctl$KGPT_USBDEVFS_REAPURB32(fd fd_usbdev, cmd const[USBDEVFS_REAPURB32], arg ptr[out, intptr])",
+    "ioctl$KGPT_USBDEVFS_REAPURBNDELAY32": "ioctl$KGPT_USBDEVFS_REAPURBNDELAY32(fd fd_usbdev, cmd const[USBDEVFS_REAPURBNDELAY32], arg ptr[out, intptr])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_usbdev"
+  ],
+  "includes": [
+    "uapi/linux/usbdevice_fs.h"
+  ],
+  "unused_types": {
+    "usbdevfs_ctrltransfer32": "usbdevfs_ctrltransfer32 {\n\tbRequestType\tint8\n\tbRequest\tint8\n\twValue\tint16\n\twIndex\tint16\n\twLength\tint16\n\ttimeout\tint32\n\tdata\tintptr\n}",
+    "usbdevfs_bulktransfer32": "usbdevfs_bulktransfer32 {\n\tep\tint32\n\tlen\tint32\n\ttimeout\tint32\n\tdata\tptr[in, array[int8]]\n}",
+    "usbdevfs_disconnectsignal32": "usbdevfs_disconnectsignal32 {\n\tsignr\tint32\n\tcontext\tintptr\n}",
+    "usbdevfs_urb32": "usbdevfs_urb32 {\n\ttype\tint8\n\tendpoint\tint8\n\tstatus\tint32\n\tflags\tint32\n\tbuffer\tintptr\n\tbuffer_length\tint32\n\tactual_length\tint32\n\tstart_frame\tint32\n\tnumber_of_packets\tint32\n\terror_count\tint32\n\tsignr\tint32\n\tusercontext\tintptr\n\tiso_frame_desc\tarray[usbdevfs_iso_packet_desc, 0]\n}",
+    "usbdevfs_ioctl32": "usbdevfs_ioctl32 {\n\tifno\tint32\n\tioctl_code\tint32\n\tdata\tintptr\n}",
+    "usbdevfs_conninfo_ex": "usbdevfs_conninfo_ex {\n\tsize\tint32\n\tbusnum\tint32\n\tdevnum\tint32\n\tspeed\tint32\n\tnum_ports\tint8\n\tports\tarray[int8, 7]\n}"
+  },
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/v4l2_subdev_fops#drivers_media_v4l2-core_v4l2-subdev.c:1034.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/v4l2_subdev_fops#drivers_media_v4l2-core_v4l2-subdev.c:1034.json
@@ -1,0 +1,560 @@
+{
+  "open": {
+    "filename": "/dev/v4l-subdev#",
+    "fd_name": "fd_v4l_subdev",
+    "spec": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_v4l_subdev"
+  },
+  "resources": {
+    "fd_v4l_subdev": {
+      "type": "fd",
+      "spec": "resource fd_v4l_subdev[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/media/v4l2-core/v4l2-subdev.c:1034",
+  "ioctls": {
+    "VIDIOC_SUBDEV_QUERYCAP": {
+      "arg": "ptr[in, v4l2_subdev_capability]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "VIDIOC_SUBDEV_G_STD": {
+      "arg": "ptr[out, v4l2_std_id]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "VIDIOC_SUBDEV_S_STD": {
+      "arg": "ptr[in, v4l2_std_id]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "VIDIOC_SUBDEV_ENUMSTD": {
+      "arg": "ptr[inout, v4l2_standard]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    },
+    "VIDIOC_SUBDEV_QUERYSTD": {
+      "arg": "ptr[out, v4l2_std_id]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_SUBDEV_G_ROUTING": {
+      "arg": "ptr[in, v4l2_subdev_routing]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_SUBDEV_S_ROUTING": {
+      "arg": "ptr[in, v4l2_subdev_routing]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_SUBDEV_G_CLIENT_CAP": {
+      "arg": "ptr[in, v4l2_subdev_client_capability]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "VIDIOC_SUBDEV_S_CLIENT_CAP": {
+      "arg": "ptr[in, v4l2_subdev_client_capability]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "v4l2_subdev_capability": "v4l2_subdev_capability {\n\tversion\tint32\n\tcapabilities\tint32\n\treserved\tarray[int32, 14]\n}",
+    "v4l2_subdev_routing": "v4l2_subdev_routing {\n\twhich\tint32\n\tnum_routes\tint32\n\troutes\tintptr\n\treserved\tarray[int32, 6]\n}",
+    "v4l2_subdev_client_capability": "v4l2_subdev_client_capability {\n\tcapabilities\tint64\n}"
+  },
+  "existing_ioctls": {
+    "VIDIOC_QUERYCTRL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_queryctrl"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_queryctrl(vfh->ctrl_handler, arg);"
+        ]
+      }
+    },
+    "VIDIOC_QUERY_EXT_CTRL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_query_ext_ctrl"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_query_ext_ctrl(vfh->ctrl_handler, arg);"
+        ]
+      }
+    },
+    "VIDIOC_QUERYMENU": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_querymenu"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_querymenu(vfh->ctrl_handler, arg);"
+        ]
+      }
+    },
+    "VIDIOC_G_CTRL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_g_ctrl"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_g_ctrl(vfh->ctrl_handler, arg);"
+        ]
+      }
+    },
+    "VIDIOC_S_CTRL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_s_ctrl"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_s_ctrl(vfh, vfh->ctrl_handler, arg);"
+        ]
+      }
+    },
+    "VIDIOC_G_EXT_CTRLS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_g_ext_ctrls"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_g_ext_ctrls(vfh->ctrl_handler, vdev, sd->v4l2_dev->mdev, arg);"
+        ]
+      }
+    },
+    "VIDIOC_S_EXT_CTRLS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_s_ext_ctrls"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_s_ext_ctrls(vfh, vfh->ctrl_handler, vdev, sd->v4l2_dev->mdev, arg);"
+        ]
+      }
+    },
+    "VIDIOC_TRY_EXT_CTRLS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_try_ext_ctrls"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_try_ext_ctrls(vfh->ctrl_handler, vdev, sd->v4l2_dev->mdev, arg);"
+        ]
+      }
+    },
+    "VIDIOC_DQEVENT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_event_dequeue"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_event_dequeue(vfh, arg, file->f_flags & O_NONBLOCK);"
+        ]
+      }
+    },
+    "VIDIOC_SUBSCRIBE_EVENT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_subdev_call(sd, core, subscribe_event, vfh, arg);"
+        ]
+      }
+    },
+    "VIDIOC_UNSUBSCRIBE_EVENT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_subdev_call(sd, core, unsubscribe_event, vfh, arg);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_G_FMT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_format"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, get_fmt, state, format);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_S_FMT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_format"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, set_fmt, state, format);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_G_CROP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_crop"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, get_selection, state, &sel);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_S_CROP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_crop"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, set_selection, state, &sel);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_ENUM_MBUS_CODE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_mbus_code_enum"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, enum_mbus_code, state, code);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_ENUM_FRAME_SIZE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_frame_size_enum"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, enum_frame_size, state, fse);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_G_FRAME_INTERVAL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_frame_interval"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, video, g_frame_interval, arg);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_S_FRAME_INTERVAL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_frame_interval"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, video, s_frame_interval, arg);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_ENUM_FRAME_INTERVAL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_frame_interval_enum"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, enum_frame_interval, state, fie);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_G_SELECTION": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_selection"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, get_selection, state, sel);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_S_SELECTION": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_selection"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, set_selection, state, sel);"
+        ]
+      }
+    },
+    "VIDIOC_G_EDID": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_edid"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, get_edid, edid);"
+        ]
+      }
+    },
+    "VIDIOC_S_EDID": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_subdev_edid"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, set_edid, edid);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_DV_TIMINGS_CAP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_dv_timings_cap"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, dv_timings_cap, cap);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_ENUM_DV_TIMINGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [
+          "v4l2_enum_dv_timings"
+        ],
+        "usage": [
+          "return v4l2_subdev_call(sd, pad, enum_dv_timings, dvt);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_QUERY_DV_TIMINGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_subdev_call(sd, video, query_dv_timings, arg);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_G_DV_TIMINGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_subdev_call(sd, video, g_dv_timings, arg);"
+        ]
+      }
+    },
+    "VIDIOC_SUBDEV_S_DV_TIMINGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "v4l2_subdev_call"
+        ],
+        "type": [],
+        "usage": [
+          "return v4l2_subdev_call(sd, video, s_dv_timings, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_v4l_subdev": "syz_open_dev$KGPT_v4l_subdev(dev ptr[in, string[\"/dev/v4l-subdev#\"]], id proc[0, 1], flags flags[open_flags]) fd_v4l_subdev",
+    "ioctl$KGPT_VIDIOC_SUBDEV_QUERYCAP": "ioctl$KGPT_VIDIOC_SUBDEV_QUERYCAP(fd fd_v4l_subdev, cmd const[VIDIOC_SUBDEV_QUERYCAP], arg ptr[in, v4l2_subdev_capability])",
+    "ioctl$KGPT_VIDIOC_SUBDEV_G_STD": "ioctl$KGPT_VIDIOC_SUBDEV_G_STD(fd fd_v4l_subdev, cmd const[VIDIOC_SUBDEV_G_STD], arg ptr[out, v4l2_std_id])",
+    "ioctl$KGPT_VIDIOC_SUBDEV_S_STD": "ioctl$KGPT_VIDIOC_SUBDEV_S_STD(fd fd_v4l_subdev, cmd const[VIDIOC_SUBDEV_S_STD], arg ptr[in, v4l2_std_id])",
+    "ioctl$KGPT_VIDIOC_SUBDEV_ENUMSTD": "ioctl$KGPT_VIDIOC_SUBDEV_ENUMSTD(fd fd_v4l_subdev, cmd const[VIDIOC_SUBDEV_ENUMSTD], arg ptr[inout, v4l2_standard])",
+    "ioctl$KGPT_VIDIOC_SUBDEV_QUERYSTD": "ioctl$KGPT_VIDIOC_SUBDEV_QUERYSTD(fd fd_v4l_subdev, cmd const[VIDIOC_SUBDEV_QUERYSTD], arg ptr[out, v4l2_std_id])",
+    "ioctl$KGPT_VIDIOC_SUBDEV_G_ROUTING": "ioctl$KGPT_VIDIOC_SUBDEV_G_ROUTING(fd fd_v4l_subdev, cmd const[VIDIOC_SUBDEV_G_ROUTING], arg ptr[in, v4l2_subdev_routing])",
+    "ioctl$KGPT_VIDIOC_SUBDEV_S_ROUTING": "ioctl$KGPT_VIDIOC_SUBDEV_S_ROUTING(fd fd_v4l_subdev, cmd const[VIDIOC_SUBDEV_S_ROUTING], arg ptr[in, v4l2_subdev_routing])",
+    "ioctl$KGPT_VIDIOC_SUBDEV_G_CLIENT_CAP": "ioctl$KGPT_VIDIOC_SUBDEV_G_CLIENT_CAP(fd fd_v4l_subdev, cmd const[VIDIOC_SUBDEV_G_CLIENT_CAP], arg ptr[in, v4l2_subdev_client_capability])",
+    "ioctl$KGPT_VIDIOC_SUBDEV_S_CLIENT_CAP": "ioctl$KGPT_VIDIOC_SUBDEV_S_CLIENT_CAP(fd fd_v4l_subdev, cmd const[VIDIOC_SUBDEV_S_CLIENT_CAP], arg ptr[in, v4l2_subdev_client_capability])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_v4l_subdev"
+  ],
+  "includes": [
+    "uapi/linux/v4l2-subdev.h"
+  ],
+  "unused_types": {
+    "v4l2_fract": "EXISTING",
+    "v4l2_subdev_route": "v4l2_subdev_route {\n\tsink_pad\tint32\n\tsink_stream\tint32\n\tsource_pad\tint32\n\tsource_stream\tint32\n\tflags\tint32\n\treserved\tarray[int32, 5]\n}"
+  },
+  "ignored_types": {
+    "v4l2_std_id": "EXISTING",
+    "v4l2_standard": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/vfio_device_fops#drivers_vfio_vfio_main.c:1311.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/vfio_device_fops#drivers_vfio_vfio_main.c:1311.json
@@ -1,0 +1,64 @@
+{
+  "open": {
+    "filename": "/dev/vfio/#",
+    "fd_name": "fd_vfio",
+    "spec": "syz_open_dev$KGPT_vfio(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_vfio"
+  },
+  "resources": {
+    "fd_vfio": {
+      "type": "fd",
+      "spec": "resource fd_vfio[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/vfio/vfio_main.c:1311",
+  "ioctls": {
+    "VFIO_DEVICE_BIND_IOMMUFD": {
+      "arg": "ptr[in, vfio_device_bind_iommufd]",
+      "arg_name_in_usage": "uptr",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_ATTACH_IOMMUFD_PT": {
+      "arg": "ptr[in, vfio_device_attach_iommufd_pt]",
+      "arg_name_in_usage": "uptr",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_DETACH_IOMMUFD_PT": {
+      "arg": "ptr[in, vfio_device_detach_iommufd_pt]",
+      "arg_name_in_usage": "uptr",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_FEATURE": {
+      "arg": "ptr[in, vfio_device_feature]",
+      "arg_name_in_usage": "uptr",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "vfio_device_bind_iommufd": "vfio_device_bind_iommufd {\n\targsz\tint32\n\tflags\tint32\n\tiommufd\tint32\n\tout_devid\tint32\n}",
+    "vfio_device_attach_iommufd_pt": "vfio_device_attach_iommufd_pt {\n\targsz\tint32\n\tflags\tint32\n\tpt_id\tint32\n}",
+    "vfio_device_detach_iommufd_pt": "vfio_device_detach_iommufd_pt {\n\targsz\tint32\n\tflags\tint32\n}",
+    "vfio_device_feature": "vfio_device_feature {\n\targsz\tint32\n\tflags\tflags[vfio_device_feature_flags, int32]\n\tdata\tarray[int8]\n}",
+    "vfio_device_feature_flags": "vfio_device_feature_flags = VFIO_DEVICE_FEATURE_MASK, VFIO_DEVICE_FEATURE_GET, VFIO_DEVICE_FEATURE_SET, VFIO_DEVICE_FEATURE_PROBE",
+    "VFIO_DEVICE_FEATURE_MASK": "define VFIO_DEVICE_FEATURE_MASK 0xffff",
+    "VFIO_DEVICE_FEATURE_GET": "define VFIO_DEVICE_FEATURE_GET (1 << 16)",
+    "VFIO_DEVICE_FEATURE_SET": "define VFIO_DEVICE_FEATURE_SET (1 << 17)",
+    "VFIO_DEVICE_FEATURE_PROBE": "define VFIO_DEVICE_FEATURE_PROBE (1 << 18)"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_vfio": "syz_open_dev$KGPT_vfio(dev ptr[in, string[\"/dev/vfio/#\"]], id proc[0, 1], flags flags[open_flags]) fd_vfio",
+    "ioctl$KGPT_VFIO_DEVICE_BIND_IOMMUFD": "ioctl$KGPT_VFIO_DEVICE_BIND_IOMMUFD(fd fd_vfio, cmd const[VFIO_DEVICE_BIND_IOMMUFD], arg ptr[in, vfio_device_bind_iommufd])",
+    "ioctl$KGPT_VFIO_DEVICE_ATTACH_IOMMUFD_PT": "ioctl$KGPT_VFIO_DEVICE_ATTACH_IOMMUFD_PT(fd fd_vfio, cmd const[VFIO_DEVICE_ATTACH_IOMMUFD_PT], arg ptr[in, vfio_device_attach_iommufd_pt])",
+    "ioctl$KGPT_VFIO_DEVICE_DETACH_IOMMUFD_PT": "ioctl$KGPT_VFIO_DEVICE_DETACH_IOMMUFD_PT(fd fd_vfio, cmd const[VFIO_DEVICE_DETACH_IOMMUFD_PT], arg ptr[in, vfio_device_detach_iommufd_pt])",
+    "ioctl$KGPT_VFIO_DEVICE_FEATURE": "ioctl$KGPT_VFIO_DEVICE_FEATURE(fd fd_vfio, cmd const[VFIO_DEVICE_FEATURE], arg ptr[in, vfio_device_feature])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_vfio"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/vfio_group_fops#drivers_vfio_group.c:497.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/vfio_group_fops#drivers_vfio_group.c:497.json
@@ -1,0 +1,67 @@
+{
+  "open": {
+    "filename": "/dev/vfio/vfio#",
+    "fd_name": "fd_vfio_group",
+    "spec": "syz_open_dev$KGPT_vfio_group(dev ptr[in, string[\"/dev/vfio/vfio#\"]], id proc[0, 1], flags flags[open_flags]) fd_vfio_group"
+  },
+  "resources": {
+    "fd_vfio_group": {
+      "type": "fd",
+      "spec": "resource fd_vfio_group[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/vfio/group.c:497",
+  "ioctls": {
+    "VFIO_GROUP_UNSET_CONTAINER": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VFIO_GROUP_GET_DEVICE_FD": {
+      "arg": "ptr[in, string]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_GROUP_GET_STATUS": {
+      "arg": "ptr[inout, vfio_group_status]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_GROUP_SET_CONTAINER": {
+      "arg": "intptr",
+      "arg_name_in_usage": "fd",
+      "arg_inference": {
+        "function": [
+          "vfio_group_ioctl_set_container"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "if (get_user(fd, arg))\n\t\treturn -EFAULT;"
+        ]
+      }
+    }
+  },
+  "types": {
+    "vfio_group_status": "vfio_group_status {\n\targsz\tint32\n\tflags\tflags[vfio_group_status_flags, int32]\n}",
+    "vfio_group_status_flags": "vfio_group_status_flags = VFIO_GROUP_FLAGS_VIABLE, VFIO_GROUP_FLAGS_CONTAINER_SET"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_vfio_group": "syz_open_dev$KGPT_vfio_group(dev ptr[in, string[\"/dev/vfio/vfio#\"]], id proc[0, 1], flags flags[open_flags]) fd_vfio_group",
+    "ioctl$KGPT_VFIO_GROUP_UNSET_CONTAINER": "ioctl$KGPT_VFIO_GROUP_UNSET_CONTAINER(fd fd_vfio_group, cmd const[VFIO_GROUP_UNSET_CONTAINER], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_GROUP_GET_DEVICE_FD": "ioctl$KGPT_VFIO_GROUP_GET_DEVICE_FD(fd fd_vfio_group, cmd const[VFIO_GROUP_GET_DEVICE_FD], arg ptr[in, string])",
+    "ioctl$KGPT_VFIO_GROUP_GET_STATUS": "ioctl$KGPT_VFIO_GROUP_GET_STATUS(fd fd_vfio_group, cmd const[VFIO_GROUP_GET_STATUS], arg ptr[inout, vfio_group_status])",
+    "ioctl$KGPT_VFIO_GROUP_SET_CONTAINER": "ioctl$KGPT_VFIO_GROUP_SET_CONTAINER(fd fd_vfio_group, cmd const[VFIO_GROUP_SET_CONTAINER], arg intptr)"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_vfio_group"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/vfio_iommu_driver_ops_type1#drivers_vfio_vfio_iommu_type1.c:3168.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/vfio_iommu_driver_ops_type1#drivers_vfio_vfio_iommu_type1.c:3168.json
@@ -1,0 +1,105 @@
+{
+  "open": {
+    "filename": "/dev/vfio/vfio",
+    "fd_name": "fd_vfio",
+    "spec": "openat$KGPT_vfio(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vfio/vfio\"]], flags const[O_RDWR], mode const[0]) fd_vfio"
+  },
+  "resources": {
+    "fd_vfio": {
+      "type": "fd",
+      "spec": "resource fd_vfio[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/vfio/vfio_iommu_type1.c:3168",
+  "ioctls": {
+    "VFIO_IOMMU_DIRTY_PAGES": {
+      "arg": "ptr[in, vfio_iommu_type1_dirty_bitmap]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "vfio_iommu_type1_dirty_bitmap": "vfio_iommu_type1_dirty_bitmap {\n\targsz\tint32\n\tflags\tflags[vfio_iommu_dirty_pages_flags, int32]\n\tdata\tarray[int8]\n}",
+    "vfio_iommu_dirty_pages_flags": "vfio_iommu_dirty_pages_flags = VFIO_IOMMU_DIRTY_PAGES_FLAG_START, VFIO_IOMMU_DIRTY_PAGES_FLAG_STOP, VFIO_IOMMU_DIRTY_PAGES_FLAG_GET_BITMAP",
+    "VFIO_IOMMU_DIRTY_PAGES_FLAG_START": "define VFIO_IOMMU_DIRTY_PAGES_FLAG_START (1<<0)",
+    "VFIO_IOMMU_DIRTY_PAGES_FLAG_STOP": "define VFIO_IOMMU_DIRTY_PAGES_FLAG_STOP (1<<1)",
+    "VFIO_IOMMU_DIRTY_PAGES_FLAG_GET_BITMAP": "define VFIO_IOMMU_DIRTY_PAGES_FLAG_GET_BITMAP (1<<2)"
+  },
+  "existing_ioctls": {
+    "VFIO_CHECK_EXTENSION": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "vfio_iommu_type1_check_extension"
+        ],
+        "type": [],
+        "usage": [
+          "return vfio_iommu_type1_check_extension(iommu, arg);"
+        ]
+      }
+    },
+    "VFIO_IOMMU_GET_INFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "vfio_iommu_type1_get_info"
+        ],
+        "type": [],
+        "usage": [
+          "return vfio_iommu_type1_get_info(iommu, arg);"
+        ]
+      }
+    },
+    "VFIO_IOMMU_MAP_DMA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "vfio_iommu_type1_map_dma"
+        ],
+        "type": [],
+        "usage": [
+          "return vfio_iommu_type1_map_dma(iommu, arg);"
+        ]
+      }
+    },
+    "VFIO_IOMMU_UNMAP_DMA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "vfio_iommu_type1_unmap_dma"
+        ],
+        "type": [],
+        "usage": [
+          "return vfio_iommu_type1_unmap_dma(iommu, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_vfio": "openat$KGPT_vfio(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vfio/vfio\"]], flags const[O_RDWR], mode const[0]) fd_vfio",
+    "ioctl$KGPT_VFIO_IOMMU_DIRTY_PAGES": "ioctl$KGPT_VFIO_IOMMU_DIRTY_PAGES(fd fd_vfio, cmd const[VFIO_IOMMU_DIRTY_PAGES], arg ptr[in, vfio_iommu_type1_dirty_bitmap])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_vfio"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h",
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/vfio_pci_ops#drivers_vfio_pci_vfio_pci.c:128.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/vfio_pci_ops#drivers_vfio_pci_vfio_pci.c:128.json
@@ -1,0 +1,95 @@
+{
+  "open": {
+    "filename": "/dev/vfio/vfio",
+    "fd_name": "fd_vfio",
+    "spec": "openat$KGPT_vfio(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vfio/vfio\"]], flags const[O_RDWR], mode const[0]) fd_vfio"
+  },
+  "resources": {
+    "fd_vfio": {
+      "type": "fd",
+      "spec": "resource fd_vfio[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/vfio/pci/vfio_pci.c:128",
+  "ioctls": {
+    "VFIO_DEVICE_GET_INFO": {
+      "arg": "ptr[out, vfio_device_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_IRQ_INFO": {
+      "arg": "ptr[in,out, vfio_irq_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_PCI_HOT_RESET_INFO": {
+      "arg": "ptr[inout, vfio_pci_hot_reset_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_GET_REGION_INFO": {
+      "arg": "ptr[in,out, vfio_region_info]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_IOEVENTFD": {
+      "arg": "ptr[in, vfio_device_ioeventfd]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_PCI_HOT_RESET": {
+      "arg": "ptr[in, vfio_pci_hot_reset]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_RESET": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    },
+    "VFIO_DEVICE_SET_IRQS": {
+      "arg": "ptr[in, vfio_irq_set]",
+      "arg_name_in_usage": "uarg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "vfio_device_info": "vfio_device_info {\n\targsz\tint32\n\tflags\tflags[vfio_device_flags, int32]\n\tnum_regions\tint32\n\tnum_irqs\tint32\n\tcap_offset\tint32\n\tpad\tint32\n}",
+    "vfio_region_info": "vfio_region_info {\n\targsz\tint32\n\tflags\tflags[vfio_region_info_flags, int32]\n\tindex\tint32\n\tcap_offset\tint32\n\tsize\tint64\n\toffset\tint64\n}",
+    "vfio_device_ioeventfd": "vfio_device_ioeventfd {\n\targsz\tint32\n\tflags\tflags[vfio_device_ioeventfd_flags, int32]\n\toffset\tint64\n\tdata\tint64\n\tfd\tint32\n\treserved\tint32\n}",
+    "vfio_pci_hot_reset_info": "vfio_pci_hot_reset_info {\n\targsz\tint32\n\tflags\tflags[vfio_pci_hot_reset_flags, int32]\n\tcount\tlen[devices, int32]\n\tdevices\tptr[inout, array[vfio_pci_dependent_device]]\n}",
+    "vfio_pci_hot_reset": "vfio_pci_hot_reset {\n\targsz\tint32\n\tflags\tint32\n\tcount\tlen[group_fds, int32]\n\tgroup_fds\tptr[in, array[int32]]\n}",
+    "vfio_irq_set": "vfio_irq_set {\n\targsz\tint32\n\tflags\tflags[vfio_irq_set_flags, int32]\n\tindex\tint32\n\tstart\tint32\n\tcount\tlen[data, int32]\n\tdata\tarray[int8]\n}",
+    "vfio_irq_info": "vfio_irq_info {\n\targsz\tint32\n\tflags\tflags[vfio_irq_info_flags, int32]\n\tindex\tint32\n\tcount\tint32\n}",
+    "vfio_device_flags": "vfio_device_flags = VFIO_DEVICE_FLAGS_RESET, VFIO_DEVICE_FLAGS_PCI, VFIO_DEVICE_FLAGS_PLATFORM, VFIO_DEVICE_FLAGS_AMBA, VFIO_DEVICE_FLAGS_CCW, VFIO_DEVICE_FLAGS_AP, VFIO_DEVICE_FLAGS_FSL_MC, VFIO_DEVICE_FLAGS_CAPS, VFIO_DEVICE_FLAGS_CDX",
+    "vfio_irq_info_flags": "vfio_irq_info_flags = VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_INFO_MASKABLE, VFIO_IRQ_INFO_AUTOMASKED, VFIO_IRQ_INFO_NORESIZE",
+    "vfio_pci_hot_reset_flags": "vfio_pci_hot_reset_flags = VFIO_PCI_HOT_RESET_FLAG_DEV_ID, VFIO_PCI_HOT_RESET_FLAG_DEV_ID_OWNED",
+    "vfio_region_info_flags": "vfio_region_info_flags = VFIO_REGION_INFO_FLAG_READ, VFIO_REGION_INFO_FLAG_WRITE, VFIO_REGION_INFO_FLAG_MMAP, VFIO_REGION_INFO_FLAG_CAPS",
+    "vfio_device_ioeventfd_flags": "vfio_device_ioeventfd_flags = VFIO_DEVICE_IOEVENTFD_8, VFIO_DEVICE_IOEVENTFD_16, VFIO_DEVICE_IOEVENTFD_32, VFIO_DEVICE_IOEVENTFD_64",
+    "vfio_irq_set_flags": "vfio_irq_set_flags = VFIO_IRQ_SET_DATA_NONE, VFIO_IRQ_SET_DATA_BOOL, VFIO_IRQ_SET_DATA_EVENTFD, VFIO_IRQ_SET_ACTION_MASK, VFIO_IRQ_SET_ACTION_UNMASK, VFIO_IRQ_SET_ACTION_TRIGGER",
+    "vfio_pci_dependent_device": "vfio_pci_dependent_device {\n\tgroup_id\tint32\n\tsegment\tint16\n\tbus\tint8\n\tdevfn\tint8\n}"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_vfio": "openat$KGPT_vfio(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vfio/vfio\"]], flags const[O_RDWR], mode const[0]) fd_vfio",
+    "ioctl$KGPT_VFIO_DEVICE_GET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_INFO(fd fd_vfio, cmd const[VFIO_DEVICE_GET_INFO], arg ptr[out, vfio_device_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_IRQ_INFO(fd fd_vfio, cmd const[VFIO_DEVICE_GET_IRQ_INFO], arg ptr[inout, vfio_irq_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_PCI_HOT_RESET_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_PCI_HOT_RESET_INFO(fd fd_vfio, cmd const[VFIO_DEVICE_GET_PCI_HOT_RESET_INFO], arg ptr[inout, vfio_pci_hot_reset_info])",
+    "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO": "ioctl$KGPT_VFIO_DEVICE_GET_REGION_INFO(fd fd_vfio, cmd const[VFIO_DEVICE_GET_REGION_INFO], arg ptr[inout, vfio_region_info])",
+    "ioctl$KGPT_VFIO_DEVICE_IOEVENTFD": "ioctl$KGPT_VFIO_DEVICE_IOEVENTFD(fd fd_vfio, cmd const[VFIO_DEVICE_IOEVENTFD], arg ptr[in, vfio_device_ioeventfd])",
+    "ioctl$KGPT_VFIO_DEVICE_PCI_HOT_RESET": "ioctl$KGPT_VFIO_DEVICE_PCI_HOT_RESET(fd fd_vfio, cmd const[VFIO_DEVICE_PCI_HOT_RESET], arg ptr[in, vfio_pci_hot_reset])",
+    "ioctl$KGPT_VFIO_DEVICE_RESET": "ioctl$KGPT_VFIO_DEVICE_RESET(fd fd_vfio, cmd const[VFIO_DEVICE_RESET], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VFIO_DEVICE_SET_IRQS": "ioctl$KGPT_VFIO_DEVICE_SET_IRQS(fd fd_vfio, cmd const[VFIO_DEVICE_SET_IRQS], arg ptr[in, vfio_irq_set])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_vfio"
+  ],
+  "includes": [
+    "uapi/linux/vfio.h",
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/vhost_net_fops#drivers_vhost_net.c:1778.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/vhost_net_fops#drivers_vhost_net.c:1778.json
@@ -1,0 +1,308 @@
+{
+  "open": {
+    "filename": "/dev/vhost-net",
+    "fd_name": "fd_vhost_net",
+    "spec": "openat$KGPT_net(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vhost-net\"]], flags const[O_RDWR], mode const[0]) fd_vhost_net"
+  },
+  "resources": {
+    "fd_vhost_net": {
+      "type": "fd",
+      "spec": "resource fd_vhost_net[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/vhost/net.c:1778",
+  "ioctls": {
+    "VHOST_GET_BACKEND_FEATURES": {
+      "arg": "ptr[out, int64]",
+      "arg_name_in_usage": "featurep",
+      "arg_inference": null
+    },
+    "VHOST_SET_BACKEND_FEATURES": {
+      "arg": "ptr[in, int64]",
+      "arg_name_in_usage": "featurep",
+      "arg_inference": null
+    },
+    "VHOST_GET_VRING_BUSYLOOP_TIMEOUT": {
+      "arg": "ptr[out, vhost_vring_state]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "VHOST_NET_SET_BACKEND": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "backend"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_net_set_backend"
+        ],
+        "type": [
+          "vhost_vring_file"
+        ],
+        "usage": [
+          "struct vhost_vring_file backend;",
+          "if (copy_from_user(&backend, argp, sizeof backend))",
+          "return vhost_net_set_backend(n, backend.index, backend.fd);"
+        ]
+      }
+    },
+    "VHOST_GET_FEATURES": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "featurep"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "u64 __user *featurep = argp;",
+          "u64 features;",
+          "features = VHOST_NET_FEATURES;",
+          "if (copy_to_user(featurep, &features, sizeof features))"
+        ]
+      }
+    },
+    "VHOST_SET_FEATURES": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "featurep"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_net_set_features"
+        ],
+        "type": [],
+        "usage": [
+          "u64 __user *featurep = argp;",
+          "u64 features;",
+          "if (copy_from_user(&features, featurep, sizeof features))",
+          "return vhost_net_set_features(n, features);"
+        ]
+      }
+    },
+    "VHOST_RESET_OWNER": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VHOST_SET_OWNER": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VHOST_SET_MEM_TABLE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_set_memory"
+        ],
+        "type": [],
+        "usage": [
+          "r = vhost_set_memory(d, argp);"
+        ]
+      }
+    },
+    "VHOST_SET_LOG_BASE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "if (copy_from_user(&p, argp, sizeof p)) {",
+          "void __user *base = (void __user *)(unsigned long)p;"
+        ]
+      }
+    },
+    "VHOST_SET_LOG_FD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "r = get_user(fd, (int __user *)argp);"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_NUM": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_vring_set_num_addr"
+        ],
+        "type": [],
+        "usage": [
+          "return vhost_vring_set_num_addr(d, vq, ioctl, argp);"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_ADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_vring_set_num_addr"
+        ],
+        "type": [],
+        "usage": [
+          "return vhost_vring_set_num_addr(d, vq, ioctl, argp);"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_BASE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "vhost_vring_state"
+        ],
+        "usage": [
+          "if (copy_from_user(&s, argp, sizeof s)) {"
+        ]
+      }
+    },
+    "VHOST_GET_VRING_BASE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "vhost_vring_state"
+        ],
+        "usage": [
+          "if (copy_to_user(argp, &s, sizeof s))"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_KICK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "vhost_vring_file"
+        ],
+        "usage": [
+          "if (copy_from_user(&f, argp, sizeof f)) {"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_CALL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "vhost_vring_file"
+        ],
+        "usage": [
+          "if (copy_from_user(&f, argp, sizeof f)) {"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_ERR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "vhost_vring_file"
+        ],
+        "usage": [
+          "if (copy_from_user(&f, argp, sizeof f)) {"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_ENDIAN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_set_vring_endian"
+        ],
+        "type": [],
+        "usage": [
+          "r = vhost_set_vring_endian(vq, argp);"
+        ]
+      }
+    },
+    "VHOST_GET_VRING_ENDIAN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_get_vring_endian"
+        ],
+        "type": [],
+        "usage": [
+          "r = vhost_get_vring_endian(vq, idx, argp);"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_BUSYLOOP_TIMEOUT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "vhost_vring_state"
+        ],
+        "usage": [
+          "if (copy_from_user(&s, argp, sizeof(s))) {"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_net": "openat$KGPT_net(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vhost-net\"]], flags const[O_RDWR], mode const[0]) fd_vhost_net",
+    "ioctl$KGPT_VHOST_GET_BACKEND_FEATURES": "ioctl$KGPT_VHOST_GET_BACKEND_FEATURES(fd fd_vhost_net, cmd const[VHOST_GET_BACKEND_FEATURES], arg ptr[out, int64])",
+    "ioctl$KGPT_VHOST_SET_BACKEND_FEATURES": "ioctl$KGPT_VHOST_SET_BACKEND_FEATURES(fd fd_vhost_net, cmd const[VHOST_SET_BACKEND_FEATURES], arg ptr[in, int64])",
+    "ioctl$KGPT_VHOST_GET_VRING_BUSYLOOP_TIMEOUT": "ioctl$KGPT_VHOST_GET_VRING_BUSYLOOP_TIMEOUT(fd fd_vhost_net, cmd const[VHOST_GET_VRING_BUSYLOOP_TIMEOUT], arg ptr[out, vhost_vring_state])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_net"
+  ],
+  "includes": [
+    "uapi/linux/vhost.h",
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "vhost_vring_state": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/vhost_vsock_fops#drivers_vhost_vsock.c:912.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/vhost_vsock_fops#drivers_vhost_vsock.c:912.json
@@ -1,0 +1,318 @@
+{
+  "open": {
+    "filename": "/dev/vhost-vsock",
+    "fd_name": "fd_vhost_vsock",
+    "spec": "openat$KGPT_vhost_vsock(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vhost-vsock\"]], flags const[O_RDWR], mode const[0]) fd_vhost_vsock"
+  },
+  "resources": {
+    "fd_vhost_vsock": {
+      "type": "fd",
+      "spec": "resource fd_vhost_vsock[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/vhost/vsock.c:912",
+  "ioctls": {
+    "VHOST_GET_BACKEND_FEATURES": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VHOST_SET_BACKEND_FEATURES": {
+      "arg": "int64",
+      "arg_name_in_usage": "features",
+      "arg_inference": null
+    },
+    "VHOST_GET_VRING_BUSYLOOP_TIMEOUT": {
+      "arg": "ptr[out, vhost_vring_state]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {
+    "VHOST_VSOCK_SET_GUEST_CID": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "guest_cid"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_vsock_set_cid"
+        ],
+        "type": [],
+        "usage": [
+          "u64 guest_cid;",
+          "if (copy_from_user(&guest_cid, argp, sizeof(guest_cid)))",
+          "return vhost_vsock_set_cid(vsock, guest_cid);"
+        ]
+      }
+    },
+    "VHOST_VSOCK_SET_RUNNING": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "start"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_vsock_start",
+          "vhost_vsock_stop"
+        ],
+        "type": [],
+        "usage": [
+          "int start;",
+          "if (copy_from_user(&start, argp, sizeof(start)))",
+          "if (start)",
+          "return vhost_vsock_start(vsock);",
+          "else",
+          "return vhost_vsock_stop(vsock, true);"
+        ]
+      }
+    },
+    "VHOST_GET_FEATURES": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VHOST_SET_FEATURES": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "features"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_vsock_set_features"
+        ],
+        "type": [],
+        "usage": [
+          "u64 features;",
+          "if (copy_from_user(&features, argp, sizeof(features)))",
+          "return vhost_vsock_set_features(vsock, features);"
+        ]
+      }
+    },
+    "VHOST_SET_OWNER": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "VHOST_SET_MEM_TABLE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_set_memory"
+        ],
+        "type": [],
+        "usage": [
+          "r = vhost_set_memory(d, argp);"
+        ]
+      }
+    },
+    "VHOST_SET_LOG_BASE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "if (copy_from_user(&p, argp, sizeof p)) {",
+          "r = -EFAULT;",
+          "break;",
+          "}"
+        ]
+      }
+    },
+    "VHOST_SET_LOG_FD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "r = get_user(fd, (int __user *)argp);",
+          "if (r < 0)",
+          "break;"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_NUM": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_vring_set_num_addr"
+        ],
+        "type": [],
+        "usage": [
+          "return vhost_vring_set_num_addr(d, vq, ioctl, argp);"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_ADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_vring_set_num_addr"
+        ],
+        "type": [],
+        "usage": [
+          "return vhost_vring_set_num_addr(d, vq, ioctl, argp);"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_BASE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "if (copy_from_user(&s, argp, sizeof s)) {",
+          "r = -EFAULT;",
+          "break;",
+          "}"
+        ]
+      }
+    },
+    "VHOST_GET_VRING_BASE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "if (copy_to_user(argp, &s, sizeof s))",
+          "r = -EFAULT;"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_KICK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "if (copy_from_user(&f, argp, sizeof f)) {",
+          "r = -EFAULT;",
+          "break;",
+          "}"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_CALL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "if (copy_from_user(&f, argp, sizeof f)) {",
+          "r = -EFAULT;",
+          "break;",
+          "}"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_ERR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "if (copy_from_user(&f, argp, sizeof f)) {",
+          "r = -EFAULT;",
+          "break;",
+          "}"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_ENDIAN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_set_vring_endian"
+        ],
+        "type": [],
+        "usage": [
+          "r = vhost_set_vring_endian(vq, argp);"
+        ]
+      }
+    },
+    "VHOST_GET_VRING_ENDIAN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "vhost_get_vring_endian"
+        ],
+        "type": [],
+        "usage": [
+          "r = vhost_get_vring_endian(vq, idx, argp);"
+        ]
+      }
+    },
+    "VHOST_SET_VRING_BUSYLOOP_TIMEOUT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [],
+        "usage": [
+          "if (copy_from_user(&s, argp, sizeof(s))) {",
+          "r = -EFAULT;",
+          "break;",
+          "}"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_vhost_vsock": "openat$KGPT_vhost_vsock(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vhost-vsock\"]], flags const[O_RDWR], mode const[0]) fd_vhost_vsock",
+    "ioctl$KGPT_VHOST_GET_BACKEND_FEATURES": "ioctl$KGPT_VHOST_GET_BACKEND_FEATURES(fd fd_vhost_vsock, cmd const[VHOST_GET_BACKEND_FEATURES], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_VHOST_SET_BACKEND_FEATURES": "ioctl$KGPT_VHOST_SET_BACKEND_FEATURES(fd fd_vhost_vsock, cmd const[VHOST_SET_BACKEND_FEATURES], arg int64)",
+    "ioctl$KGPT_VHOST_GET_VRING_BUSYLOOP_TIMEOUT": "ioctl$KGPT_VHOST_GET_VRING_BUSYLOOP_TIMEOUT(fd fd_vhost_vsock, cmd const[VHOST_GET_VRING_BUSYLOOP_TIMEOUT], arg ptr[out, vhost_vring_state])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_vhost_vsock"
+  ],
+  "includes": [
+    "uapi/linux/vhost.h",
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "vhost_vring_state": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/vmwgfx_driver_fops#drivers_gpu_drm_vmwgfx_vmwgfx_drv.c:1598.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/vmwgfx_driver_fops#drivers_gpu_drm_vmwgfx_vmwgfx_drv.c:1598.json
@@ -1,0 +1,45 @@
+{
+  "open": {
+    "filename": "/dev/dri/card#",
+    "fd_name": "fd_vmwgfx",
+    "spec": "syz_open_dev$KGPT_vmwgfx(dev ptr[in, string[\"/dev/dri/card#\"]], id proc[0, 1], flags flags[open_flags]) fd_vmwgfx"
+  },
+  "resources": {
+    "fd_vmwgfx": {
+      "type": "fd",
+      "spec": "resource fd_vmwgfx[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/drivers/gpu/drm/vmwgfx/vmwgfx_drv.c:1598",
+  "ioctls": {
+    "DRM_VMW_EXECBUF": {
+      "arg": "ptr[in, drm_vmw_execbuf_arg]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "DRM_VMW_UPDATE_LAYOUT": {
+      "arg": "ptr[in, drm_vmw_update_layout]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "types": {
+    "drm_vmw_execbuf_arg": "drm_vmw_execbuf_arg {\n\tcommands\tintptr\n\tcommand_size\tint32\n\tthrottle_us\tint32\n\tfence_rep\tintptr\n\tversion\tint32\n\tflags\tint32\n\tcontext_handle\tint32\n\timported_fence_fd\tint32\n}",
+    "drm_vmw_update_layout": "type drm_vmw_update_layout ptr[in, array[int8]]"
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "syz_open_dev$KGPT_vmwgfx": "syz_open_dev$KGPT_vmwgfx(dev ptr[in, string[\"/dev/dri/card#\"]], id proc[0, 1], flags flags[open_flags]) fd_vmwgfx",
+    "ioctl$KGPT_DRM_VMW_EXECBUF": "ioctl$KGPT_DRM_VMW_EXECBUF(fd fd_vmwgfx, cmd const[DRM_VMW_EXECBUF], arg ptr[in, drm_vmw_execbuf_arg])",
+    "ioctl$KGPT_DRM_VMW_UPDATE_LAYOUT": "ioctl$KGPT_DRM_VMW_UPDATE_LAYOUT(fd fd_vmwgfx, cmd const[DRM_VMW_UPDATE_LAYOUT], arg ptr[in, drm_vmw_update_layout])"
+  },
+  "init_syscalls": [
+    "syz_open_dev$KGPT_vmwgfx"
+  ],
+  "includes": [
+    "uapi/drm/vmwgfx_drm.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-driver-spec/vsock_device_ops#net_vmw_vsock_af_vsock.c:2419.json
+++ b/generated-specs/specs-6.7/correct-driver-spec/vsock_device_ops#net_vmw_vsock_af_vsock.c:2419.json
@@ -1,0 +1,38 @@
+{
+  "open": {
+    "filename": "/dev/vsock",
+    "fd_name": "fd_vsock",
+    "spec": "openat$KGPT_vmw_vsock(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vsock\"]], flags const[O_RDWR], mode const[0]) fd_vsock"
+  },
+  "resources": {
+    "fd_vsock": {
+      "type": "fd",
+      "spec": "resource fd_vsock[fd]"
+    }
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/vmw_vsock/af_vsock.c:2419",
+  "ioctls": {
+    "IOCTL_VM_SOCKETS_GET_LOCAL_CID": {
+      "arg": "ptr[out, int32]",
+      "arg_name_in_usage": "p",
+      "arg_inference": null
+    }
+  },
+  "types": {},
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "syscall_specs": {
+    "openat$KGPT_vmw_vsock": "openat$KGPT_vmw_vsock(fd const[AT_FDCWD], file ptr[in, string[\"/dev/vsock\"]], flags const[O_RDWR], mode const[0]) fd_vsock",
+    "ioctl$KGPT_IOCTL_VM_SOCKETS_GET_LOCAL_CID": "ioctl$KGPT_IOCTL_VM_SOCKETS_GET_LOCAL_CID(fd fd_vsock, cmd const[IOCTL_VM_SOCKETS_GET_LOCAL_CID], arg ptr[out, int32])"
+  },
+  "init_syscalls": [
+    "openat$KGPT_vmw_vsock"
+  ],
+  "includes": [
+    "uapi/linux/vm_sockets.h",
+    "uapi/linux/fcntl.h",
+    "uapi/asm-generic/fcntl.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/bcm_ops#net_can_bcm.c:1690.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/bcm_ops#net_can_bcm.c:1690.json
@@ -1,0 +1,48 @@
+{
+  "socket": {
+    "domain": "AF_CAN",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_can_bcm(domain const[AF_CAN], type const[SOCK_DGRAM], proto const[CAN_BCM]) sock_can_bcm"
+  },
+  "resources": {
+    "sock_can_bcm": {
+      "type": "sock",
+      "spec": "resource sock_can_bcm[sock]"
+    }
+  },
+  "types": {
+    "CAN_BCM": "define CAN_BCM 2"
+  },
+  "socket_addr": "sockaddr",
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "bcm_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "bcm_sock_no_ioctlcmd",
+    "sendmsg": "bcm_sendmsg",
+    "recvmsg": "bcm_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/can/bcm.c:1690",
+  "ops_name": "bcm_ops",
+  "syscall_specs": {
+    "socket$KGPT_can_bcm": "socket$KGPT_can_bcm(domain const[AF_CAN], type const[SOCK_DGRAM], proto const[CAN_BCM]) sock_can_bcm",
+    "bind$KGPT_bcm_ops": "bind$KGPT_bcm_ops(fd sock_can_bcm, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_bcm_ops": "connect$KGPT_bcm_ops(fd sock_can_bcm, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_bcm_ops": "accept4$KGPT_bcm_ops(fd sock_can_bcm, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_can_bcm",
+    "sendto$KGPT_bcm_ops": "sendto$KGPT_bcm_ops(fd sock_can_bcm, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_bcm_ops": "recvfrom$KGPT_bcm_ops(fd sock_can_bcm, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_can_bcm"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/can.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/bnep_sock_ops#net_bluetooth_bnep_sock.c:172.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/bnep_sock_ops#net_bluetooth_bnep_sock.c:172.json
@@ -1,0 +1,138 @@
+{
+  "socket": {
+    "domain": "AF_BLUETOOTH",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_bnep(domain const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[0]) sock_bnep"
+  },
+  "resources": {
+    "sock_bnep": {
+      "type": "sock",
+      "spec": "resource sock_bnep[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "BNEPCONNADD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "bnep_add_connection"
+        ],
+        "type": [
+          "bnep_connadd_req"
+        ],
+        "usage": [
+          "if (copy_from_user(&ca, argp, sizeof(ca)))",
+          "err = bnep_add_connection(&ca, nsock);",
+          "if (copy_to_user(argp, &ca, sizeof(ca)))"
+        ]
+      }
+    },
+    "BNEPCONNDEL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "bnep_del_connection"
+        ],
+        "type": [
+          "bnep_conndel_req"
+        ],
+        "usage": [
+          "if (copy_from_user(&cd, argp, sizeof(cd)))",
+          "return bnep_del_connection(&cd);"
+        ]
+      }
+    },
+    "BNEPGETCONNLIST": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "bnep_get_connlist"
+        ],
+        "type": [
+          "bnep_connlist_req"
+        ],
+        "usage": [
+          "if (copy_from_user(&cl, argp, sizeof(cl)))",
+          "err = bnep_get_connlist(&cl);",
+          "if (!err && copy_to_user(argp, &cl, sizeof(cl)))"
+        ]
+      }
+    },
+    "BNEPGETCONNINFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "bnep_get_conninfo"
+        ],
+        "type": [
+          "bnep_conninfo"
+        ],
+        "usage": [
+          "if (copy_from_user(&ci, argp, sizeof(ci)))",
+          "err = bnep_get_conninfo(&ci);",
+          "if (!err && copy_to_user(argp, &ci, sizeof(ci)))"
+        ]
+      }
+    },
+    "BNEPGETSUPPFEAT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "__u32"
+        ],
+        "usage": [
+          "if (copy_to_user(argp, &supp_feat, sizeof(supp_feat)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "ioctl": "bnep_sock_ioctl",
+    "sendmsg": "sock_no_sendmsg",
+    "recvmsg": "sock_no_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/bluetooth/bnep/sock.c:172",
+  "ops_name": "bnep_sock_ops",
+  "syscall_specs": {
+    "socket$KGPT_bnep": "socket$KGPT_bnep(domain const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[0]) sock_bnep",
+    "bind$KGPT_bnep_sock_ops": "bind$KGPT_bnep_sock_ops(fd sock_bnep, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_bnep_sock_ops": "connect$KGPT_bnep_sock_ops(fd sock_bnep, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_bnep_sock_ops": "accept4$KGPT_bnep_sock_ops(fd sock_bnep, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_bnep",
+    "sendto$KGPT_bnep_sock_ops": "sendto$KGPT_bnep_sock_ops(fd sock_bnep, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_bnep_sock_ops": "recvfrom$KGPT_bnep_sock_ops(fd sock_bnep, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_bnep"
+  ],
+  "includes": [
+    "linux/net.h",
+    "net/bluetooth/bluetooth.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/caif_seqpacket_ops#net_caif_caif_socket.c:962.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/caif_seqpacket_ops#net_caif_caif_socket.c:962.json
@@ -1,0 +1,64 @@
+{
+  "socket": {
+    "domain": "PF_CAIF",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_caif(domain const[PF_CAIF], type const[SOCK_SEQPACKET], proto const[0]) sock_caif"
+  },
+  "resources": {
+    "sock_caif": {
+      "type": "sock",
+      "spec": "resource sock_caif[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr",
+  "setsockopt": {
+    "CAIFSO_LINK_SELECT": {
+      "level": "SOL_CAIF",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "CAIFSO_REQ_PARAM": {
+      "level": "SOL_CAIF",
+      "val": "ptr[in, array[int8]]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "caif_connect",
+    "accept": "sock_no_accept",
+    "poll": "caif_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "caif_seqpkt_sendmsg",
+    "recvmsg": "caif_seqpkt_recvmsg",
+    "setsockopt": "setsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/caif/caif_socket.c:962",
+  "ops_name": "caif_seqpacket_ops",
+  "syscall_specs": {
+    "socket$KGPT_caif": "socket$KGPT_caif(domain const[PF_CAIF], type const[SOCK_SEQPACKET], proto const[0]) sock_caif",
+    "bind$KGPT_caif_seqpacket_ops": "bind$KGPT_caif_seqpacket_ops(fd sock_caif, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_caif_seqpacket_ops": "connect$KGPT_caif_seqpacket_ops(fd sock_caif, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_caif_seqpacket_ops": "accept4$KGPT_caif_seqpacket_ops(fd sock_caif, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_caif",
+    "sendto$KGPT_caif_seqpacket_ops": "sendto$KGPT_caif_seqpacket_ops(fd sock_caif, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_caif_seqpacket_ops": "recvfrom$KGPT_caif_seqpacket_ops(fd sock_caif, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "setsockopt$KGPT_CAIFSO_LINK_SELECT": "setsockopt$KGPT_CAIFSO_LINK_SELECT(fd sock_caif, level const[SOL_CAIF], opt const[CAIFSO_LINK_SELECT], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_CAIFSO_REQ_PARAM": "setsockopt$KGPT_CAIFSO_REQ_PARAM(fd sock_caif, level const[SOL_CAIF], opt const[CAIFSO_REQ_PARAM], val ptr[in, array[int8]], len len[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_caif"
+  ],
+  "includes": [
+    "uapi/linux/caif/caif_socket.h",
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/caif_stream_ops#net_caif_caif_socket.c:981.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/caif_stream_ops#net_caif_caif_socket.c:981.json
@@ -1,0 +1,64 @@
+{
+  "socket": {
+    "domain": "PF_CAIF",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_caif_stream(domain const[PF_CAIF], type const[SOCK_STREAM], proto const[0]) sock_caif_stream"
+  },
+  "resources": {
+    "sock_caif_stream": {
+      "type": "sock",
+      "spec": "resource sock_caif_stream[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr",
+  "setsockopt": {
+    "CAIFSO_LINK_SELECT": {
+      "level": "SOL_CAIF",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "CAIFSO_REQ_PARAM": {
+      "level": "SOL_CAIF",
+      "val": "ptr[in, array[int8]]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "caif_connect",
+    "accept": "sock_no_accept",
+    "poll": "caif_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "caif_stream_sendmsg",
+    "recvmsg": "caif_stream_recvmsg",
+    "setsockopt": "setsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/caif/caif_socket.c:981",
+  "ops_name": "caif_stream_ops",
+  "syscall_specs": {
+    "socket$KGPT_caif_stream": "socket$KGPT_caif_stream(domain const[PF_CAIF], type const[SOCK_STREAM], proto const[0]) sock_caif_stream",
+    "bind$KGPT_caif_stream_ops": "bind$KGPT_caif_stream_ops(fd sock_caif_stream, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_caif_stream_ops": "connect$KGPT_caif_stream_ops(fd sock_caif_stream, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_caif_stream_ops": "accept4$KGPT_caif_stream_ops(fd sock_caif_stream, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_caif_stream",
+    "sendto$KGPT_caif_stream_ops": "sendto$KGPT_caif_stream_ops(fd sock_caif_stream, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_caif_stream_ops": "recvfrom$KGPT_caif_stream_ops(fd sock_caif_stream, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "setsockopt$KGPT_CAIFSO_LINK_SELECT": "setsockopt$KGPT_CAIFSO_LINK_SELECT(fd sock_caif_stream, level const[SOL_CAIF], opt const[CAIFSO_LINK_SELECT], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_CAIFSO_REQ_PARAM": "setsockopt$KGPT_CAIFSO_REQ_PARAM(fd sock_caif_stream, level const[SOL_CAIF], opt const[CAIFSO_REQ_PARAM], val ptr[in, array[int8]], len len[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_caif_stream"
+  ],
+  "includes": [
+    "uapi/linux/caif/caif_socket.h",
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/cmtp_sock_ops#net_bluetooth_cmtp_sock.c:174.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/cmtp_sock_ops#net_bluetooth_cmtp_sock.c:174.json
@@ -1,0 +1,127 @@
+{
+  "socket": {
+    "domain": "AF_BLUETOOTH",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_cmtp(domain const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[0]) sock_cmtp"
+  },
+  "resources": {
+    "sock_cmtp": {
+      "type": "sock",
+      "spec": "resource sock_cmtp[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "CMTPCONNADD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cmtp_add_connection"
+        ],
+        "type": [
+          "cmtp_connadd_req"
+        ],
+        "usage": [
+          "struct cmtp_connadd_req ca;",
+          "if (copy_from_user(&ca, argp, sizeof(ca)))",
+          "err = cmtp_add_connection(&ca, nsock);",
+          "if (copy_to_user(argp, &ca, sizeof(ca)))"
+        ]
+      }
+    },
+    "CMTPCONNDEL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cmtp_del_connection"
+        ],
+        "type": [
+          "cmtp_conndel_req"
+        ],
+        "usage": [
+          "struct cmtp_conndel_req cd;",
+          "if (copy_from_user(&cd, argp, sizeof(cd)))",
+          "return cmtp_del_connection(&cd);"
+        ]
+      }
+    },
+    "CMTPGETCONNLIST": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cmtp_get_connlist"
+        ],
+        "type": [
+          "cmtp_connlist_req"
+        ],
+        "usage": [
+          "struct cmtp_connlist_req cl;",
+          "if (copy_from_user(&cl, argp, sizeof(cl)))",
+          "err = cmtp_get_connlist(&cl);",
+          "if (copy_to_user(argp, &cl, sizeof(cl)))"
+        ]
+      }
+    },
+    "CMTPGETCONNINFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "cmtp_get_conninfo"
+        ],
+        "type": [
+          "cmtp_conninfo"
+        ],
+        "usage": [
+          "struct cmtp_conninfo ci;",
+          "if (copy_from_user(&ci, argp, sizeof(ci)))",
+          "err = cmtp_get_conninfo(&ci);",
+          "if (copy_to_user(argp, &ci, sizeof(ci)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "ioctl": "cmtp_sock_ioctl",
+    "sendmsg": "sock_no_sendmsg",
+    "recvmsg": "sock_no_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/bluetooth/cmtp/sock.c:174",
+  "ops_name": "cmtp_sock_ops",
+  "syscall_specs": {
+    "socket$KGPT_cmtp": "socket$KGPT_cmtp(domain const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[0]) sock_cmtp",
+    "bind$KGPT_cmtp_sock_ops": "bind$KGPT_cmtp_sock_ops(fd sock_cmtp, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_cmtp_sock_ops": "connect$KGPT_cmtp_sock_ops(fd sock_cmtp, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_cmtp_sock_ops": "accept4$KGPT_cmtp_sock_ops(fd sock_cmtp, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_cmtp",
+    "sendto$KGPT_cmtp_sock_ops": "sendto$KGPT_cmtp_sock_ops(fd sock_cmtp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_cmtp_sock_ops": "recvfrom$KGPT_cmtp_sock_ops(fd sock_cmtp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_cmtp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/hidp_sock_ops#net_bluetooth_hidp_sock.c:223.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/hidp_sock_ops#net_bluetooth_hidp_sock.c:223.json
@@ -1,0 +1,127 @@
+{
+  "socket": {
+    "domain": "AF_BLUETOOTH",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_hidp(domain const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[0]) sock_hidp"
+  },
+  "resources": {
+    "sock_hidp": {
+      "type": "sock",
+      "spec": "resource sock_hidp[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "HIDPCONNADD": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp",
+        "ca"
+      ],
+      "arg_inference": {
+        "function": [
+          "hidp_connection_add"
+        ],
+        "type": [
+          "hidp_connadd_req"
+        ],
+        "usage": [
+          "if (copy_from_user(&ca, argp, sizeof(ca)))",
+          "err = hidp_connection_add(&ca, csock, isock);",
+          "if (!err && copy_to_user(argp, &ca, sizeof(ca)))"
+        ]
+      }
+    },
+    "HIDPCONNDEL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp",
+        "cd"
+      ],
+      "arg_inference": {
+        "function": [
+          "hidp_connection_del"
+        ],
+        "type": [
+          "hidp_conndel_req"
+        ],
+        "usage": [
+          "if (copy_from_user(&cd, argp, sizeof(cd)))",
+          "return hidp_connection_del(&cd);"
+        ]
+      }
+    },
+    "HIDPGETCONNLIST": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp",
+        "cl"
+      ],
+      "arg_inference": {
+        "function": [
+          "hidp_get_connlist"
+        ],
+        "type": [
+          "hidp_connlist_req"
+        ],
+        "usage": [
+          "if (copy_from_user(&cl, argp, sizeof(cl)))",
+          "err = hidp_get_connlist(&cl);",
+          "if (!err && copy_to_user(argp, &cl, sizeof(cl)))"
+        ]
+      }
+    },
+    "HIDPGETCONNINFO": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp",
+        "ci"
+      ],
+      "arg_inference": {
+        "function": [
+          "hidp_get_conninfo"
+        ],
+        "type": [
+          "hidp_conninfo"
+        ],
+        "usage": [
+          "if (copy_from_user(&ci, argp, sizeof(ci)))",
+          "err = hidp_get_conninfo(&ci);",
+          "if (!err && copy_to_user(argp, &ci, sizeof(ci)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "ioctl": "hidp_sock_ioctl",
+    "sendmsg": "sock_no_sendmsg",
+    "recvmsg": "sock_no_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/bluetooth/hidp/sock.c:223",
+  "ops_name": "hidp_sock_ops",
+  "syscall_specs": {
+    "socket$KGPT_hidp": "socket$KGPT_hidp(domain const[AF_BLUETOOTH], type const[SOCK_RAW], proto const[0]) sock_hidp",
+    "bind$KGPT_hidp_sock_ops": "bind$KGPT_hidp_sock_ops(fd sock_hidp, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_hidp_sock_ops": "connect$KGPT_hidp_sock_ops(fd sock_hidp, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_hidp_sock_ops": "accept4$KGPT_hidp_sock_ops(fd sock_hidp, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_hidp",
+    "sendto$KGPT_hidp_sock_ops": "sendto$KGPT_hidp_sock_ops(fd sock_hidp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_hidp_sock_ops": "recvfrom$KGPT_hidp_sock_ops(fd sock_hidp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_hidp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/ieee802154_dgram_ops#net_ieee802154_socket.c:972.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/ieee802154_dgram_ops#net_ieee802154_socket.c:972.json
@@ -1,0 +1,182 @@
+{
+  "socket": {
+    "domain": "AF_IEEE802154",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_ieee802154(domain const[AF_IEEE802154], type const[SOCK_DGRAM], proto const[0]) sock_ieee802154"
+  },
+  "resources": {
+    "sock_ieee802154": {
+      "type": "sock",
+      "spec": "resource sock_ieee802154[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_ieee802154",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "ieee802154_dev_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "return ieee802154_dev_ioctl(sk, (struct ifreq __user *)arg, cmd);"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "ieee802154_dev_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "return ieee802154_dev_ioctl(sk, (struct ifreq __user *)arg, cmd);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg",
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(karg, (int __user *)arg))\n\t\treturn -EFAULT;",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "ieee802154_sock_bind",
+    "connect": "ieee802154_sock_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "ieee802154_sock_ioctl",
+    "sendmsg": "ieee802154_sock_sendmsg",
+    "recvmsg": "sock_common_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/ieee802154/socket.c:972",
+  "ops_name": "ieee802154_dgram_ops",
+  "syscall_specs": {
+    "socket$KGPT_ieee802154": "socket$KGPT_ieee802154(domain const[AF_IEEE802154], type const[SOCK_DGRAM], proto const[0]) sock_ieee802154",
+    "bind$KGPT_ieee802154_dgram_ops": "bind$KGPT_ieee802154_dgram_ops(fd sock_ieee802154, addr ptr[in, sockaddr_ieee802154], addrlen len[addr])",
+    "connect$KGPT_ieee802154_dgram_ops": "connect$KGPT_ieee802154_dgram_ops(fd sock_ieee802154, addr ptr[in, sockaddr_ieee802154], addrlen len[addr])",
+    "accept4$KGPT_ieee802154_dgram_ops": "accept4$KGPT_ieee802154_dgram_ops(fd sock_ieee802154, peer ptr[out, sockaddr_ieee802154, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_ieee802154",
+    "sendto$KGPT_ieee802154_dgram_ops": "sendto$KGPT_ieee802154_dgram_ops(fd sock_ieee802154, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_ieee802154, opt], addrlen len[addr])",
+    "recvfrom$KGPT_ieee802154_dgram_ops": "recvfrom$KGPT_ieee802154_dgram_ops(fd sock_ieee802154, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_ieee802154, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_ieee802154, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_ieee802154"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_ieee802154": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/ieee802154_dgram_prot#net_ieee802154_socket.c:954.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/ieee802154_dgram_prot#net_ieee802154_socket.c:954.json
@@ -1,0 +1,142 @@
+{
+  "socket": {
+    "domain": "AF_IEEE802154",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_ieee802154(domain const[AF_IEEE802154], type const[SOCK_DGRAM], proto const[0]) sock_ieee802154"
+  },
+  "resources": {
+    "sock_ieee802154": {
+      "type": "sock",
+      "spec": "resource sock_ieee802154[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_ieee802154",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk_wmem_alloc_get"
+        ],
+        "type": [],
+        "usage": [
+          "*karg = sk_wmem_alloc_get(sk);"
+        ]
+      }
+    },
+    "SIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "skb_peek",
+          "ieee802154_hdr_length"
+        ],
+        "type": [
+          "sk_buff"
+        ],
+        "usage": [
+          "struct sk_buff *skb;",
+          "*karg = 0;",
+          "spin_lock_bh(&sk->sk_receive_queue.lock);",
+          "skb = skb_peek(&sk->sk_receive_queue);",
+          "if (skb) {",
+          "    *karg = skb->len - ieee802154_hdr_length(skb);",
+          "}",
+          "spin_unlock_bh(&sk->sk_receive_queue.lock);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "WPAN_WANTACK": {
+      "level": "SOL_WPAN",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "WPAN_WANTLQI": {
+      "level": "SOL_WPAN",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "WPAN_SECURITY": {
+      "level": "SOL_WPAN",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "WPAN_SECURITY_LEVEL": {
+      "level": "SOL_WPAN",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "WPAN_WANTACK": {
+      "level": "SOL_IEEE802154",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "WPAN_WANTLQI": {
+      "level": "SOL_IEEE802154",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "WPAN_SECURITY": {
+      "level": "SOL_IEEE802154",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "WPAN_SECURITY_LEVEL": {
+      "level": "SOL_IEEE802154",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "dgram_bind",
+    "connect": "dgram_connect",
+    "ioctl": "dgram_ioctl",
+    "sendmsg": "dgram_sendmsg",
+    "recvmsg": "dgram_recvmsg",
+    "setsockopt": "dgram_setsockopt",
+    "getsockopt": "dgram_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/ieee802154/socket.c:954",
+  "ops_name": "ieee802154_dgram_prot",
+  "syscall_specs": {
+    "socket$KGPT_ieee802154": "socket$KGPT_ieee802154(domain const[AF_IEEE802154], type const[SOCK_DGRAM], proto const[0]) sock_ieee802154",
+    "bind$KGPT_ieee802154_dgram_prot": "bind$KGPT_ieee802154_dgram_prot(fd sock_ieee802154, addr ptr[in, sockaddr_ieee802154], addrlen len[addr])",
+    "connect$KGPT_ieee802154_dgram_prot": "connect$KGPT_ieee802154_dgram_prot(fd sock_ieee802154, addr ptr[in, sockaddr_ieee802154], addrlen len[addr])",
+    "sendto$KGPT_ieee802154_dgram_prot": "sendto$KGPT_ieee802154_dgram_prot(fd sock_ieee802154, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_ieee802154, opt], addrlen len[addr])",
+    "recvfrom$KGPT_ieee802154_dgram_prot": "recvfrom$KGPT_ieee802154_dgram_prot(fd sock_ieee802154, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_ieee802154, opt], addrlen len[addr])",
+    "getsockopt$KGPT_WPAN_WANTACK": "getsockopt$KGPT_WPAN_WANTACK(fd sock_ieee802154, level const[SOL_IEEE802154], opt const[WPAN_WANTACK], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_WPAN_WANTLQI": "getsockopt$KGPT_WPAN_WANTLQI(fd sock_ieee802154, level const[SOL_IEEE802154], opt const[WPAN_WANTLQI], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_WPAN_SECURITY": "getsockopt$KGPT_WPAN_SECURITY(fd sock_ieee802154, level const[SOL_IEEE802154], opt const[WPAN_SECURITY], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_WPAN_SECURITY_LEVEL": "getsockopt$KGPT_WPAN_SECURITY_LEVEL(fd sock_ieee802154, level const[SOL_IEEE802154], opt const[WPAN_SECURITY_LEVEL], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_ieee802154"
+  ],
+  "includes": [
+    "linux/net.h",
+    "net/af_ieee802154.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/ieee802154_raw_ops#net_ieee802154_socket.c:410.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/ieee802154_raw_ops#net_ieee802154_socket.c:410.json
@@ -1,0 +1,184 @@
+{
+  "socket": {
+    "domain": "AF_IEEE802154",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_ieee802154(domain const[AF_IEEE802154], type flags[ieee802154_socket_type], proto const[0]) sock_ieee802154"
+  },
+  "resources": {
+    "sock_ieee802154": {
+      "type": "sock",
+      "spec": "resource sock_ieee802154[sock]"
+    }
+  },
+  "types": {
+    "ieee802154_socket_type": "ieee802154_socket_type = SOCK_RAW, SOCK_DGRAM"
+  },
+  "socket_addr": "sockaddr_ieee802154",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "ieee802154_dev_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "return ieee802154_dev_ioctl(sk, (struct ifreq __user *)arg, cmd);"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "ieee802154_dev_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "return ieee802154_dev_ioctl(sk, (struct ifreq __user *)arg, cmd);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg",
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(karg, (int __user *)arg))\n\t\treturn -EFAULT;",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "ieee802154_sock_bind",
+    "connect": "ieee802154_sock_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "ieee802154_sock_ioctl",
+    "sendmsg": "ieee802154_sock_sendmsg",
+    "recvmsg": "sock_common_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/ieee802154/socket.c:410",
+  "ops_name": "ieee802154_raw_ops",
+  "syscall_specs": {
+    "socket$KGPT_ieee802154": "socket$KGPT_ieee802154(domain const[AF_IEEE802154], type flags[ieee802154_socket_type], proto const[0]) sock_ieee802154",
+    "bind$KGPT_ieee802154_raw_ops": "bind$KGPT_ieee802154_raw_ops(fd sock_ieee802154, addr ptr[in, sockaddr_ieee802154], addrlen len[addr])",
+    "connect$KGPT_ieee802154_raw_ops": "connect$KGPT_ieee802154_raw_ops(fd sock_ieee802154, addr ptr[in, sockaddr_ieee802154], addrlen len[addr])",
+    "accept4$KGPT_ieee802154_raw_ops": "accept4$KGPT_ieee802154_raw_ops(fd sock_ieee802154, peer ptr[out, sockaddr_ieee802154, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_ieee802154",
+    "sendto$KGPT_ieee802154_raw_ops": "sendto$KGPT_ieee802154_raw_ops(fd sock_ieee802154, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_ieee802154, opt], addrlen len[addr])",
+    "recvfrom$KGPT_ieee802154_raw_ops": "recvfrom$KGPT_ieee802154_raw_ops(fd sock_ieee802154, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_ieee802154, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_ieee802154, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_ieee802154"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_ieee802154": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/inet6_dccp_ops#net_dccp_ipv6.c:1072.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/inet6_dccp_ops#net_dccp_ipv6.c:1072.json
@@ -1,0 +1,231 @@
+{
+  "socket": {
+    "domain": "AF_INET6",
+    "type": "SOCK_DCCP",
+    "spec": "socket$KGPT_inet6_dccp(domain const[AF_INET6], type const[SOCK_DCCP], proto const[IPPROTO_DCCP]) sock_inet6_dccp"
+  },
+  "resources": {
+    "sock_inet6_dccp": {
+      "type": "sock",
+      "spec": "resource sock_inet6_dccp[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_DCCP": "define IPPROTO_DCCP 33"
+  },
+  "socket_addr": "sockaddr_in6",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_add_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_add_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCDIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_del_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_del_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_set_dstaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_set_dstaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet6_bind",
+    "connect": "inet_stream_connect",
+    "accept": "inet_accept",
+    "poll": "dccp_poll",
+    "ioctl": "inet6_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "sock_common_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/dccp/ipv6.c:1072",
+  "ops_name": "inet6_dccp_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet6_dccp": "socket$KGPT_inet6_dccp(domain const[AF_INET6], type const[SOCK_DCCP], proto const[IPPROTO_DCCP]) sock_inet6_dccp",
+    "bind$KGPT_inet6_dccp_ops": "bind$KGPT_inet6_dccp_ops(fd sock_inet6_dccp, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "connect$KGPT_inet6_dccp_ops": "connect$KGPT_inet6_dccp_ops(fd sock_inet6_dccp, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "accept4$KGPT_inet6_dccp_ops": "accept4$KGPT_inet6_dccp_ops(fd sock_inet6_dccp, peer ptr[out, sockaddr_in6, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet6_dccp",
+    "sendto$KGPT_inet6_dccp_ops": "sendto$KGPT_inet6_dccp_ops(fd sock_inet6_dccp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "recvfrom$KGPT_inet6_dccp_ops": "recvfrom$KGPT_inet6_dccp_ops(fd sock_inet6_dccp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_inet6_dccp, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet6_dccp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in6": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/inet6_dgram_ops#net_ipv6_af_inet6.c:716.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/inet6_dgram_ops#net_ipv6_af_inet6.c:716.json
@@ -1,0 +1,231 @@
+{
+  "socket": {
+    "domain": "AF_INET6",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_inet6_udp(domain const[AF_INET6], type const[SOCK_DGRAM], proto const[IPPROTO_UDP]) sock_inet6_udp"
+  },
+  "resources": {
+    "sock_inet6_udp": {
+      "type": "sock",
+      "spec": "resource sock_inet6_udp[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_UDP": "define IPPROTO_UDP 17"
+  },
+  "socket_addr": "sockaddr_in6",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_add_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_add_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCDIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_del_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_del_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_set_dstaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_set_dstaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet6_bind",
+    "connect": "inet_dgram_connect",
+    "accept": "sock_no_accept",
+    "poll": "udp_poll",
+    "ioctl": "inet6_ioctl",
+    "sendmsg": "inet6_sendmsg",
+    "recvmsg": "inet6_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/ipv6/af_inet6.c:716",
+  "ops_name": "inet6_dgram_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet6_udp": "socket$KGPT_inet6_udp(domain const[AF_INET6], type const[SOCK_DGRAM], proto const[IPPROTO_UDP]) sock_inet6_udp",
+    "bind$KGPT_inet6_dgram_ops": "bind$KGPT_inet6_dgram_ops(fd sock_inet6_udp, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "connect$KGPT_inet6_dgram_ops": "connect$KGPT_inet6_dgram_ops(fd sock_inet6_udp, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "accept4$KGPT_inet6_dgram_ops": "accept4$KGPT_inet6_dgram_ops(fd sock_inet6_udp, peer ptr[out, sockaddr_in6, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet6_udp",
+    "sendto$KGPT_inet6_dgram_ops": "sendto$KGPT_inet6_dgram_ops(fd sock_inet6_udp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "recvfrom$KGPT_inet6_dgram_ops": "recvfrom$KGPT_inet6_dgram_ops(fd sock_inet6_udp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_inet6_udp, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet6_udp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in6": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/inet6_seqpacket_ops#net_sctp_ipv6.c:1077.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/inet6_seqpacket_ops#net_sctp_ipv6.c:1077.json
@@ -1,0 +1,231 @@
+{
+  "socket": {
+    "domain": "AF_INET6",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_inet6_sctp(domain const[AF_INET6], type const[SOCK_SEQPACKET], proto const[IPPROTO_SCTP]) sock_inet6_sctp"
+  },
+  "resources": {
+    "sock_inet6_sctp": {
+      "type": "sock",
+      "spec": "resource sock_inet6_sctp[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_SCTP": "define IPPROTO_SCTP 132"
+  },
+  "socket_addr": "sockaddr_in6",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_add_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_add_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCDIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_del_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_del_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_set_dstaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_set_dstaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet6_bind",
+    "connect": "sctp_inet_connect",
+    "accept": "inet_accept",
+    "poll": "sctp_poll",
+    "ioctl": "inet6_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "inet_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/sctp/ipv6.c:1077",
+  "ops_name": "inet6_seqpacket_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet6_sctp": "socket$KGPT_inet6_sctp(domain const[AF_INET6], type const[SOCK_SEQPACKET], proto const[IPPROTO_SCTP]) sock_inet6_sctp",
+    "bind$KGPT_inet6_seqpacket_ops": "bind$KGPT_inet6_seqpacket_ops(fd sock_inet6_sctp, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "connect$KGPT_inet6_seqpacket_ops": "connect$KGPT_inet6_seqpacket_ops(fd sock_inet6_sctp, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "accept4$KGPT_inet6_seqpacket_ops": "accept4$KGPT_inet6_seqpacket_ops(fd sock_inet6_sctp, peer ptr[out, sockaddr_in6, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet6_sctp",
+    "sendto$KGPT_inet6_seqpacket_ops": "sendto$KGPT_inet6_seqpacket_ops(fd sock_inet6_sctp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "recvfrom$KGPT_inet6_seqpacket_ops": "recvfrom$KGPT_inet6_seqpacket_ops(fd sock_inet6_sctp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_inet6_sctp, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet6_sctp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in6": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/inet6_sockraw_ops#net_ipv6_raw.c:1275.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/inet6_sockraw_ops#net_ipv6_raw.c:1275.json
@@ -1,0 +1,230 @@
+{
+  "socket": {
+    "domain": "AF_INET6",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_inet6_raw(domain const[AF_INET6], type const[SOCK_RAW], proto const[IPPROTO_RAW]) sock_inet6_raw"
+  },
+  "resources": {
+    "sock_inet6_raw": {
+      "type": "sock",
+      "spec": "resource sock_inet6_raw[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_RAW": "define IPPROTO_RAW 255"
+  },
+  "socket_addr": "sockaddr_in6",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_add_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_add_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCDIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_del_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_del_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_set_dstaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_set_dstaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet6_bind",
+    "connect": "inet_dgram_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "inet6_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "sock_common_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/ipv6/raw.c:1275",
+  "ops_name": "inet6_sockraw_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet6_raw": "socket$KGPT_inet6_raw(domain const[AF_INET6], type const[SOCK_RAW], proto const[IPPROTO_RAW]) sock_inet6_raw",
+    "bind$KGPT_inet6_sockraw_ops": "bind$KGPT_inet6_sockraw_ops(fd sock_inet6_raw, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "connect$KGPT_inet6_sockraw_ops": "connect$KGPT_inet6_sockraw_ops(fd sock_inet6_raw, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "accept4$KGPT_inet6_sockraw_ops": "accept4$KGPT_inet6_sockraw_ops(fd sock_inet6_raw, peer ptr[out, sockaddr_in6, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet6_raw",
+    "sendto$KGPT_inet6_sockraw_ops": "sendto$KGPT_inet6_sockraw_ops(fd sock_inet6_raw, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "recvfrom$KGPT_inet6_sockraw_ops": "recvfrom$KGPT_inet6_sockraw_ops(fd sock_inet6_raw, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_inet6_raw, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet6_raw"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in6": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/inet6_stream_ops#net_ipv6_af_inet6.c:683.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/inet6_stream_ops#net_ipv6_af_inet6.c:683.json
@@ -1,0 +1,231 @@
+{
+  "socket": {
+    "domain": "AF_INET6",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_inet6_tcp(domain const[AF_INET6], type const[SOCK_STREAM], proto const[IPPROTO_TCP]) sock_inet6_tcp"
+  },
+  "resources": {
+    "sock_inet6_tcp": {
+      "type": "sock",
+      "spec": "resource sock_inet6_tcp[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_TCP": "define IPPROTO_TCP 6"
+  },
+  "socket_addr": "sockaddr_in6",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_add_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_add_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCDIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_del_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_del_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_set_dstaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_set_dstaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet6_bind",
+    "connect": "inet_stream_connect",
+    "accept": "inet_accept",
+    "poll": "tcp_poll",
+    "ioctl": "inet6_ioctl",
+    "sendmsg": "inet6_sendmsg",
+    "recvmsg": "inet6_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/ipv6/af_inet6.c:683",
+  "ops_name": "inet6_stream_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet6_tcp": "socket$KGPT_inet6_tcp(domain const[AF_INET6], type const[SOCK_STREAM], proto const[IPPROTO_TCP]) sock_inet6_tcp",
+    "bind$KGPT_inet6_stream_ops": "bind$KGPT_inet6_stream_ops(fd sock_inet6_tcp, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "connect$KGPT_inet6_stream_ops": "connect$KGPT_inet6_stream_ops(fd sock_inet6_tcp, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "accept4$KGPT_inet6_stream_ops": "accept4$KGPT_inet6_stream_ops(fd sock_inet6_tcp, peer ptr[out, sockaddr_in6, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet6_tcp",
+    "sendto$KGPT_inet6_stream_ops": "sendto$KGPT_inet6_stream_ops(fd sock_inet6_tcp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "recvfrom$KGPT_inet6_stream_ops": "recvfrom$KGPT_inet6_stream_ops(fd sock_inet6_tcp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_inet6_tcp, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet6_tcp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in6": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/inet_dccp_ops#net_dccp_ipv4.c:991.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/inet_dccp_ops#net_dccp_ipv4.c:991.json
@@ -1,0 +1,439 @@
+{
+  "socket": {
+    "domain": "AF_INET",
+    "type": "SOCK_DCCP",
+    "spec": "socket$KGPT_inet_dccp_ops(domain const[AF_INET], type const[SOCK_DCCP], proto const[IPPROTO_DCCP]) sock_inet_dccp"
+  },
+  "resources": {
+    "sock_inet_dccp": {
+      "type": "sock",
+      "spec": "resource sock_inet_dccp[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_DCCP": "define IPPROTO_DCCP 33"
+  },
+  "socket_addr": "sockaddr_in",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCRTMSG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCDARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCSARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet_bind",
+    "connect": "inet_stream_connect",
+    "accept": "inet_accept",
+    "poll": "dccp_poll",
+    "ioctl": "inet_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "sock_common_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/dccp/ipv4.c:991",
+  "ops_name": "inet_dccp_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet_dccp_ops": "socket$KGPT_inet_dccp_ops(domain const[AF_INET], type const[SOCK_DCCP], proto const[IPPROTO_DCCP]) sock_inet_dccp",
+    "bind$KGPT_inet_dccp_ops": "bind$KGPT_inet_dccp_ops(fd sock_inet_dccp, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "connect$KGPT_inet_dccp_ops": "connect$KGPT_inet_dccp_ops(fd sock_inet_dccp, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "accept4$KGPT_inet_dccp_ops": "accept4$KGPT_inet_dccp_ops(fd sock_inet_dccp, peer ptr[out, sockaddr_in, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet_dccp",
+    "sendto$KGPT_inet_dccp_ops": "sendto$KGPT_inet_dccp_ops(fd sock_inet_dccp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "recvfrom$KGPT_inet_dccp_ops": "recvfrom$KGPT_inet_dccp_ops(fd sock_inet_dccp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_inet_dccp, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet_dccp_ops"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/inet_dgram_ops#net_ipv4_af_inet.c:1082.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/inet_dgram_ops#net_ipv4_af_inet.c:1082.json
@@ -1,0 +1,439 @@
+{
+  "socket": {
+    "domain": "AF_INET",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_inet_udplite(domain const[AF_INET], type const[SOCK_DGRAM], proto const[IPPROTO_UDPLITE]) sock_inet_udplite"
+  },
+  "resources": {
+    "sock_inet_udplite": {
+      "type": "sock",
+      "spec": "resource sock_inet_udplite[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_UDPLITE": "define IPPROTO_UDPLITE 136"
+  },
+  "socket_addr": "sockaddr_in",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCRTMSG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCDARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCSARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet_bind",
+    "connect": "inet_dgram_connect",
+    "accept": "sock_no_accept",
+    "poll": "udp_poll",
+    "ioctl": "inet_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "inet_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/ipv4/af_inet.c:1082",
+  "ops_name": "inet_dgram_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet_udplite": "socket$KGPT_inet_udplite(domain const[AF_INET], type const[SOCK_DGRAM], proto const[IPPROTO_UDPLITE]) sock_inet_udplite",
+    "bind$KGPT_inet_dgram_ops": "bind$KGPT_inet_dgram_ops(fd sock_inet_udplite, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "connect$KGPT_inet_dgram_ops": "connect$KGPT_inet_dgram_ops(fd sock_inet_udplite, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "accept4$KGPT_inet_dgram_ops": "accept4$KGPT_inet_dgram_ops(fd sock_inet_udplite, peer ptr[out, sockaddr_in, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet_udplite",
+    "sendto$KGPT_inet_dgram_ops": "sendto$KGPT_inet_dgram_ops(fd sock_inet_udplite, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "recvfrom$KGPT_inet_dgram_ops": "recvfrom$KGPT_inet_dgram_ops(fd sock_inet_udplite, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_inet_udplite, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet_udplite"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/inet_seqpacket_ops#net_sctp_protocol.c:1118.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/inet_seqpacket_ops#net_sctp_protocol.c:1118.json
@@ -1,0 +1,439 @@
+{
+  "socket": {
+    "domain": "AF_INET",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_inet_sctp(domain const[AF_INET], type const[SOCK_SEQPACKET], proto const[IPPROTO_SCTP]) sock_sctp"
+  },
+  "resources": {
+    "sock_sctp": {
+      "type": "sock",
+      "spec": "resource sock_sctp[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_SCTP": "define IPPROTO_SCTP 132"
+  },
+  "socket_addr": "sockaddr_in",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCRTMSG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCDARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCSARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet_bind",
+    "connect": "sctp_inet_connect",
+    "accept": "inet_accept",
+    "poll": "sctp_poll",
+    "ioctl": "inet_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "inet_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/sctp/protocol.c:1118",
+  "ops_name": "inet_seqpacket_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet_sctp": "socket$KGPT_inet_sctp(domain const[AF_INET], type const[SOCK_SEQPACKET], proto const[IPPROTO_SCTP]) sock_sctp",
+    "bind$KGPT_inet_seqpacket_ops": "bind$KGPT_inet_seqpacket_ops(fd sock_sctp, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "connect$KGPT_inet_seqpacket_ops": "connect$KGPT_inet_seqpacket_ops(fd sock_sctp, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "accept4$KGPT_inet_seqpacket_ops": "accept4$KGPT_inet_seqpacket_ops(fd sock_sctp, peer ptr[out, sockaddr_in, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_sctp",
+    "sendto$KGPT_inet_seqpacket_ops": "sendto$KGPT_inet_seqpacket_ops(fd sock_sctp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "recvfrom$KGPT_inet_seqpacket_ops": "recvfrom$KGPT_inet_seqpacket_ops(fd sock_sctp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_sctp, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet_sctp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/inet_sockraw_ops#net_ipv4_af_inet.c:1114.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/inet_sockraw_ops#net_ipv4_af_inet.c:1114.json
@@ -1,0 +1,439 @@
+{
+  "socket": {
+    "domain": "AF_INET",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_inet_raw(domain const[AF_INET], type const[SOCK_RAW], proto const[IPPROTO_IP]) sock_inet_raw"
+  },
+  "resources": {
+    "sock_inet_raw": {
+      "type": "sock",
+      "spec": "resource sock_inet_raw[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_IP": "define IPPROTO_IP 0"
+  },
+  "socket_addr": "sockaddr_in",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCRTMSG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCDARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCSARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet_bind",
+    "connect": "inet_dgram_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "inet_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "inet_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/ipv4/af_inet.c:1114",
+  "ops_name": "inet_sockraw_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet_raw": "socket$KGPT_inet_raw(domain const[AF_INET], type const[SOCK_RAW], proto const[IPPROTO_IP]) sock_inet_raw",
+    "bind$KGPT_inet_sockraw_ops": "bind$KGPT_inet_sockraw_ops(fd sock_inet_raw, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "connect$KGPT_inet_sockraw_ops": "connect$KGPT_inet_sockraw_ops(fd sock_inet_raw, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "accept4$KGPT_inet_sockraw_ops": "accept4$KGPT_inet_sockraw_ops(fd sock_inet_raw, peer ptr[out, sockaddr_in, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet_raw",
+    "sendto$KGPT_inet_sockraw_ops": "sendto$KGPT_inet_sockraw_ops(fd sock_inet_raw, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "recvfrom$KGPT_inet_sockraw_ops": "recvfrom$KGPT_inet_sockraw_ops(fd sock_inet_raw, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_inet_raw, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet_raw"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/inet_stream_ops#net_ipv4_af_inet.c:1048.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/inet_stream_ops#net_ipv4_af_inet.c:1048.json
@@ -1,0 +1,439 @@
+{
+  "socket": {
+    "domain": "AF_INET",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_inet_stream(domain const[AF_INET], type const[SOCK_STREAM], proto const[IPPROTO_TCP]) sock_inet_stream"
+  },
+  "resources": {
+    "sock_inet_stream": {
+      "type": "sock",
+      "spec": "resource sock_inet_stream[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_TCP": "define IPPROTO_TCP 6"
+  },
+  "socket_addr": "sockaddr_in",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCRTMSG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCDARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCSARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet_bind",
+    "connect": "inet_stream_connect",
+    "accept": "inet_accept",
+    "poll": "tcp_poll",
+    "ioctl": "inet_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "inet_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/ipv4/af_inet.c:1048",
+  "ops_name": "inet_stream_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet_stream": "socket$KGPT_inet_stream(domain const[AF_INET], type const[SOCK_STREAM], proto const[IPPROTO_TCP]) sock_inet_stream",
+    "bind$KGPT_inet_stream_ops": "bind$KGPT_inet_stream_ops(fd sock_inet_stream, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "connect$KGPT_inet_stream_ops": "connect$KGPT_inet_stream_ops(fd sock_inet_stream, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "accept4$KGPT_inet_stream_ops": "accept4$KGPT_inet_stream_ops(fd sock_inet_stream, peer ptr[out, sockaddr_in, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet_stream",
+    "sendto$KGPT_inet_stream_ops": "sendto$KGPT_inet_stream_ops(fd sock_inet_stream, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "recvfrom$KGPT_inet_stream_ops": "recvfrom$KGPT_inet_stream_ops(fd sock_inet_stream, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_inet_stream, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet_stream"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/isotp_ops#net_can_isotp.c:1674.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/isotp_ops#net_can_isotp.c:1674.json
@@ -1,0 +1,124 @@
+{
+  "socket": {
+    "domain": "PF_CAN",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_can_isotp(domain const[PF_CAN], type const[SOCK_DGRAM], proto const[CAN_ISOTP]) sock_can_isotp"
+  },
+  "resources": {
+    "sock_can_isotp": {
+      "type": "sock",
+      "spec": "resource sock_can_isotp[sock]"
+    }
+  },
+  "types": {
+    "CAN_ISOTP": "define CAN_ISOTP 6",
+    "can_isotp_options": "can_isotp_options {\n\tflags\tint32\n\tframe_txtime\tint32\n\text_address\tint8\n\ttxpad_content\tint8\n\trxpad_content\tint8\n\trx_ext_address\tint8\n}",
+    "can_isotp_fc_options": "can_isotp_fc_options {\n\tbs\tint8\n\tstmin\tint8\n\twftmax\tint8\n}",
+    "can_isotp_ll_options": "can_isotp_ll_options {\n\tmtu\tint8\n\ttx_dl\tint8\n\ttx_flags\tint8\n}"
+  },
+  "socket_addr": "sockaddr_can",
+  "setsockopt": {
+    "CAN_ISOTP_OPTS": {
+      "level": "SOL_CAN_ISOTP",
+      "val": "ptr[in, can_isotp_options]",
+      "len": "bytesize[val]"
+    },
+    "CAN_ISOTP_RECV_FC": {
+      "level": "SOL_CAN_ISOTP",
+      "val": "ptr[in, can_isotp_fc_options]",
+      "len": "bytesize[val]"
+    },
+    "CAN_ISOTP_TX_STMIN": {
+      "level": "SOL_CAN_ISOTP",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "CAN_ISOTP_RX_STMIN": {
+      "level": "SOL_CAN_ISOTP",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "CAN_ISOTP_LL_OPTS": {
+      "level": "SOL_CAN_ISOTP",
+      "val": "ptr[in, can_isotp_ll_options]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "CAN_ISOTP_OPTS": {
+      "level": "SOL_CAN_ISOTP",
+      "val": "ptr[out, can_isotp_options]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "CAN_ISOTP_RECV_FC": {
+      "level": "SOL_CAN_ISOTP",
+      "val": "ptr[out, can_isotp_fc_options]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "CAN_ISOTP_TX_STMIN": {
+      "level": "SOL_CAN_ISOTP",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "CAN_ISOTP_RX_STMIN": {
+      "level": "SOL_CAN_ISOTP",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "CAN_ISOTP_LL_OPTS": {
+      "level": "SOL_CAN_ISOTP",
+      "val": "ptr[out, can_isotp_ll_options]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "isotp_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "poll": "isotp_poll",
+    "ioctl": "isotp_sock_no_ioctlcmd",
+    "sendmsg": "isotp_sendmsg",
+    "recvmsg": "isotp_recvmsg",
+    "setsockopt": "isotp_setsockopt",
+    "getsockopt": "isotp_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/can/isotp.c:1674",
+  "ops_name": "isotp_ops",
+  "syscall_specs": {
+    "socket$KGPT_can_isotp": "socket$KGPT_can_isotp(domain const[PF_CAN], type const[SOCK_DGRAM], proto const[CAN_ISOTP]) sock_can_isotp",
+    "bind$KGPT_isotp_ops": "bind$KGPT_isotp_ops(fd sock_can_isotp, addr ptr[in, sockaddr_can], addrlen len[addr])",
+    "connect$KGPT_isotp_ops": "connect$KGPT_isotp_ops(fd sock_can_isotp, addr ptr[in, sockaddr_can], addrlen len[addr])",
+    "accept4$KGPT_isotp_ops": "accept4$KGPT_isotp_ops(fd sock_can_isotp, peer ptr[out, sockaddr_can, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_can_isotp",
+    "sendto$KGPT_isotp_ops": "sendto$KGPT_isotp_ops(fd sock_can_isotp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_can, opt], addrlen len[addr])",
+    "recvfrom$KGPT_isotp_ops": "recvfrom$KGPT_isotp_ops(fd sock_can_isotp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_can, opt], addrlen len[addr])",
+    "getsockopt$KGPT_CAN_ISOTP_OPTS": "getsockopt$KGPT_CAN_ISOTP_OPTS(fd sock_can_isotp, level const[SOL_CAN_ISOTP], opt const[CAN_ISOTP_OPTS], val ptr[out, can_isotp_options], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_CAN_ISOTP_RECV_FC": "getsockopt$KGPT_CAN_ISOTP_RECV_FC(fd sock_can_isotp, level const[SOL_CAN_ISOTP], opt const[CAN_ISOTP_RECV_FC], val ptr[out, can_isotp_fc_options], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_CAN_ISOTP_TX_STMIN": "getsockopt$KGPT_CAN_ISOTP_TX_STMIN(fd sock_can_isotp, level const[SOL_CAN_ISOTP], opt const[CAN_ISOTP_TX_STMIN], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_CAN_ISOTP_RX_STMIN": "getsockopt$KGPT_CAN_ISOTP_RX_STMIN(fd sock_can_isotp, level const[SOL_CAN_ISOTP], opt const[CAN_ISOTP_RX_STMIN], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_CAN_ISOTP_LL_OPTS": "getsockopt$KGPT_CAN_ISOTP_LL_OPTS(fd sock_can_isotp, level const[SOL_CAN_ISOTP], opt const[CAN_ISOTP_LL_OPTS], val ptr[out, can_isotp_ll_options], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_CAN_ISOTP_OPTS": "setsockopt$KGPT_CAN_ISOTP_OPTS(fd sock_can_isotp, level const[SOL_CAN_ISOTP], opt const[CAN_ISOTP_OPTS], val ptr[in, can_isotp_options], len bytesize[val])",
+    "setsockopt$KGPT_CAN_ISOTP_RECV_FC": "setsockopt$KGPT_CAN_ISOTP_RECV_FC(fd sock_can_isotp, level const[SOL_CAN_ISOTP], opt const[CAN_ISOTP_RECV_FC], val ptr[in, can_isotp_fc_options], len bytesize[val])",
+    "setsockopt$KGPT_CAN_ISOTP_TX_STMIN": "setsockopt$KGPT_CAN_ISOTP_TX_STMIN(fd sock_can_isotp, level const[SOL_CAN_ISOTP], opt const[CAN_ISOTP_TX_STMIN], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_CAN_ISOTP_RX_STMIN": "setsockopt$KGPT_CAN_ISOTP_RX_STMIN(fd sock_can_isotp, level const[SOL_CAN_ISOTP], opt const[CAN_ISOTP_RX_STMIN], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_CAN_ISOTP_LL_OPTS": "setsockopt$KGPT_CAN_ISOTP_LL_OPTS(fd sock_can_isotp, level const[SOL_CAN_ISOTP], opt const[CAN_ISOTP_LL_OPTS], val ptr[in, can_isotp_ll_options], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_can_isotp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/can.h",
+    "linux/socket.h",
+    "uapi/linux/can/isotp.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/j1939_ops#net_can_j1939_socket.c:1294.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/j1939_ops#net_can_j1939_socket.c:1294.json
@@ -1,0 +1,101 @@
+{
+  "socket": {
+    "domain": "PF_CAN",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_can_j1939(domain const[PF_CAN], type const[SOCK_DGRAM], proto const[CAN_J1939]) sock_j1939"
+  },
+  "resources": {
+    "sock_j1939": {
+      "type": "sock",
+      "spec": "resource sock_j1939[sock]"
+    }
+  },
+  "types": {
+    "CAN_J1939": "define CAN_J1939\t0x0E"
+  },
+  "socket_addr": "sockaddr_can",
+  "setsockopt": {
+    "SO_J1939_FILTER": {
+      "level": "SOL_CAN_J1939",
+      "val": "ptr[in, array[j1939_filter]]",
+      "len": "bytesize[val]"
+    },
+    "SO_J1939_PROMISC": {
+      "level": "SOL_CAN_J1939",
+      "val": "int32",
+      "len": "sizeof[int32]"
+    },
+    "SO_J1939_ERRQUEUE": {
+      "level": "SOL_CAN_J1939",
+      "val": "int32",
+      "len": "sizeof[int32]"
+    },
+    "SO_J1939_SEND_PRIO": {
+      "level": "SOL_CAN_J1939",
+      "val": "int32",
+      "len": "sizeof[int32]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "SO_J1939_PROMISC": {
+      "level": "SOL_CAN_J1939",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_J1939_ERRQUEUE": {
+      "level": "SOL_CAN_J1939",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_J1939_SEND_PRIO": {
+      "level": "SOL_CAN_J1939",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "j1939_sk_bind",
+    "connect": "j1939_sk_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "j1939_sk_no_ioctlcmd",
+    "sendmsg": "j1939_sk_sendmsg",
+    "recvmsg": "j1939_sk_recvmsg",
+    "setsockopt": "j1939_sk_setsockopt",
+    "getsockopt": "j1939_sk_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/can/j1939/socket.c:1294",
+  "ops_name": "j1939_ops",
+  "syscall_specs": {
+    "socket$KGPT_can_j1939": "socket$KGPT_can_j1939(domain const[PF_CAN], type const[SOCK_DGRAM], proto const[CAN_J1939]) sock_j1939",
+    "bind$KGPT_j1939_ops": "bind$KGPT_j1939_ops(fd sock_j1939, addr ptr[in, sockaddr_can], addrlen len[addr])",
+    "connect$KGPT_j1939_ops": "connect$KGPT_j1939_ops(fd sock_j1939, addr ptr[in, sockaddr_can], addrlen len[addr])",
+    "accept4$KGPT_j1939_ops": "accept4$KGPT_j1939_ops(fd sock_j1939, peer ptr[out, sockaddr_can, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_j1939",
+    "sendto$KGPT_j1939_ops": "sendto$KGPT_j1939_ops(fd sock_j1939, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_can, opt], addrlen len[addr])",
+    "recvfrom$KGPT_j1939_ops": "recvfrom$KGPT_j1939_ops(fd sock_j1939, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_can, opt], addrlen len[addr])",
+    "getsockopt$KGPT_SO_J1939_PROMISC": "getsockopt$KGPT_SO_J1939_PROMISC(fd sock_j1939, level const[SOL_CAN_J1939], opt const[SO_J1939_PROMISC], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_J1939_ERRQUEUE": "getsockopt$KGPT_SO_J1939_ERRQUEUE(fd sock_j1939, level const[SOL_CAN_J1939], opt const[SO_J1939_ERRQUEUE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_J1939_SEND_PRIO": "getsockopt$KGPT_SO_J1939_SEND_PRIO(fd sock_j1939, level const[SOL_CAN_J1939], opt const[SO_J1939_SEND_PRIO], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_SO_J1939_FILTER": "setsockopt$KGPT_SO_J1939_FILTER(fd sock_j1939, level const[SOL_CAN_J1939], opt const[SO_J1939_FILTER], val ptr[in, array[j1939_filter]], len bytesize[val])",
+    "setsockopt$KGPT_SO_J1939_PROMISC": "setsockopt$KGPT_SO_J1939_PROMISC(fd sock_j1939, level const[SOL_CAN_J1939], opt const[SO_J1939_PROMISC], val ptr[in, int32], len const[4])",
+    "setsockopt$KGPT_SO_J1939_ERRQUEUE": "setsockopt$KGPT_SO_J1939_ERRQUEUE(fd sock_j1939, level const[SOL_CAN_J1939], opt const[SO_J1939_ERRQUEUE], val ptr[in, int32], len len[val])",
+    "setsockopt$KGPT_SO_J1939_SEND_PRIO": "setsockopt$KGPT_SO_J1939_SEND_PRIO(fd sock_j1939, level const[SOL_CAN_J1939], opt const[SO_J1939_SEND_PRIO], val ptr[in, int32], len const[4])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_can_j1939"
+  ],
+  "includes": [
+    "uapi/linux/can/j1939.h",
+    "linux/net.h",
+    "uapi/linux/can.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/kcm_dgram_ops#net_kcm_kcmsock.c:1738.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/kcm_dgram_ops#net_kcm_kcmsock.c:1738.json
@@ -1,0 +1,133 @@
+{
+  "socket": {
+    "domain": "AF_KCM",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_kcm(domain const[AF_KCM], type const[SOCK_DGRAM], proto const[KCMPROTO_CONNECTED]) sock_kcm"
+  },
+  "resources": {
+    "sock_kcm": {
+      "type": "sock",
+      "spec": "resource sock_kcm[sock]"
+    }
+  },
+  "types": {
+    "KCMPROTO_CONNECTED": "define KCMPROTO_CONNECTED 1"
+  },
+  "socket_addr": "sockaddr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCKCMATTACH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "info"
+      ],
+      "arg_inference": {
+        "function": [
+          "kcm_attach_ioctl"
+        ],
+        "type": [
+          "kcm_attach"
+        ],
+        "usage": [
+          "struct kcm_attach info;",
+          "if (copy_from_user(&info, (void __user *)arg, sizeof(info)))",
+          "err = kcm_attach_ioctl(sock, &info);"
+        ]
+      }
+    },
+    "SIOCKCMUNATTACH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "info"
+      ],
+      "arg_inference": {
+        "function": [
+          "kcm_unattach_ioctl"
+        ],
+        "type": [
+          "kcm_unattach"
+        ],
+        "usage": [
+          "struct kcm_unattach info;",
+          "if (copy_from_user(&info, (void __user *)arg, sizeof(info)))",
+          "err = kcm_unattach_ioctl(sock, &info);"
+        ]
+      }
+    },
+    "SIOCKCMCLONE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "info"
+      ],
+      "arg_inference": {
+        "function": [
+          "kcm_clone"
+        ],
+        "type": [
+          "kcm_clone"
+        ],
+        "usage": [
+          "struct kcm_clone info;",
+          "struct file *file;",
+          "info.fd = get_unused_fd_flags(0);",
+          "file = kcm_clone(sock);",
+          "if (copy_to_user((void __user *)arg, &info, sizeof(info)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "KCM_RECV_DISABLE": {
+      "level": "SOL_KCM",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "KCM_RECV_DISABLE": {
+      "level": "SOL_KCM",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "kcm_ioctl",
+    "sendmsg": "kcm_sendmsg",
+    "recvmsg": "kcm_recvmsg",
+    "setsockopt": "kcm_setsockopt",
+    "getsockopt": "kcm_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/kcm/kcmsock.c:1738",
+  "ops_name": "kcm_dgram_ops",
+  "syscall_specs": {
+    "socket$KGPT_kcm": "socket$KGPT_kcm(domain const[AF_KCM], type const[SOCK_DGRAM], proto const[KCMPROTO_CONNECTED]) sock_kcm",
+    "bind$KGPT_kcm_dgram_ops": "bind$KGPT_kcm_dgram_ops(fd sock_kcm, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_kcm_dgram_ops": "connect$KGPT_kcm_dgram_ops(fd sock_kcm, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_kcm_dgram_ops": "accept4$KGPT_kcm_dgram_ops(fd sock_kcm, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_kcm",
+    "sendto$KGPT_kcm_dgram_ops": "sendto$KGPT_kcm_dgram_ops(fd sock_kcm, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_kcm_dgram_ops": "recvfrom$KGPT_kcm_dgram_ops(fd sock_kcm, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "getsockopt$KGPT_KCM_RECV_DISABLE": "getsockopt$KGPT_KCM_RECV_DISABLE(fd sock_kcm, level const[SOL_KCM], opt const[KCM_RECV_DISABLE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_KCM_RECV_DISABLE": "setsockopt$KGPT_KCM_RECV_DISABLE(fd sock_kcm, level const[SOL_KCM], opt const[KCM_RECV_DISABLE], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_kcm"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/kcm.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/kcm_seqpacket_ops#net_kcm_kcmsock.c:1759.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/kcm_seqpacket_ops#net_kcm_kcmsock.c:1759.json
@@ -1,0 +1,133 @@
+{
+  "socket": {
+    "domain": "AF_KCM",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_kcm(domain const[AF_KCM], type const[SOCK_SEQPACKET], proto const[KCMPROTO_CONNECTED]) sock_kcm"
+  },
+  "resources": {
+    "sock_kcm": {
+      "type": "sock",
+      "spec": "resource sock_kcm[sock]"
+    }
+  },
+  "types": {
+    "KCMPROTO_CONNECTED": "define KCMPROTO_CONNECTED 1"
+  },
+  "socket_addr": "sockaddr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCKCMATTACH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "info"
+      ],
+      "arg_inference": {
+        "function": [
+          "kcm_attach_ioctl"
+        ],
+        "type": [
+          "kcm_attach"
+        ],
+        "usage": [
+          "struct kcm_attach info;",
+          "if (copy_from_user(&info, (void __user *)arg, sizeof(info)))",
+          "err = kcm_attach_ioctl(sock, &info);"
+        ]
+      }
+    },
+    "SIOCKCMUNATTACH": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "info"
+      ],
+      "arg_inference": {
+        "function": [
+          "kcm_unattach_ioctl"
+        ],
+        "type": [
+          "kcm_unattach"
+        ],
+        "usage": [
+          "struct kcm_unattach info;",
+          "if (copy_from_user(&info, (void __user *)arg, sizeof(info)))",
+          "err = kcm_unattach_ioctl(sock, &info);"
+        ]
+      }
+    },
+    "SIOCKCMCLONE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "info"
+      ],
+      "arg_inference": {
+        "function": [
+          "kcm_clone"
+        ],
+        "type": [
+          "kcm_clone"
+        ],
+        "usage": [
+          "struct kcm_clone info;",
+          "struct file *file;",
+          "info.fd = get_unused_fd_flags(0);",
+          "file = kcm_clone(sock);",
+          "if (copy_to_user((void __user *)arg, &info, sizeof(info)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "KCM_RECV_DISABLE": {
+      "level": "SOL_KCM",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "KCM_RECV_DISABLE": {
+      "level": "SOL_KCM",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "kcm_ioctl",
+    "sendmsg": "kcm_sendmsg",
+    "recvmsg": "kcm_recvmsg",
+    "setsockopt": "kcm_setsockopt",
+    "getsockopt": "kcm_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/kcm/kcmsock.c:1759",
+  "ops_name": "kcm_seqpacket_ops",
+  "syscall_specs": {
+    "socket$KGPT_kcm": "socket$KGPT_kcm(domain const[AF_KCM], type const[SOCK_SEQPACKET], proto const[KCMPROTO_CONNECTED]) sock_kcm",
+    "bind$KGPT_kcm_seqpacket_ops": "bind$KGPT_kcm_seqpacket_ops(fd sock_kcm, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_kcm_seqpacket_ops": "connect$KGPT_kcm_seqpacket_ops(fd sock_kcm, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_kcm_seqpacket_ops": "accept4$KGPT_kcm_seqpacket_ops(fd sock_kcm, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_kcm",
+    "sendto$KGPT_kcm_seqpacket_ops": "sendto$KGPT_kcm_seqpacket_ops(fd sock_kcm, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_kcm_seqpacket_ops": "recvfrom$KGPT_kcm_seqpacket_ops(fd sock_kcm, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "getsockopt$KGPT_KCM_RECV_DISABLE": "getsockopt$KGPT_KCM_RECV_DISABLE(fd sock_kcm, level const[SOL_KCM], opt const[KCM_RECV_DISABLE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_KCM_RECV_DISABLE": "setsockopt$KGPT_KCM_RECV_DISABLE(fd sock_kcm, level const[SOL_KCM], opt const[KCM_RECV_DISABLE], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_kcm"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/kcm.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/l2tp_ip6_ops#net_l2tp_l2tp_ip6.c:733.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/l2tp_ip6_ops#net_l2tp_l2tp_ip6.c:733.json
@@ -1,0 +1,230 @@
+{
+  "socket": {
+    "domain": "AF_INET6",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_l2tp(domain const[AF_INET6], type const[SOCK_DGRAM], proto const[IPPROTO_L2TP]) sock_l2tp6"
+  },
+  "resources": {
+    "sock_l2tp6": {
+      "type": "sock",
+      "spec": "resource sock_l2tp6[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_L2TP": "define IPPROTO_L2TP 115"
+  },
+  "socket_addr": "sockaddr_in6",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_add_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_add_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCDIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_del_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_del_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_set_dstaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_set_dstaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet6_bind",
+    "connect": "inet_dgram_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "inet6_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "sock_common_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/l2tp/l2tp_ip6.c:733",
+  "ops_name": "l2tp_ip6_ops",
+  "syscall_specs": {
+    "socket$KGPT_l2tp": "socket$KGPT_l2tp(domain const[AF_INET6], type const[SOCK_DGRAM], proto const[IPPROTO_L2TP]) sock_l2tp6",
+    "bind$KGPT_l2tp_ip6_ops": "bind$KGPT_l2tp_ip6_ops(fd sock_l2tp6, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "connect$KGPT_l2tp_ip6_ops": "connect$KGPT_l2tp_ip6_ops(fd sock_l2tp6, addr ptr[in, sockaddr_in6], addrlen len[addr])",
+    "accept4$KGPT_l2tp_ip6_ops": "accept4$KGPT_l2tp_ip6_ops(fd sock_l2tp6, peer ptr[out, sockaddr_in6, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_l2tp6",
+    "sendto$KGPT_l2tp_ip6_ops": "sendto$KGPT_l2tp_ip6_ops(fd sock_l2tp6, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "recvfrom$KGPT_l2tp_ip6_ops": "recvfrom$KGPT_l2tp_ip6_ops(fd sock_l2tp6, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in6, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_l2tp6, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_l2tp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/in.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in6": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/l2tp_ip6_prot#net_l2tp_l2tp_ip6.c:712.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/l2tp_ip6_prot#net_l2tp_l2tp_ip6.c:712.json
@@ -1,0 +1,754 @@
+{
+  "socket": {
+    "domain": "AF_INET6",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_l2tp(domain const[AF_INET6], type const[SOCK_DGRAM], proto const[IPPROTO_L2TP]) sock_l2tp6"
+  },
+  "resources": {
+    "sock_l2tp6": {
+      "type": "sock",
+      "spec": "resource sock_l2tp6[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_L2TP": "define IPPROTO_L2TP 115",
+    "group_req": "group_req {\n\tgr_interface\tint32\n\tgr_group\t__kernel_sockaddr_storage\n}",
+    "group_source_req": "group_source_req {\n\tgsr_interface\tint32\n\tgsr_group\t__kernel_sockaddr_storage\n\tgsr_source\t__kernel_sockaddr_storage\n}",
+    "ip6_mtuinfo": "ip6_mtuinfo {\n\tip6m_addr\tsockaddr_in6\n\tip6m_mtu\tint32\n}",
+    "ipv6_opt_hdr": "ipv6_opt_hdr {\n\tnexthdr\tint8\n\thdrlen\tint8\n\topts\tarray[int8]\n}",
+    "ipv6_txoptions": "ipv6_txoptions {\n\trefcnt\trefcount_t\n\ttot_len\tint32\n\topt_flen\tint16\n\topt_nflen\tint16\n\thopopt\tptr[in, ipv6_opt_hdr]\n\tdst0opt\tptr[in, ipv6_opt_hdr]\n\tsrcrt\tptr[in, ipv6_rt_hdr]\n\tdst1opt\tptr[in, ipv6_opt_hdr]\n}",
+    "group_filter": "group_filter {\n\tgf_interface\tint32\n\tgf_group\t__kernel_sockaddr_storage\n\tgf_fmode\tint32\n\tgf_numsrc\tlen[gf_slist, int32]\n\tgf_slist\tarray[__kernel_sockaddr_storage]\n}",
+    "refcount_t": "type refcount_t int32",
+    "__kernel_sockaddr_storage": "__kernel_sockaddr_storage {\n\tss_family\t__kernel_sa_family_t\n\t__data\tarray[int8, __K_SS_MAXSIZE_minus_sizeof_ushort]\n}",
+    "__K_SS_MAXSIZE_minus_sizeof_ushort": "define __K_SS_MAXSIZE_minus_sizeof_ushort _K_SS_MAXSIZE - sizeof(unsigned short)",
+    "__kernel_sa_family_t": "type __kernel_sa_family_t ptr[in, array[int8]]"
+  },
+  "socket_addr": "sockaddr_l2tpip6",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk_wmem_alloc_get"
+        ],
+        "type": [],
+        "usage": [
+          "*karg = sk_wmem_alloc_get(sk);"
+        ]
+      }
+    },
+    "SIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "skb_peek"
+        ],
+        "type": [
+          "sk_buff"
+        ],
+        "usage": [
+          "spin_lock_bh(&sk->sk_receive_queue.lock);",
+          "skb = skb_peek(&sk->sk_receive_queue);",
+          "*karg = skb ? skb->len : 0;",
+          "spin_unlock_bh(&sk->sk_receive_queue.lock);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "IPV6_UNICAST_HOPS": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_MULTICAST_LOOP": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_MULTICAST_HOPS": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_MTU": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_MINHOPCOUNT": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVERR_RFC4884": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_MULTICAST_ALL": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_AUTOFLOWLABEL": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_DONTFRAG": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVERR": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_ROUTER_ALERT_ISOLATE": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_MTU_DISCOVER": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_FLOWINFO_SEND": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_ADDR_PREFERENCES": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_V6ONLY": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVPKTINFO": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_2292PKTINFO": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVHOPLIMIT": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_2292HOPLIMIT": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVRTHDR": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_2292RTHDR": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVHOPOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_2292HOPOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVDSTOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_2292DSTOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_TCLASS": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVTCLASS": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_FLOWINFO": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVPATHMTU": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_TRANSPARENT": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_FREEBIND": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVORIGDSTADDR": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_PKTINFO": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, ipv6_mreq]",
+      "len": "bytesize[val]"
+    },
+    "IPV6_UNICAST_IF": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_MULTICAST_IF": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_ADD_MEMBERSHIP": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, ipv6_mreq]",
+      "len": "bytesize[val]"
+    },
+    "IPV6_DROP_MEMBERSHIP": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, ipv6_mreq]",
+      "len": "bytesize[val]"
+    },
+    "IPV6_JOIN_ANYCAST": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, ipv6_mreq]",
+      "len": "bytesize[val]"
+    },
+    "IPV6_LEAVE_ANYCAST": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, ipv6_mreq]",
+      "len": "bytesize[val]"
+    },
+    "IPV6_ROUTER_ALERT": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_RECVFRAGSIZE": {
+      "level": "IPPROTO_IPV6",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IPV6_HOPOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, ipv6_opt_hdr]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "IPV6_RTHDRDSTOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, ipv6_opt_hdr]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "IPV6_RTHDR": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, ipv6_opt_hdr]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "IPV6_DSTOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, ipv6_opt_hdr]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "IPV6_2292PKTOPTIONS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, ipv6_txoptions]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "MCAST_JOIN_GROUP": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, group_req]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "MCAST_LEAVE_GROUP": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, group_req]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "MCAST_JOIN_SOURCE_GROUP": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, group_source_req]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "MCAST_LEAVE_SOURCE_GROUP": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, group_source_req]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "MCAST_BLOCK_SOURCE": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, group_source_req]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "MCAST_UNBLOCK_SOURCE": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, group_source_req]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "MCAST_MSFILTER": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, group_filter]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "IPV6_FLOWLABEL_MGR": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, in6_flowlabel_req]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "IPV6_IPSEC_POLICY": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, xfrm_userpolicy_info]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "IPV6_XFRM_POLICY": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[in, xfrm_userpolicy_info]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "IPV6_ADDRFORM": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_MTU": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_V6ONLY": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVPKTINFO": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_2292PKTINFO": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVHOPLIMIT": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_2292HOPLIMIT": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVRTHDR": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_2292RTHDR": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVHOPOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_2292HOPOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVDSTOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_2292DSTOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_TCLASS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVTCLASS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_FLOWINFO": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVPATHMTU": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_PATHMTU": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, ip6_mtuinfo]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_TRANSPARENT": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_FREEBIND": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVORIGDSTADDR": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_UNICAST_HOPS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_MULTICAST_HOPS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_MULTICAST_LOOP": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_MULTICAST_IF": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_MULTICAST_ALL": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_UNICAST_IF": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_MTU_DISCOVER": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVERR": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_FLOWINFO_SEND": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_FLOWLABEL_MGR": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, in6_flowlabel_req]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_ADDR_PREFERENCES": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_MINHOPCOUNT": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_DONTFRAG": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_AUTOFLOWLABEL": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVFRAGSIZE": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_ROUTER_ALERT_ISOLATE": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RECVERR_RFC4884": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "MCAST_MSFILTER": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[inout, group_filter]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "IPV6_2292PKTOPTIONS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, array[int8]]",
+      "len": "ptr[inout, len[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_HOPOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, array[int8]]",
+      "len": "ptr[inout, len[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_RTHDRDSTOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, array[int8]]",
+      "len": "ptr[inout, len[val, int32]]",
+      "val_inference": null
+    },
+    "IPV6_DSTOPTS": {
+      "level": "IPPROTO_IPV6",
+      "val": "ptr[out, array[int8]]",
+      "len": "ptr[inout, len[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "l2tp_ip6_bind",
+    "connect": "l2tp_ip6_connect",
+    "ioctl": "l2tp_ioctl",
+    "sendmsg": "l2tp_ip6_sendmsg",
+    "recvmsg": "l2tp_ip6_recvmsg",
+    "setsockopt": "ipv6_setsockopt",
+    "getsockopt": "ipv6_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/l2tp/l2tp_ip6.c:712",
+  "ops_name": "l2tp_ip6_prot",
+  "syscall_specs": {
+    "socket$KGPT_l2tp": "socket$KGPT_l2tp(domain const[AF_INET6], type const[SOCK_DGRAM], proto const[IPPROTO_L2TP]) sock_l2tp6",
+    "bind$KGPT_l2tp_ip6_prot": "bind$KGPT_l2tp_ip6_prot(fd sock_l2tp6, addr ptr[in, sockaddr_l2tpip6], addrlen len[addr])",
+    "connect$KGPT_l2tp_ip6_prot": "connect$KGPT_l2tp_ip6_prot(fd sock_l2tp6, addr ptr[in, sockaddr_l2tpip6], addrlen len[addr])",
+    "sendto$KGPT_l2tp_ip6_prot": "sendto$KGPT_l2tp_ip6_prot(fd sock_l2tp6, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_l2tpip6, opt], addrlen len[addr])",
+    "recvfrom$KGPT_l2tp_ip6_prot": "recvfrom$KGPT_l2tp_ip6_prot(fd sock_l2tp6, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_l2tpip6, opt], addrlen len[addr])",
+    "getsockopt$KGPT_IPV6_ADDRFORM": "getsockopt$KGPT_IPV6_ADDRFORM(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_ADDRFORM], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_MTU": "getsockopt$KGPT_IPV6_MTU(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MTU], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_V6ONLY": "getsockopt$KGPT_IPV6_V6ONLY(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_V6ONLY], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVPKTINFO": "getsockopt$KGPT_IPV6_RECVPKTINFO(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVPKTINFO], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_2292PKTINFO": "getsockopt$KGPT_IPV6_2292PKTINFO(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292PKTINFO], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVHOPLIMIT": "getsockopt$KGPT_IPV6_RECVHOPLIMIT(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVHOPLIMIT], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_2292HOPLIMIT": "getsockopt$KGPT_IPV6_2292HOPLIMIT(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292HOPLIMIT], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVRTHDR": "getsockopt$KGPT_IPV6_RECVRTHDR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVRTHDR], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_2292RTHDR": "getsockopt$KGPT_IPV6_2292RTHDR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292RTHDR], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVHOPOPTS": "getsockopt$KGPT_IPV6_RECVHOPOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVHOPOPTS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_2292HOPOPTS": "getsockopt$KGPT_IPV6_2292HOPOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292HOPOPTS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVDSTOPTS": "getsockopt$KGPT_IPV6_RECVDSTOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVDSTOPTS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_2292DSTOPTS": "getsockopt$KGPT_IPV6_2292DSTOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292DSTOPTS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_TCLASS": "getsockopt$KGPT_IPV6_TCLASS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_TCLASS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVTCLASS": "getsockopt$KGPT_IPV6_RECVTCLASS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVTCLASS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_FLOWINFO": "getsockopt$KGPT_IPV6_FLOWINFO(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_FLOWINFO], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVPATHMTU": "getsockopt$KGPT_IPV6_RECVPATHMTU(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVPATHMTU], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_PATHMTU": "getsockopt$KGPT_IPV6_PATHMTU(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_PATHMTU], val ptr[out, ip6_mtuinfo], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_TRANSPARENT": "getsockopt$KGPT_IPV6_TRANSPARENT(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_TRANSPARENT], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_FREEBIND": "getsockopt$KGPT_IPV6_FREEBIND(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_FREEBIND], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVORIGDSTADDR": "getsockopt$KGPT_IPV6_RECVORIGDSTADDR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVORIGDSTADDR], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_UNICAST_HOPS": "getsockopt$KGPT_IPV6_UNICAST_HOPS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_UNICAST_HOPS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_MULTICAST_HOPS": "getsockopt$KGPT_IPV6_MULTICAST_HOPS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MULTICAST_HOPS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_MULTICAST_LOOP": "getsockopt$KGPT_IPV6_MULTICAST_LOOP(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MULTICAST_LOOP], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_MULTICAST_IF": "getsockopt$KGPT_IPV6_MULTICAST_IF(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MULTICAST_IF], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_MULTICAST_ALL": "getsockopt$KGPT_IPV6_MULTICAST_ALL(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MULTICAST_ALL], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_UNICAST_IF": "getsockopt$KGPT_IPV6_UNICAST_IF(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_UNICAST_IF], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_MTU_DISCOVER": "getsockopt$KGPT_IPV6_MTU_DISCOVER(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MTU_DISCOVER], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVERR": "getsockopt$KGPT_IPV6_RECVERR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVERR], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_FLOWINFO_SEND": "getsockopt$KGPT_IPV6_FLOWINFO_SEND(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_FLOWINFO_SEND], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_FLOWLABEL_MGR": "getsockopt$KGPT_IPV6_FLOWLABEL_MGR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_FLOWLABEL_MGR], val ptr[out, in6_flowlabel_req], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_ADDR_PREFERENCES": "getsockopt$KGPT_IPV6_ADDR_PREFERENCES(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_ADDR_PREFERENCES], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_MINHOPCOUNT": "getsockopt$KGPT_IPV6_MINHOPCOUNT(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MINHOPCOUNT], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_DONTFRAG": "getsockopt$KGPT_IPV6_DONTFRAG(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_DONTFRAG], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_AUTOFLOWLABEL": "getsockopt$KGPT_IPV6_AUTOFLOWLABEL(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_AUTOFLOWLABEL], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVFRAGSIZE": "getsockopt$KGPT_IPV6_RECVFRAGSIZE(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVFRAGSIZE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_ROUTER_ALERT_ISOLATE": "getsockopt$KGPT_IPV6_ROUTER_ALERT_ISOLATE(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_ROUTER_ALERT_ISOLATE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_IPV6_RECVERR_RFC4884": "getsockopt$KGPT_IPV6_RECVERR_RFC4884(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVERR_RFC4884], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_MCAST_MSFILTER": "getsockopt$KGPT_MCAST_MSFILTER(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[MCAST_MSFILTER], val ptr[inout, group_filter], len len[val])",
+    "getsockopt$KGPT_IPV6_2292PKTOPTIONS": "getsockopt$KGPT_IPV6_2292PKTOPTIONS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292PKTOPTIONS], val ptr[out, array[int8]], len ptr[inout, len[val, int32]])",
+    "getsockopt$KGPT_IPV6_HOPOPTS": "getsockopt$KGPT_IPV6_HOPOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_HOPOPTS], val ptr[out, array[int8]], len ptr[inout, len[val, int32]])",
+    "getsockopt$KGPT_IPV6_RTHDRDSTOPTS": "getsockopt$KGPT_IPV6_RTHDRDSTOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RTHDRDSTOPTS], val ptr[out, array[int8]], len ptr[inout, len[val, int32]])",
+    "getsockopt$KGPT_IPV6_DSTOPTS": "getsockopt$KGPT_IPV6_DSTOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_DSTOPTS], val ptr[out, array[int8]], len ptr[inout, len[val, int32]])",
+    "setsockopt$KGPT_IPV6_UNICAST_HOPS": "setsockopt$KGPT_IPV6_UNICAST_HOPS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_UNICAST_HOPS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_MULTICAST_LOOP": "setsockopt$KGPT_IPV6_MULTICAST_LOOP(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MULTICAST_LOOP], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_MULTICAST_HOPS": "setsockopt$KGPT_IPV6_MULTICAST_HOPS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MULTICAST_HOPS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_MTU": "setsockopt$KGPT_IPV6_MTU(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MTU], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_MINHOPCOUNT": "setsockopt$KGPT_IPV6_MINHOPCOUNT(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MINHOPCOUNT], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVERR_RFC4884": "setsockopt$KGPT_IPV6_RECVERR_RFC4884(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVERR_RFC4884], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_MULTICAST_ALL": "setsockopt$KGPT_IPV6_MULTICAST_ALL(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MULTICAST_ALL], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_AUTOFLOWLABEL": "setsockopt$KGPT_IPV6_AUTOFLOWLABEL(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_AUTOFLOWLABEL], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_DONTFRAG": "setsockopt$KGPT_IPV6_DONTFRAG(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_DONTFRAG], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVERR": "setsockopt$KGPT_IPV6_RECVERR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVERR], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_ROUTER_ALERT_ISOLATE": "setsockopt$KGPT_IPV6_ROUTER_ALERT_ISOLATE(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_ROUTER_ALERT_ISOLATE], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_MTU_DISCOVER": "setsockopt$KGPT_IPV6_MTU_DISCOVER(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MTU_DISCOVER], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_FLOWINFO_SEND": "setsockopt$KGPT_IPV6_FLOWINFO_SEND(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_FLOWINFO_SEND], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_ADDR_PREFERENCES": "setsockopt$KGPT_IPV6_ADDR_PREFERENCES(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_ADDR_PREFERENCES], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_V6ONLY": "setsockopt$KGPT_IPV6_V6ONLY(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_V6ONLY], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVPKTINFO": "setsockopt$KGPT_IPV6_RECVPKTINFO(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVPKTINFO], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_2292PKTINFO": "setsockopt$KGPT_IPV6_2292PKTINFO(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292PKTINFO], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVHOPLIMIT": "setsockopt$KGPT_IPV6_RECVHOPLIMIT(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVHOPLIMIT], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_2292HOPLIMIT": "setsockopt$KGPT_IPV6_2292HOPLIMIT(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292HOPLIMIT], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVRTHDR": "setsockopt$KGPT_IPV6_RECVRTHDR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVRTHDR], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_2292RTHDR": "setsockopt$KGPT_IPV6_2292RTHDR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292RTHDR], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVHOPOPTS": "setsockopt$KGPT_IPV6_RECVHOPOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVHOPOPTS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_2292HOPOPTS": "setsockopt$KGPT_IPV6_2292HOPOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292HOPOPTS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVDSTOPTS": "setsockopt$KGPT_IPV6_RECVDSTOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVDSTOPTS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_2292DSTOPTS": "setsockopt$KGPT_IPV6_2292DSTOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292DSTOPTS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_TCLASS": "setsockopt$KGPT_IPV6_TCLASS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_TCLASS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVTCLASS": "setsockopt$KGPT_IPV6_RECVTCLASS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVTCLASS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_FLOWINFO": "setsockopt$KGPT_IPV6_FLOWINFO(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_FLOWINFO], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVPATHMTU": "setsockopt$KGPT_IPV6_RECVPATHMTU(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVPATHMTU], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_TRANSPARENT": "setsockopt$KGPT_IPV6_TRANSPARENT(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_TRANSPARENT], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_FREEBIND": "setsockopt$KGPT_IPV6_FREEBIND(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_FREEBIND], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVORIGDSTADDR": "setsockopt$KGPT_IPV6_RECVORIGDSTADDR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVORIGDSTADDR], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_PKTINFO": "setsockopt$KGPT_IPV6_PKTINFO(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_PKTINFO], val ptr[in, ipv6_mreq], len bytesize[val])",
+    "setsockopt$KGPT_IPV6_UNICAST_IF": "setsockopt$KGPT_IPV6_UNICAST_IF(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_UNICAST_IF], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_MULTICAST_IF": "setsockopt$KGPT_IPV6_MULTICAST_IF(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_MULTICAST_IF], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_ADD_MEMBERSHIP": "setsockopt$KGPT_IPV6_ADD_MEMBERSHIP(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_ADD_MEMBERSHIP], val ptr[in, ipv6_mreq], len bytesize[val])",
+    "setsockopt$KGPT_IPV6_DROP_MEMBERSHIP": "setsockopt$KGPT_IPV6_DROP_MEMBERSHIP(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_DROP_MEMBERSHIP], val ptr[in, ipv6_mreq], len bytesize[val])",
+    "setsockopt$KGPT_IPV6_JOIN_ANYCAST": "setsockopt$KGPT_IPV6_JOIN_ANYCAST(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_JOIN_ANYCAST], val ptr[in, ipv6_mreq], len bytesize[val])",
+    "setsockopt$KGPT_IPV6_LEAVE_ANYCAST": "setsockopt$KGPT_IPV6_LEAVE_ANYCAST(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_LEAVE_ANYCAST], val ptr[in, ipv6_mreq], len bytesize[val])",
+    "setsockopt$KGPT_IPV6_ROUTER_ALERT": "setsockopt$KGPT_IPV6_ROUTER_ALERT(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_ROUTER_ALERT], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_RECVFRAGSIZE": "setsockopt$KGPT_IPV6_RECVFRAGSIZE(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RECVFRAGSIZE], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IPV6_HOPOPTS": "setsockopt$KGPT_IPV6_HOPOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_HOPOPTS], val ptr[in, ipv6_opt_hdr], len len[val])",
+    "setsockopt$KGPT_IPV6_RTHDRDSTOPTS": "setsockopt$KGPT_IPV6_RTHDRDSTOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RTHDRDSTOPTS], val ptr[in, ipv6_opt_hdr], len len[val])",
+    "setsockopt$KGPT_IPV6_RTHDR": "setsockopt$KGPT_IPV6_RTHDR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_RTHDR], val ptr[in, ipv6_opt_hdr], len len[val])",
+    "setsockopt$KGPT_IPV6_DSTOPTS": "setsockopt$KGPT_IPV6_DSTOPTS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_DSTOPTS], val ptr[in, ipv6_opt_hdr], len len[val])",
+    "setsockopt$KGPT_IPV6_2292PKTOPTIONS": "setsockopt$KGPT_IPV6_2292PKTOPTIONS(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_2292PKTOPTIONS], val ptr[in, ipv6_txoptions], len len[val])",
+    "setsockopt$KGPT_MCAST_JOIN_GROUP": "setsockopt$KGPT_MCAST_JOIN_GROUP(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[MCAST_JOIN_GROUP], val ptr[in, group_req], len len[val])",
+    "setsockopt$KGPT_MCAST_LEAVE_GROUP": "setsockopt$KGPT_MCAST_LEAVE_GROUP(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[MCAST_LEAVE_GROUP], val ptr[in, group_req], len len[val])",
+    "setsockopt$KGPT_MCAST_JOIN_SOURCE_GROUP": "setsockopt$KGPT_MCAST_JOIN_SOURCE_GROUP(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[MCAST_JOIN_SOURCE_GROUP], val ptr[in, group_source_req], len len[val])",
+    "setsockopt$KGPT_MCAST_LEAVE_SOURCE_GROUP": "setsockopt$KGPT_MCAST_LEAVE_SOURCE_GROUP(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[MCAST_LEAVE_SOURCE_GROUP], val ptr[in, group_source_req], len len[val])",
+    "setsockopt$KGPT_MCAST_BLOCK_SOURCE": "setsockopt$KGPT_MCAST_BLOCK_SOURCE(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[MCAST_BLOCK_SOURCE], val ptr[in, group_source_req], len len[val])",
+    "setsockopt$KGPT_MCAST_UNBLOCK_SOURCE": "setsockopt$KGPT_MCAST_UNBLOCK_SOURCE(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[MCAST_UNBLOCK_SOURCE], val ptr[in, group_source_req], len len[val])",
+    "setsockopt$KGPT_MCAST_MSFILTER": "setsockopt$KGPT_MCAST_MSFILTER(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[MCAST_MSFILTER], val ptr[in, group_filter], len len[val])",
+    "setsockopt$KGPT_IPV6_FLOWLABEL_MGR": "setsockopt$KGPT_IPV6_FLOWLABEL_MGR(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_FLOWLABEL_MGR], val ptr[in, in6_flowlabel_req], len len[val])",
+    "setsockopt$KGPT_IPV6_IPSEC_POLICY": "setsockopt$KGPT_IPV6_IPSEC_POLICY(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_IPSEC_POLICY], val ptr[in, xfrm_userpolicy_info], len len[val])",
+    "setsockopt$KGPT_IPV6_XFRM_POLICY": "setsockopt$KGPT_IPV6_XFRM_POLICY(fd sock_l2tp6, level const[IPPROTO_IPV6], opt const[IPV6_XFRM_POLICY], val ptr[in, xfrm_userpolicy_info], len len[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_l2tp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/in.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in6.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/l2tp_ip_ops#net_l2tp_l2tp_ip.c:608.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/l2tp_ip_ops#net_l2tp_l2tp_ip.c:608.json
@@ -1,0 +1,438 @@
+{
+  "socket": {
+    "domain": "AF_INET",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_inet_l2tp(domain const[AF_INET], type const[SOCK_DGRAM], proto const[IPPROTO_L2TP]) sock_inet_l2tp"
+  },
+  "resources": {
+    "sock_inet_l2tp": {
+      "type": "sock",
+      "spec": "resource sock_inet_l2tp[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_L2TP": "define IPPROTO_L2TP 115"
+  },
+  "socket_addr": "sockaddr_in",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCRTMSG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCDARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCSARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "inet_bind",
+    "connect": "inet_dgram_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "inet_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "sock_common_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/l2tp/l2tp_ip.c:608",
+  "ops_name": "l2tp_ip_ops",
+  "syscall_specs": {
+    "socket$KGPT_inet_l2tp": "socket$KGPT_inet_l2tp(domain const[AF_INET], type const[SOCK_DGRAM], proto const[IPPROTO_L2TP]) sock_inet_l2tp",
+    "bind$KGPT_l2tp_ip_ops": "bind$KGPT_l2tp_ip_ops(fd sock_inet_l2tp, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "connect$KGPT_l2tp_ip_ops": "connect$KGPT_l2tp_ip_ops(fd sock_inet_l2tp, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "accept4$KGPT_l2tp_ip_ops": "accept4$KGPT_l2tp_ip_ops(fd sock_inet_l2tp, peer ptr[out, sockaddr_in, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet_l2tp",
+    "sendto$KGPT_l2tp_ip_ops": "sendto$KGPT_l2tp_ip_ops(fd sock_inet_l2tp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "recvfrom$KGPT_l2tp_ip_ops": "recvfrom$KGPT_l2tp_ip_ops(fd sock_inet_l2tp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_inet_l2tp, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet_l2tp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/in.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/llc_ui_ops#net_llc_af_llc.c:1217.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/llc_ui_ops#net_llc_af_llc.c:1217.json
@@ -1,0 +1,173 @@
+{
+  "socket": {
+    "domain": "PF_LLC",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_llc(domain const[PF_LLC], type const[SOCK_DGRAM], proto const[0]) sock_llc",
+    "comment": "Assuming SOCK_DGRAM as the type since it's the most common for datagram-oriented protocols and there's no explicit type in the provided code."
+  },
+  "resources": {
+    "sock_llc": {
+      "type": "sock",
+      "spec": "resource sock_llc[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_llc",
+  "setsockopt": {
+    "LLC_OPT_RETRY": {
+      "level": "SOL_LLC",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "LLC_OPT_SIZE": {
+      "level": "SOL_LLC",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "LLC_OPT_ACK_TMR_EXP": {
+      "level": "SOL_LLC",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "LLC_OPT_P_TMR_EXP": {
+      "level": "SOL_LLC",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "LLC_OPT_REJ_TMR_EXP": {
+      "level": "SOL_LLC",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "LLC_OPT_BUSY_TMR_EXP": {
+      "level": "SOL_LLC",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "LLC_OPT_TX_WIN": {
+      "level": "SOL_LLC",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "LLC_OPT_RX_WIN": {
+      "level": "SOL_LLC",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "LLC_OPT_PKTINFO": {
+      "level": "SOL_LLC",
+      "val": "int32",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "LLC_OPT_RETRY": {
+      "level": "SOL_LLC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "LLC_OPT_SIZE": {
+      "level": "SOL_LLC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "LLC_OPT_ACK_TMR_EXP": {
+      "level": "SOL_LLC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "LLC_OPT_P_TMR_EXP": {
+      "level": "SOL_LLC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "LLC_OPT_REJ_TMR_EXP": {
+      "level": "SOL_LLC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "LLC_OPT_BUSY_TMR_EXP": {
+      "level": "SOL_LLC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "LLC_OPT_TX_WIN": {
+      "level": "SOL_LLC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "LLC_OPT_RX_WIN": {
+      "level": "SOL_LLC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "LLC_OPT_PKTINFO": {
+      "level": "SOL_LLC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "llc_ui_bind",
+    "connect": "llc_ui_connect",
+    "accept": "llc_ui_accept",
+    "poll": "datagram_poll",
+    "ioctl": "llc_ui_ioctl",
+    "sendmsg": "llc_ui_sendmsg",
+    "recvmsg": "llc_ui_recvmsg",
+    "setsockopt": "llc_ui_setsockopt",
+    "getsockopt": "llc_ui_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/llc/af_llc.c:1217",
+  "ops_name": "llc_ui_ops",
+  "syscall_specs": {
+    "socket$KGPT_llc": "socket$KGPT_llc(domain const[PF_LLC], type const[SOCK_DGRAM], proto const[0]) sock_llc",
+    "bind$KGPT_llc_ui_ops": "bind$KGPT_llc_ui_ops(fd sock_llc, addr ptr[in, sockaddr_llc], addrlen len[addr])",
+    "connect$KGPT_llc_ui_ops": "connect$KGPT_llc_ui_ops(fd sock_llc, addr ptr[in, sockaddr_llc], addrlen len[addr])",
+    "accept4$KGPT_llc_ui_ops": "accept4$KGPT_llc_ui_ops(fd sock_llc, peer ptr[out, sockaddr_llc, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_llc",
+    "sendto$KGPT_llc_ui_ops": "sendto$KGPT_llc_ui_ops(fd sock_llc, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_llc, opt], addrlen len[addr])",
+    "recvfrom$KGPT_llc_ui_ops": "recvfrom$KGPT_llc_ui_ops(fd sock_llc, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_llc, opt], addrlen len[addr])",
+    "getsockopt$KGPT_LLC_OPT_RETRY": "getsockopt$KGPT_LLC_OPT_RETRY(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_RETRY], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_LLC_OPT_SIZE": "getsockopt$KGPT_LLC_OPT_SIZE(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_SIZE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_LLC_OPT_ACK_TMR_EXP": "getsockopt$KGPT_LLC_OPT_ACK_TMR_EXP(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_ACK_TMR_EXP], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_LLC_OPT_P_TMR_EXP": "getsockopt$KGPT_LLC_OPT_P_TMR_EXP(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_P_TMR_EXP], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_LLC_OPT_REJ_TMR_EXP": "getsockopt$KGPT_LLC_OPT_REJ_TMR_EXP(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_REJ_TMR_EXP], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_LLC_OPT_BUSY_TMR_EXP": "getsockopt$KGPT_LLC_OPT_BUSY_TMR_EXP(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_BUSY_TMR_EXP], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_LLC_OPT_TX_WIN": "getsockopt$KGPT_LLC_OPT_TX_WIN(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_TX_WIN], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_LLC_OPT_RX_WIN": "getsockopt$KGPT_LLC_OPT_RX_WIN(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_RX_WIN], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_LLC_OPT_PKTINFO": "getsockopt$KGPT_LLC_OPT_PKTINFO(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_PKTINFO], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_LLC_OPT_RETRY": "setsockopt$KGPT_LLC_OPT_RETRY(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_RETRY], val int32, len bytesize[val])",
+    "setsockopt$KGPT_LLC_OPT_SIZE": "setsockopt$KGPT_LLC_OPT_SIZE(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_SIZE], val int32, len bytesize[val])",
+    "setsockopt$KGPT_LLC_OPT_ACK_TMR_EXP": "setsockopt$KGPT_LLC_OPT_ACK_TMR_EXP(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_ACK_TMR_EXP], val int32, len bytesize[val])",
+    "setsockopt$KGPT_LLC_OPT_P_TMR_EXP": "setsockopt$KGPT_LLC_OPT_P_TMR_EXP(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_P_TMR_EXP], val int32, len bytesize[val])",
+    "setsockopt$KGPT_LLC_OPT_REJ_TMR_EXP": "setsockopt$KGPT_LLC_OPT_REJ_TMR_EXP(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_REJ_TMR_EXP], val int32, len bytesize[val])",
+    "setsockopt$KGPT_LLC_OPT_BUSY_TMR_EXP": "setsockopt$KGPT_LLC_OPT_BUSY_TMR_EXP(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_BUSY_TMR_EXP], val int32, len bytesize[val])",
+    "setsockopt$KGPT_LLC_OPT_TX_WIN": "setsockopt$KGPT_LLC_OPT_TX_WIN(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_TX_WIN], val int32, len bytesize[val])",
+    "setsockopt$KGPT_LLC_OPT_RX_WIN": "setsockopt$KGPT_LLC_OPT_RX_WIN(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_RX_WIN], val int32, len bytesize[val])",
+    "setsockopt$KGPT_LLC_OPT_PKTINFO": "setsockopt$KGPT_LLC_OPT_PKTINFO(fd sock_llc, level const[SOL_LLC], opt const[LLC_OPT_PKTINFO], val int32, len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_llc"
+  ],
+  "includes": [
+    "uapi/linux/llc.h",
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_llc": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/llcp_rawsock_ops#net_nfc_llcp_sock.c:932.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/llcp_rawsock_ops#net_nfc_llcp_sock.c:932.json
@@ -1,0 +1,45 @@
+{
+  "socket": {
+    "domain": "AF_NFC",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_llcp(domain const[AF_NFC], type const[SOCK_RAW], proto const[0]) sock_llcp"
+  },
+  "resources": {
+    "sock_llcp": {
+      "type": "sock",
+      "spec": "resource sock_llcp[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_nfc_llcp",
+  "proto_ops": {
+    "bind": "llcp_raw_sock_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "poll": "llcp_sock_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "sock_no_sendmsg",
+    "recvmsg": "llcp_sock_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/nfc/llcp_sock.c:932",
+  "ops_name": "llcp_rawsock_ops",
+  "syscall_specs": {
+    "socket$KGPT_llcp": "socket$KGPT_llcp(domain const[AF_NFC], type const[SOCK_RAW], proto const[0]) sock_llcp",
+    "bind$KGPT_llcp_rawsock_ops": "bind$KGPT_llcp_rawsock_ops(fd sock_llcp, addr ptr[in, sockaddr_nfc_llcp], addrlen len[addr])",
+    "connect$KGPT_llcp_rawsock_ops": "connect$KGPT_llcp_rawsock_ops(fd sock_llcp, addr ptr[in, sockaddr_nfc_llcp], addrlen len[addr])",
+    "accept4$KGPT_llcp_rawsock_ops": "accept4$KGPT_llcp_rawsock_ops(fd sock_llcp, peer ptr[out, sockaddr_nfc_llcp, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_llcp",
+    "sendto$KGPT_llcp_rawsock_ops": "sendto$KGPT_llcp_rawsock_ops(fd sock_llcp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_nfc_llcp, opt], addrlen len[addr])",
+    "recvfrom$KGPT_llcp_rawsock_ops": "recvfrom$KGPT_llcp_rawsock_ops(fd sock_llcp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_nfc_llcp, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_llcp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_nfc_llcp": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/llcp_sock_ops#net_nfc_llcp_sock.c:912.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/llcp_sock_ops#net_nfc_llcp_sock.c:912.json
@@ -1,0 +1,104 @@
+{
+  "socket": {
+    "domain": "AF_NFC",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_llcp(domain const[AF_NFC], type flags[llcp_socket_type], proto const[0]) sock_llcp"
+  },
+  "resources": {
+    "sock_llcp": {
+      "type": "sock",
+      "spec": "resource sock_llcp[sock]"
+    }
+  },
+  "types": {
+    "llcp_socket_type": "llcp_socket_type = SOCK_STREAM, SOCK_DGRAM, SOCK_RAW"
+  },
+  "socket_addr": "sockaddr_nfc_llcp",
+  "setsockopt": {
+    "NFC_LLCP_RW": {
+      "level": "SOL_NFC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "NFC_LLCP_MIUX": {
+      "level": "SOL_NFC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "NFC_LLCP_RW": {
+      "level": "SOL_NFC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NFC_LLCP_MIUX": {
+      "level": "SOL_NFC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NFC_LLCP_REMOTE_MIU": {
+      "level": "SOL_NFC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NFC_LLCP_REMOTE_LTO": {
+      "level": "SOL_NFC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NFC_LLCP_REMOTE_RW": {
+      "level": "SOL_NFC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "llcp_sock_bind",
+    "connect": "llcp_sock_connect",
+    "accept": "llcp_sock_accept",
+    "poll": "llcp_sock_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "llcp_sock_sendmsg",
+    "recvmsg": "llcp_sock_recvmsg",
+    "setsockopt": "nfc_llcp_setsockopt",
+    "getsockopt": "nfc_llcp_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/nfc/llcp_sock.c:912",
+  "ops_name": "llcp_sock_ops",
+  "syscall_specs": {
+    "socket$KGPT_llcp": "socket$KGPT_llcp(domain const[AF_NFC], type flags[llcp_socket_type], proto const[0]) sock_llcp",
+    "bind$KGPT_llcp_sock_ops": "bind$KGPT_llcp_sock_ops(fd sock_llcp, addr ptr[in, sockaddr_nfc_llcp], addrlen len[addr])",
+    "connect$KGPT_llcp_sock_ops": "connect$KGPT_llcp_sock_ops(fd sock_llcp, addr ptr[in, sockaddr_nfc_llcp], addrlen len[addr])",
+    "accept4$KGPT_llcp_sock_ops": "accept4$KGPT_llcp_sock_ops(fd sock_llcp, peer ptr[out, sockaddr_nfc_llcp, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_llcp",
+    "sendto$KGPT_llcp_sock_ops": "sendto$KGPT_llcp_sock_ops(fd sock_llcp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_nfc_llcp, opt], addrlen len[addr])",
+    "recvfrom$KGPT_llcp_sock_ops": "recvfrom$KGPT_llcp_sock_ops(fd sock_llcp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_nfc_llcp, opt], addrlen len[addr])",
+    "getsockopt$KGPT_NFC_LLCP_RW": "getsockopt$KGPT_NFC_LLCP_RW(fd sock_llcp, level const[SOL_NFC], opt const[NFC_LLCP_RW], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NFC_LLCP_MIUX": "getsockopt$KGPT_NFC_LLCP_MIUX(fd sock_llcp, level const[SOL_NFC], opt const[NFC_LLCP_MIUX], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NFC_LLCP_REMOTE_MIU": "getsockopt$KGPT_NFC_LLCP_REMOTE_MIU(fd sock_llcp, level const[SOL_NFC], opt const[NFC_LLCP_REMOTE_MIU], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NFC_LLCP_REMOTE_LTO": "getsockopt$KGPT_NFC_LLCP_REMOTE_LTO(fd sock_llcp, level const[SOL_NFC], opt const[NFC_LLCP_REMOTE_LTO], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NFC_LLCP_REMOTE_RW": "getsockopt$KGPT_NFC_LLCP_REMOTE_RW(fd sock_llcp, level const[SOL_NFC], opt const[NFC_LLCP_REMOTE_RW], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_NFC_LLCP_RW": "setsockopt$KGPT_NFC_LLCP_RW(fd sock_llcp, level const[SOL_NFC], opt const[NFC_LLCP_RW], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_NFC_LLCP_MIUX": "setsockopt$KGPT_NFC_LLCP_MIUX(fd sock_llcp, level const[SOL_NFC], opt const[NFC_LLCP_MIUX], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_llcp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h",
+    "uapi/linux/nfc.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_nfc_llcp": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/mctp_dgram_ops#net_mctp_af_mctp.c:470.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/mctp_dgram_ops#net_mctp_af_mctp.c:470.json
@@ -1,0 +1,87 @@
+{
+  "socket": {
+    "domain": "AF_MCTP",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_MCTP(domain const[AF_MCTP], type const[SOCK_DGRAM], proto const[0]) sock_mctp"
+  },
+  "resources": {
+    "sock_mctp": {
+      "type": "sock",
+      "spec": "resource sock_mctp[sock]"
+    }
+  },
+  "types": {
+    "sockaddr_mctp": "sockaddr_mctp {\n\tsmctp_family\tconst[AF_MCTP, int16]\n\t__smctp_pad0\tconst[0, int16]\n\tsmctp_network\tint32\n\tsmctp_addr\tmctp_addr\n\tsmctp_type\tint8\n\tsmctp_tag\tint8\n\t__smctp_pad1\tconst[0, int8]\n}",
+    "mctp_ioc_tag_ctl": "mctp_ioc_tag_ctl {\n\tpeer_addr\tmctp_eid_t\n\ttag\tint8\n\tflags\tint16\n}",
+    "mctp_addr": "mctp_addr {\n\ts_addr\tmctp_eid_t\n}",
+    "mctp_eid_t": "type mctp_eid_t ptr[in, array[int8]]"
+  },
+  "socket_addr": "sockaddr_mctp",
+  "ioctls": {
+    "SIOCMCTPALLOCTAG": {
+      "arg": "ptr[inout, mctp_ioc_tag_ctl]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "SIOCMCTPDROPTAG": {
+      "arg": "ptr[in, mctp_ioc_tag_ctl]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "MCTP_OPT_ADDR_EXT": {
+      "level": "SOL_MCTP",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "MCTP_OPT_ADDR_EXT": {
+      "level": "SOL_MCTP",
+      "val": "ptr[out, int32]",
+      "len": "ptr[in, int32]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "mctp_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "mctp_ioctl",
+    "sendmsg": "mctp_sendmsg",
+    "recvmsg": "mctp_recvmsg",
+    "setsockopt": "mctp_setsockopt",
+    "getsockopt": "mctp_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/mctp/af_mctp.c:470",
+  "ops_name": "mctp_dgram_ops",
+  "syscall_specs": {
+    "socket$KGPT_MCTP": "socket$KGPT_MCTP(domain const[AF_MCTP], type const[SOCK_DGRAM], proto const[0]) sock_mctp",
+    "bind$KGPT_mctp_dgram_ops": "bind$KGPT_mctp_dgram_ops(fd sock_mctp, addr ptr[in, sockaddr_mctp], addrlen len[addr])",
+    "connect$KGPT_mctp_dgram_ops": "connect$KGPT_mctp_dgram_ops(fd sock_mctp, addr ptr[in, sockaddr_mctp], addrlen len[addr])",
+    "accept4$KGPT_mctp_dgram_ops": "accept4$KGPT_mctp_dgram_ops(fd sock_mctp, peer ptr[out, sockaddr_mctp, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_mctp",
+    "sendto$KGPT_mctp_dgram_ops": "sendto$KGPT_mctp_dgram_ops(fd sock_mctp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_mctp, opt], addrlen len[addr])",
+    "recvfrom$KGPT_mctp_dgram_ops": "recvfrom$KGPT_mctp_dgram_ops(fd sock_mctp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_mctp, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCMCTPALLOCTAG": "ioctl$KGPT_SIOCMCTPALLOCTAG(fd sock_mctp, cmd const[SIOCMCTPALLOCTAG], arg ptr[inout, mctp_ioc_tag_ctl])",
+    "ioctl$KGPT_SIOCMCTPDROPTAG": "ioctl$KGPT_SIOCMCTPDROPTAG(fd sock_mctp, cmd const[SIOCMCTPDROPTAG], arg ptr[in, mctp_ioc_tag_ctl])",
+    "getsockopt$KGPT_MCTP_OPT_ADDR_EXT": "getsockopt$KGPT_MCTP_OPT_ADDR_EXT(fd sock_mctp, level const[SOL_MCTP], opt const[MCTP_OPT_ADDR_EXT], val ptr[out, int32], len ptr[in, int32])",
+    "setsockopt$KGPT_MCTP_OPT_ADDR_EXT": "setsockopt$KGPT_MCTP_OPT_ADDR_EXT(fd sock_mctp, level const[SOL_MCTP], opt const[MCTP_OPT_ADDR_EXT], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_MCTP"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h",
+    "uapi/linux/mctp.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/mptcp_stream_ops#net_mptcp_protocol.c:3950.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/mptcp_stream_ops#net_mptcp_protocol.c:3950.json
@@ -1,0 +1,441 @@
+{
+  "socket": {
+    "domain": "AF_INET",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_mptcp(domain const[AF_INET], type const[SOCK_STREAM], proto const[IPPROTO_MPTCP]) sock_mptcp"
+  },
+  "resources": {
+    "sock_mptcp": {
+      "type": "sock",
+      "spec": "resource sock_mptcp[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_MPTCP": "define IPPROTO_MPTCP 262",
+    "sockaddr_in_any": "sockaddr_in_any [\n\tipv4\tsockaddr_in\n\tipv6\tsockaddr_in6\n] [varlen]"
+  },
+  "socket_addr": "sockaddr_in_any",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "ip_rt_ioctl"
+        ],
+        "type": [
+          "rtentry"
+        ],
+        "usage": [
+          "if (copy_from_user(&rt, p, sizeof(struct rtentry)))"
+        ]
+      }
+    },
+    "SIOCRTMSG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCDARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCSARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "arp_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "err = arp_ioctl(net, cmd, (void __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCGIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);",
+          "if (!err && put_user_ifreq(&ifr, p))"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFPFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCSIFFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "p"
+      ],
+      "arg_inference": {
+        "function": [
+          "devinet_ioctl"
+        ],
+        "type": [
+          "ifreq"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, p))",
+          "err = devinet_ioctl(net, cmd, &ifr);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "mptcp_bind",
+    "connect": "inet_stream_connect",
+    "accept": "mptcp_stream_accept",
+    "poll": "mptcp_poll",
+    "ioctl": "inet_ioctl",
+    "sendmsg": "inet_sendmsg",
+    "recvmsg": "inet_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/mptcp/protocol.c:3950",
+  "ops_name": "mptcp_stream_ops",
+  "syscall_specs": {
+    "socket$KGPT_mptcp": "socket$KGPT_mptcp(domain const[AF_INET], type const[SOCK_STREAM], proto const[IPPROTO_MPTCP]) sock_mptcp",
+    "bind$KGPT_mptcp_stream_ops": "bind$KGPT_mptcp_stream_ops(fd sock_mptcp, addr ptr[in, sockaddr_in_any], addrlen len[addr])",
+    "connect$KGPT_mptcp_stream_ops": "connect$KGPT_mptcp_stream_ops(fd sock_mptcp, addr ptr[in, sockaddr_in_any], addrlen len[addr])",
+    "accept4$KGPT_mptcp_stream_ops": "accept4$KGPT_mptcp_stream_ops(fd sock_mptcp, peer ptr[out, sockaddr_in_any, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_mptcp",
+    "sendto$KGPT_mptcp_stream_ops": "sendto$KGPT_mptcp_stream_ops(fd sock_mptcp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in_any, opt], addrlen len[addr])",
+    "recvfrom$KGPT_mptcp_stream_ops": "recvfrom$KGPT_mptcp_stream_ops(fd sock_mptcp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in_any, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_mptcp, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_mptcp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in": "EXISTING",
+    "sockaddr_in6": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/mptcp_v6_stream_ops#net_mptcp_protocol.c:4049.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/mptcp_v6_stream_ops#net_mptcp_protocol.c:4049.json
@@ -1,0 +1,233 @@
+{
+  "socket": {
+    "domain": "AF_INET6",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_mptcp_v6(domain const[AF_INET6], type const[SOCK_STREAM], proto const[IPPROTO_MPTCP]) sock_mptcp_v6"
+  },
+  "resources": {
+    "sock_mptcp_v6": {
+      "type": "sock",
+      "spec": "resource sock_mptcp_v6[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_MPTCP": "define IPPROTO_MPTCP 262",
+    "sockaddr_in_any": "sockaddr_in_any [\n\tipv4\tsockaddr_in\n\tipv6\tsockaddr_in6\n] [varlen]"
+  },
+  "socket_addr": "sockaddr_in_any",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "intptr",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipv6_route_ioctl"
+        ],
+        "type": [
+          "in6_rtmsg"
+        ],
+        "usage": [
+          "if (copy_from_user(&rtmsg, argp, sizeof(rtmsg)))\n\t\treturn -EFAULT;\n\treturn ipv6_route_ioctl(net, cmd, &rtmsg);"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_add_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_add_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCDIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_del_ifaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_del_ifaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "addrconf_set_dstaddr"
+        ],
+        "type": [],
+        "usage": [
+          "return addrconf_set_dstaddr(net, argp);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "int karg;",
+          "if (get_user(karg, (int __user *)arg))",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "mptcp_bind",
+    "connect": "inet_stream_connect",
+    "accept": "mptcp_stream_accept",
+    "poll": "mptcp_poll",
+    "ioctl": "inet6_ioctl",
+    "sendmsg": "inet6_sendmsg",
+    "recvmsg": "inet6_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/mptcp/protocol.c:4049",
+  "ops_name": "mptcp_v6_stream_ops",
+  "syscall_specs": {
+    "socket$KGPT_mptcp_v6": "socket$KGPT_mptcp_v6(domain const[AF_INET6], type const[SOCK_STREAM], proto const[IPPROTO_MPTCP]) sock_mptcp_v6",
+    "bind$KGPT_mptcp_v6_stream_ops": "bind$KGPT_mptcp_v6_stream_ops(fd sock_mptcp_v6, addr ptr[in, sockaddr_in_any], addrlen len[addr])",
+    "connect$KGPT_mptcp_v6_stream_ops": "connect$KGPT_mptcp_v6_stream_ops(fd sock_mptcp_v6, addr ptr[in, sockaddr_in_any], addrlen len[addr])",
+    "accept4$KGPT_mptcp_v6_stream_ops": "accept4$KGPT_mptcp_v6_stream_ops(fd sock_mptcp_v6, peer ptr[out, sockaddr_in_any, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_mptcp_v6",
+    "sendto$KGPT_mptcp_v6_stream_ops": "sendto$KGPT_mptcp_v6_stream_ops(fd sock_mptcp_v6, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in_any, opt], addrlen len[addr])",
+    "recvfrom$KGPT_mptcp_v6_stream_ops": "recvfrom$KGPT_mptcp_v6_stream_ops(fd sock_mptcp_v6, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in_any, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_mptcp_v6, cmd const[SIOCPNADDRESOURCE], arg intptr)"
+  },
+  "init_syscalls": [
+    "socket$KGPT_mptcp_v6"
+  ],
+  "includes": [
+    "linux/net.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in": "EXISTING",
+    "sockaddr_in6": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/msg_ops#net_tipc_socket.c:3360.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/msg_ops#net_tipc_socket.c:3360.json
@@ -1,0 +1,231 @@
+{
+  "socket": {
+    "domain": "AF_TIPC",
+    "type": "SOCK_RDM",
+    "spec": "socket$KGPT_tipc(domain const[AF_TIPC], type const[SOCK_RDM], proto const[0]) sock_tipc"
+  },
+  "resources": {
+    "sock_tipc": {
+      "type": "sock",
+      "spec": "resource sock_tipc[sock]"
+    }
+  },
+  "types": {
+    "tipc_uaddr": "tipc_uaddr {\n\tfamily\tint16\n\taddrtype\tint8\n\tscope\tint8\n\tu\ttipc_uaddr_union\n}",
+    "tipc_uaddr_union": "tipc_uaddr_union [\n\tsa\ttipc_service_addr\n\tlookup_node\tint32\n\tsr\ttipc_service_range\n\tsk\ttipc_socket_addr\n]"
+  },
+  "socket_addr": "tipc_uaddr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCGETLINKNAME": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp",
+        "lnr"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "tipc_node_get_linkname",
+          "copy_to_user"
+        ],
+        "type": [
+          "tipc_sioc_ln_req"
+        ],
+        "usage": [
+          "struct tipc_sioc_ln_req lnr;",
+          "if (copy_from_user(&lnr, argp, sizeof(lnr)))",
+          "if (!tipc_node_get_linkname(net, lnr.bearer_id & 0xffff, lnr.peer, lnr.linkname, TIPC_MAX_LINK_NAME))",
+          "if (copy_to_user(argp, &lnr, sizeof(lnr)))"
+        ]
+      }
+    },
+    "SIOCGETNODEID": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp",
+        "nr"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "tipc_node_get_id",
+          "copy_to_user"
+        ],
+        "type": [
+          "tipc_sioc_nodeid_req"
+        ],
+        "usage": [
+          "struct tipc_sioc_nodeid_req nr;",
+          "if (copy_from_user(&nr, argp, sizeof(nr)))",
+          "if (!tipc_node_get_id(net, nr.peer, nr.node_id))",
+          "if (copy_to_user(argp, &nr, sizeof(nr)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "TIPC_IMPORTANCE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_SRC_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_DEST_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_CONN_TIMEOUT": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_NODELAY": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_GROUP_JOIN": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, tipc_group_req]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_MCAST_BROADCAST": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_MCAST_REPLICAST": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_GROUP_LEAVE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "TIPC_IMPORTANCE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_SRC_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_DEST_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_CONN_TIMEOUT": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_NODE_RECVQ_DEPTH": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_SOCK_RECVQ_DEPTH": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_SOCK_RECVQ_USED": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_GROUP_JOIN": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": {
+        "function": [
+          "tipc_group_self"
+        ],
+        "type": [
+          "tipc_service_range"
+        ],
+        "usage": [
+          "tipc_group_self(tsk->group, &seq, &scope);\nvalue = seq.type;"
+        ]
+      }
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "tipc_bind",
+    "connect": "tipc_connect",
+    "accept": "sock_no_accept",
+    "poll": "tipc_poll",
+    "ioctl": "tipc_ioctl",
+    "sendmsg": "tipc_sendmsg",
+    "recvmsg": "tipc_recvmsg",
+    "setsockopt": "tipc_setsockopt",
+    "getsockopt": "tipc_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/tipc/socket.c:3360",
+  "ops_name": "msg_ops",
+  "syscall_specs": {
+    "socket$KGPT_tipc": "socket$KGPT_tipc(domain const[AF_TIPC], type const[SOCK_RDM], proto const[0]) sock_tipc",
+    "bind$KGPT_msg_ops": "bind$KGPT_msg_ops(fd sock_tipc, addr ptr[in, tipc_uaddr], addrlen len[addr])",
+    "connect$KGPT_msg_ops": "connect$KGPT_msg_ops(fd sock_tipc, addr ptr[in, tipc_uaddr], addrlen len[addr])",
+    "accept4$KGPT_msg_ops": "accept4$KGPT_msg_ops(fd sock_tipc, peer ptr[out, tipc_uaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_tipc",
+    "sendto$KGPT_msg_ops": "sendto$KGPT_msg_ops(fd sock_tipc, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, tipc_uaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_msg_ops": "recvfrom$KGPT_msg_ops(fd sock_tipc, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, tipc_uaddr, opt], addrlen len[addr])",
+    "getsockopt$KGPT_TIPC_IMPORTANCE": "getsockopt$KGPT_TIPC_IMPORTANCE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_IMPORTANCE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_SRC_DROPPABLE": "getsockopt$KGPT_TIPC_SRC_DROPPABLE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_SRC_DROPPABLE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_DEST_DROPPABLE": "getsockopt$KGPT_TIPC_DEST_DROPPABLE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_DEST_DROPPABLE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_CONN_TIMEOUT": "getsockopt$KGPT_TIPC_CONN_TIMEOUT(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_CONN_TIMEOUT], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_NODE_RECVQ_DEPTH": "getsockopt$KGPT_TIPC_NODE_RECVQ_DEPTH(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_NODE_RECVQ_DEPTH], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_SOCK_RECVQ_DEPTH": "getsockopt$KGPT_TIPC_SOCK_RECVQ_DEPTH(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_SOCK_RECVQ_DEPTH], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_SOCK_RECVQ_USED": "getsockopt$KGPT_TIPC_SOCK_RECVQ_USED(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_SOCK_RECVQ_USED], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_GROUP_JOIN": "getsockopt$KGPT_TIPC_GROUP_JOIN(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_GROUP_JOIN], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_TIPC_IMPORTANCE": "setsockopt$KGPT_TIPC_IMPORTANCE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_IMPORTANCE], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_SRC_DROPPABLE": "setsockopt$KGPT_TIPC_SRC_DROPPABLE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_SRC_DROPPABLE], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_DEST_DROPPABLE": "setsockopt$KGPT_TIPC_DEST_DROPPABLE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_DEST_DROPPABLE], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_CONN_TIMEOUT": "setsockopt$KGPT_TIPC_CONN_TIMEOUT(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_CONN_TIMEOUT], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_NODELAY": "setsockopt$KGPT_TIPC_NODELAY(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_NODELAY], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_GROUP_JOIN": "setsockopt$KGPT_TIPC_GROUP_JOIN(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_GROUP_JOIN], val ptr[in, tipc_group_req], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_MCAST_BROADCAST": "setsockopt$KGPT_TIPC_MCAST_BROADCAST(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_MCAST_BROADCAST], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_MCAST_REPLICAST": "setsockopt$KGPT_TIPC_MCAST_REPLICAST(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_MCAST_REPLICAST], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_GROUP_LEAVE": "setsockopt$KGPT_TIPC_GROUP_LEAVE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_GROUP_LEAVE], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_tipc"
+  ],
+  "includes": [
+    "uapi/linux/tipc.h",
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "tipc_group_req": "EXISTING",
+    "tipc_service_addr": "EXISTING",
+    "tipc_service_range": "EXISTING",
+    "tipc_socket_addr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/netlink_ops#net_netlink_af_netlink.c:2797.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/netlink_ops#net_netlink_af_netlink.c:2797.json
@@ -1,0 +1,160 @@
+{
+  "socket": {
+    "domain": "AF_NETLINK",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_netlink(domain const[AF_NETLINK], type const[SOCK_RAW], proto const[NETLINK_ROUTE]) sock_netlink"
+  },
+  "resources": {
+    "sock_netlink": {
+      "type": "sock",
+      "spec": "resource sock_netlink[sock]"
+    }
+  },
+  "types": {
+    "NETLINK_ROUTE": "define NETLINK_ROUTE 0"
+  },
+  "socket_addr": "sockaddr_nl",
+  "setsockopt": {
+    "NETLINK_PKTINFO": {
+      "level": "SOL_NETLINK",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "NETLINK_ADD_MEMBERSHIP": {
+      "level": "SOL_NETLINK",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "NETLINK_DROP_MEMBERSHIP": {
+      "level": "SOL_NETLINK",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "NETLINK_BROADCAST_ERROR": {
+      "level": "SOL_NETLINK",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "NETLINK_NO_ENOBUFS": {
+      "level": "SOL_NETLINK",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "NETLINK_LISTEN_ALL_NSID": {
+      "level": "SOL_NETLINK",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "NETLINK_CAP_ACK": {
+      "level": "SOL_NETLINK",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "NETLINK_EXT_ACK": {
+      "level": "SOL_NETLINK",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "NETLINK_GET_STRICT_CHK": {
+      "level": "SOL_NETLINK",
+      "val": "int32",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "NETLINK_PKTINFO": {
+      "level": "SOL_NETLINK",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NETLINK_BROADCAST_ERROR": {
+      "level": "SOL_NETLINK",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NETLINK_NO_ENOBUFS": {
+      "level": "SOL_NETLINK",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NETLINK_LIST_MEMBERSHIPS": {
+      "level": "SOL_NETLINK",
+      "val": "ptr[out, array[int32]]",
+      "len": "ptr[inout, int32]",
+      "val_inference": null
+    },
+    "NETLINK_CAP_ACK": {
+      "level": "SOL_NETLINK",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NETLINK_EXT_ACK": {
+      "level": "SOL_NETLINK",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NETLINK_GET_STRICT_CHK": {
+      "level": "SOL_NETLINK",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "netlink_bind",
+    "connect": "netlink_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "netlink_ioctl",
+    "sendmsg": "netlink_sendmsg",
+    "recvmsg": "netlink_recvmsg",
+    "setsockopt": "netlink_setsockopt",
+    "getsockopt": "netlink_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/netlink/af_netlink.c:2797",
+  "ops_name": "netlink_ops",
+  "syscall_specs": {
+    "socket$KGPT_netlink": "socket$KGPT_netlink(domain const[AF_NETLINK], type const[SOCK_RAW], proto const[NETLINK_ROUTE]) sock_netlink",
+    "bind$KGPT_netlink_ops": "bind$KGPT_netlink_ops(fd sock_netlink, addr ptr[in, sockaddr_nl], addrlen len[addr])",
+    "connect$KGPT_netlink_ops": "connect$KGPT_netlink_ops(fd sock_netlink, addr ptr[in, sockaddr_nl], addrlen len[addr])",
+    "accept4$KGPT_netlink_ops": "accept4$KGPT_netlink_ops(fd sock_netlink, peer ptr[out, sockaddr_nl, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_netlink",
+    "sendto$KGPT_netlink_ops": "sendto$KGPT_netlink_ops(fd sock_netlink, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_nl, opt], addrlen len[addr])",
+    "recvfrom$KGPT_netlink_ops": "recvfrom$KGPT_netlink_ops(fd sock_netlink, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_nl, opt], addrlen len[addr])",
+    "getsockopt$KGPT_NETLINK_PKTINFO": "getsockopt$KGPT_NETLINK_PKTINFO(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_PKTINFO], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NETLINK_BROADCAST_ERROR": "getsockopt$KGPT_NETLINK_BROADCAST_ERROR(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_BROADCAST_ERROR], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NETLINK_NO_ENOBUFS": "getsockopt$KGPT_NETLINK_NO_ENOBUFS(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_NO_ENOBUFS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NETLINK_LIST_MEMBERSHIPS": "getsockopt$KGPT_NETLINK_LIST_MEMBERSHIPS(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_LIST_MEMBERSHIPS], val ptr[out, array[int32]], len ptr[inout, int32])",
+    "getsockopt$KGPT_NETLINK_CAP_ACK": "getsockopt$KGPT_NETLINK_CAP_ACK(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_CAP_ACK], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NETLINK_EXT_ACK": "getsockopt$KGPT_NETLINK_EXT_ACK(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_EXT_ACK], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NETLINK_GET_STRICT_CHK": "getsockopt$KGPT_NETLINK_GET_STRICT_CHK(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_GET_STRICT_CHK], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_NETLINK_PKTINFO": "setsockopt$KGPT_NETLINK_PKTINFO(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_PKTINFO], val int32, len bytesize[val])",
+    "setsockopt$KGPT_NETLINK_ADD_MEMBERSHIP": "setsockopt$KGPT_NETLINK_ADD_MEMBERSHIP(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_ADD_MEMBERSHIP], val int32, len bytesize[val])",
+    "setsockopt$KGPT_NETLINK_DROP_MEMBERSHIP": "setsockopt$KGPT_NETLINK_DROP_MEMBERSHIP(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_DROP_MEMBERSHIP], val int32, len bytesize[val])",
+    "setsockopt$KGPT_NETLINK_BROADCAST_ERROR": "setsockopt$KGPT_NETLINK_BROADCAST_ERROR(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_BROADCAST_ERROR], val int32, len bytesize[val])",
+    "setsockopt$KGPT_NETLINK_NO_ENOBUFS": "setsockopt$KGPT_NETLINK_NO_ENOBUFS(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_NO_ENOBUFS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_NETLINK_LISTEN_ALL_NSID": "setsockopt$KGPT_NETLINK_LISTEN_ALL_NSID(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_LISTEN_ALL_NSID], val int32, len bytesize[val])",
+    "setsockopt$KGPT_NETLINK_CAP_ACK": "setsockopt$KGPT_NETLINK_CAP_ACK(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_CAP_ACK], val int32, len bytesize[val])",
+    "setsockopt$KGPT_NETLINK_EXT_ACK": "setsockopt$KGPT_NETLINK_EXT_ACK(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_EXT_ACK], val int32, len bytesize[val])",
+    "setsockopt$KGPT_NETLINK_GET_STRICT_CHK": "setsockopt$KGPT_NETLINK_GET_STRICT_CHK(fd sock_netlink, level const[SOL_NETLINK], opt const[NETLINK_GET_STRICT_CHK], val int32, len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_netlink"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/netlink.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_nl": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/nr_proto_ops#net_netrom_af_netrom.c:1353.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/nr_proto_ops#net_netrom_af_netrom.c:1353.json
@@ -1,0 +1,260 @@
+{
+  "socket": {
+    "domain": "AF_NETROM",
+    "type": "SOCK_SEQPACKET",
+    "spec": "syz_init_net_socket$KGPT_netrom(domain const[AF_NETROM], type const[SOCK_SEQPACKET], proto const[0]) sock_netrom"
+  },
+  "resources": {
+    "sock_netrom": {
+      "type": "sock",
+      "spec": "resource sock_netrom[sock]"
+    }
+  },
+  "types": {
+    "sockaddr_ax25_any": "sockaddr_ax25_any [\n\tshort\tsockaddr_ax25\n\tfull\tfull_sockaddr_ax25\n] [varlen]"
+  },
+  "socket_addr": "sockaddr_ax25_any",
+  "ioctls": {
+    "SIOCGIFMETRIC": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFMETRIC": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "TIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "return put_user(amount, (int __user *)argp);"
+        ]
+      }
+    },
+    "TIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "return put_user(amount, (int __user *)argp);"
+        ]
+      }
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "nr_rt_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return nr_rt_ioctl(cmd, argp);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "nr_rt_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return nr_rt_ioctl(cmd, argp);"
+        ]
+      }
+    },
+    "SIOCNRDECOBS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "nr_rt_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return nr_rt_ioctl(cmd, argp);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "NETROM_T1": {
+      "level": "SOL_NETROM",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "NETROM_T2": {
+      "level": "SOL_NETROM",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "NETROM_N2": {
+      "level": "SOL_NETROM",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "NETROM_T4": {
+      "level": "SOL_NETROM",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "NETROM_IDLE": {
+      "level": "SOL_NETROM",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "NETROM_T1": {
+      "level": "SOL_NETROM",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NETROM_T2": {
+      "level": "SOL_NETROM",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NETROM_N2": {
+      "level": "SOL_NETROM",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NETROM_T4": {
+      "level": "SOL_NETROM",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "NETROM_IDLE": {
+      "level": "SOL_NETROM",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "nr_bind",
+    "connect": "nr_connect",
+    "accept": "nr_accept",
+    "poll": "datagram_poll",
+    "ioctl": "nr_ioctl",
+    "sendmsg": "nr_sendmsg",
+    "recvmsg": "nr_recvmsg",
+    "setsockopt": "nr_setsockopt",
+    "getsockopt": "nr_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/netrom/af_netrom.c:1353",
+  "ops_name": "nr_proto_ops",
+  "syscall_specs": {
+    "syz_init_net_socket$KGPT_netrom": "syz_init_net_socket$KGPT_netrom(domain const[AF_NETROM], type const[SOCK_SEQPACKET], proto const[0]) sock_netrom",
+    "bind$KGPT_nr_proto_ops": "bind$KGPT_nr_proto_ops(fd sock_netrom, addr ptr[in, sockaddr_ax25_any], addrlen len[addr])",
+    "connect$KGPT_nr_proto_ops": "connect$KGPT_nr_proto_ops(fd sock_netrom, addr ptr[in, sockaddr_ax25_any], addrlen len[addr])",
+    "accept4$KGPT_nr_proto_ops": "accept4$KGPT_nr_proto_ops(fd sock_netrom, peer ptr[out, sockaddr_ax25_any, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_netrom",
+    "sendto$KGPT_nr_proto_ops": "sendto$KGPT_nr_proto_ops(fd sock_netrom, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_ax25_any, opt], addrlen len[addr])",
+    "recvfrom$KGPT_nr_proto_ops": "recvfrom$KGPT_nr_proto_ops(fd sock_netrom, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_ax25_any, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCGIFMETRIC": "ioctl$KGPT_SIOCGIFMETRIC(fd sock_netrom, cmd const[SIOCGIFMETRIC], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SIOCSIFMETRIC": "ioctl$KGPT_SIOCSIFMETRIC(fd sock_netrom, cmd const[SIOCSIFMETRIC], arg ptr[in, array[int8]])",
+    "getsockopt$KGPT_NETROM_T1": "getsockopt$KGPT_NETROM_T1(fd sock_netrom, level const[SOL_NETROM], opt const[NETROM_T1], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NETROM_T2": "getsockopt$KGPT_NETROM_T2(fd sock_netrom, level const[SOL_NETROM], opt const[NETROM_T2], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NETROM_N2": "getsockopt$KGPT_NETROM_N2(fd sock_netrom, level const[SOL_NETROM], opt const[NETROM_N2], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NETROM_T4": "getsockopt$KGPT_NETROM_T4(fd sock_netrom, level const[SOL_NETROM], opt const[NETROM_T4], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_NETROM_IDLE": "getsockopt$KGPT_NETROM_IDLE(fd sock_netrom, level const[SOL_NETROM], opt const[NETROM_IDLE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_NETROM_T1": "setsockopt$KGPT_NETROM_T1(fd sock_netrom, level const[SOL_NETROM], opt const[NETROM_T1], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_NETROM_T2": "setsockopt$KGPT_NETROM_T2(fd sock_netrom, level const[SOL_NETROM], opt const[NETROM_T2], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_NETROM_N2": "setsockopt$KGPT_NETROM_N2(fd sock_netrom, level const[SOL_NETROM], opt const[NETROM_N2], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_NETROM_T4": "setsockopt$KGPT_NETROM_T4(fd sock_netrom, level const[SOL_NETROM], opt const[NETROM_T4], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_NETROM_IDLE": "setsockopt$KGPT_NETROM_IDLE(fd sock_netrom, level const[SOL_NETROM], opt const[NETROM_IDLE], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "syz_init_net_socket$KGPT_netrom"
+  ],
+  "includes": [
+    "uapi/linux/sockios.h",
+    "linux/net.h",
+    "uapi/linux/netrom.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_ax25": "EXISTING",
+    "full_sockaddr_ax25": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/packet_ops#net_tipc_socket.c:3380.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/packet_ops#net_tipc_socket.c:3380.json
@@ -1,0 +1,231 @@
+{
+  "socket": {
+    "domain": "AF_TIPC",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_tipc(domain const[AF_TIPC], type const[SOCK_SEQPACKET], proto const[0]) sock_tipc"
+  },
+  "resources": {
+    "sock_tipc": {
+      "type": "sock",
+      "spec": "resource sock_tipc[sock]"
+    }
+  },
+  "types": {
+    "tipc_uaddr": "tipc_uaddr {\n\tfamily\tint16\n\taddrtype\tint8\n\tscope\tint8\n\tu\ttipc_uaddr_union\n}",
+    "tipc_uaddr_union": "tipc_uaddr_union [\n\tsa\ttipc_service_addr\n\tlookup_node\tint32\n\tsr\ttipc_service_range\n\tsk\ttipc_socket_addr\n]"
+  },
+  "socket_addr": "tipc_uaddr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCGETLINKNAME": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp",
+        "lnr"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "tipc_node_get_linkname",
+          "copy_to_user"
+        ],
+        "type": [
+          "tipc_sioc_ln_req"
+        ],
+        "usage": [
+          "struct tipc_sioc_ln_req lnr;",
+          "if (copy_from_user(&lnr, argp, sizeof(lnr)))",
+          "if (!tipc_node_get_linkname(net, lnr.bearer_id & 0xffff, lnr.peer, lnr.linkname, TIPC_MAX_LINK_NAME))",
+          "if (copy_to_user(argp, &lnr, sizeof(lnr)))"
+        ]
+      }
+    },
+    "SIOCGETNODEID": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp",
+        "nr"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "tipc_node_get_id",
+          "copy_to_user"
+        ],
+        "type": [
+          "tipc_sioc_nodeid_req"
+        ],
+        "usage": [
+          "struct tipc_sioc_nodeid_req nr;",
+          "if (copy_from_user(&nr, argp, sizeof(nr)))",
+          "if (!tipc_node_get_id(net, nr.peer, nr.node_id))",
+          "if (copy_to_user(argp, &nr, sizeof(nr)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "TIPC_IMPORTANCE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_SRC_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_DEST_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_CONN_TIMEOUT": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_NODELAY": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_GROUP_JOIN": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, tipc_group_req]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_MCAST_BROADCAST": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_MCAST_REPLICAST": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_GROUP_LEAVE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "TIPC_IMPORTANCE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_SRC_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_DEST_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_CONN_TIMEOUT": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_NODE_RECVQ_DEPTH": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_SOCK_RECVQ_DEPTH": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_SOCK_RECVQ_USED": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_GROUP_JOIN": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": {
+        "function": [
+          "tipc_group_self"
+        ],
+        "type": [
+          "tipc_service_range"
+        ],
+        "usage": [
+          "tipc_group_self(tsk->group, &seq, &scope);\nvalue = seq.type;"
+        ]
+      }
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "tipc_bind",
+    "connect": "tipc_connect",
+    "accept": "tipc_accept",
+    "poll": "tipc_poll",
+    "ioctl": "tipc_ioctl",
+    "sendmsg": "tipc_send_packet",
+    "recvmsg": "tipc_recvmsg",
+    "setsockopt": "tipc_setsockopt",
+    "getsockopt": "tipc_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/tipc/socket.c:3380",
+  "ops_name": "packet_ops",
+  "syscall_specs": {
+    "socket$KGPT_tipc": "socket$KGPT_tipc(domain const[AF_TIPC], type const[SOCK_SEQPACKET], proto const[0]) sock_tipc",
+    "bind$KGPT_packet_ops": "bind$KGPT_packet_ops(fd sock_tipc, addr ptr[in, tipc_uaddr], addrlen len[addr])",
+    "connect$KGPT_packet_ops": "connect$KGPT_packet_ops(fd sock_tipc, addr ptr[in, tipc_uaddr], addrlen len[addr])",
+    "accept4$KGPT_packet_ops": "accept4$KGPT_packet_ops(fd sock_tipc, peer ptr[out, tipc_uaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_tipc",
+    "sendto$KGPT_packet_ops": "sendto$KGPT_packet_ops(fd sock_tipc, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, tipc_uaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_packet_ops": "recvfrom$KGPT_packet_ops(fd sock_tipc, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, tipc_uaddr, opt], addrlen len[addr])",
+    "getsockopt$KGPT_TIPC_IMPORTANCE": "getsockopt$KGPT_TIPC_IMPORTANCE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_IMPORTANCE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_SRC_DROPPABLE": "getsockopt$KGPT_TIPC_SRC_DROPPABLE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_SRC_DROPPABLE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_DEST_DROPPABLE": "getsockopt$KGPT_TIPC_DEST_DROPPABLE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_DEST_DROPPABLE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_CONN_TIMEOUT": "getsockopt$KGPT_TIPC_CONN_TIMEOUT(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_CONN_TIMEOUT], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_NODE_RECVQ_DEPTH": "getsockopt$KGPT_TIPC_NODE_RECVQ_DEPTH(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_NODE_RECVQ_DEPTH], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_SOCK_RECVQ_DEPTH": "getsockopt$KGPT_TIPC_SOCK_RECVQ_DEPTH(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_SOCK_RECVQ_DEPTH], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_SOCK_RECVQ_USED": "getsockopt$KGPT_TIPC_SOCK_RECVQ_USED(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_SOCK_RECVQ_USED], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_GROUP_JOIN": "getsockopt$KGPT_TIPC_GROUP_JOIN(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_GROUP_JOIN], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_TIPC_IMPORTANCE": "setsockopt$KGPT_TIPC_IMPORTANCE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_IMPORTANCE], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_SRC_DROPPABLE": "setsockopt$KGPT_TIPC_SRC_DROPPABLE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_SRC_DROPPABLE], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_DEST_DROPPABLE": "setsockopt$KGPT_TIPC_DEST_DROPPABLE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_DEST_DROPPABLE], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_CONN_TIMEOUT": "setsockopt$KGPT_TIPC_CONN_TIMEOUT(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_CONN_TIMEOUT], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_NODELAY": "setsockopt$KGPT_TIPC_NODELAY(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_NODELAY], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_GROUP_JOIN": "setsockopt$KGPT_TIPC_GROUP_JOIN(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_GROUP_JOIN], val ptr[in, tipc_group_req], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_MCAST_BROADCAST": "setsockopt$KGPT_TIPC_MCAST_BROADCAST(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_MCAST_BROADCAST], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_MCAST_REPLICAST": "setsockopt$KGPT_TIPC_MCAST_REPLICAST(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_MCAST_REPLICAST], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_GROUP_LEAVE": "setsockopt$KGPT_TIPC_GROUP_LEAVE(fd sock_tipc, level const[SOL_TIPC], opt const[TIPC_GROUP_LEAVE], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_tipc"
+  ],
+  "includes": [
+    "uapi/linux/tipc.h",
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "tipc_group_req": "EXISTING",
+    "tipc_service_addr": "EXISTING",
+    "tipc_service_range": "EXISTING",
+    "tipc_socket_addr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/packet_ops_spkt#net_packet_af_packet.c:4618.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/packet_ops_spkt#net_packet_af_packet.c:4618.json
@@ -1,0 +1,293 @@
+{
+  "socket": {
+    "domain": "AF_PACKET",
+    "type": "SOCK_PACKET",
+    "spec": "socket$KGPT_packet_spkt(domain const[AF_PACKET], type const[SOCK_PACKET], proto const[0]) sock_packet_spkt"
+  },
+  "resources": {
+    "sock_packet_spkt": {
+      "type": "sock",
+      "spec": "resource sock_packet_spkt[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "int amount = sk_wmem_alloc_get(sk);\nreturn put_user(amount, (int __user *)arg);"
+        ]
+      }
+    },
+    "SIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "struct sk_buff *skb;\nint amount = 0;\n...\nif (skb)\n\tamount = skb->len;\n...\nreturn put_user(amount, (int __user *)arg);"
+        ]
+      }
+    },
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCDARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCGARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCSARP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    },
+    "SIOCSIFFLAGS": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "inet_dgram_ops.ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return inet_dgram_ops.ioctl(sock, cmd, arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "packet_bind_spkt",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "packet_ioctl",
+    "sendmsg": "packet_sendmsg_spkt",
+    "recvmsg": "packet_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/packet/af_packet.c:4618",
+  "ops_name": "packet_ops_spkt",
+  "syscall_specs": {
+    "socket$KGPT_packet_spkt": "socket$KGPT_packet_spkt(domain const[AF_PACKET], type const[SOCK_PACKET], proto const[0]) sock_packet_spkt",
+    "bind$KGPT_packet_ops_spkt": "bind$KGPT_packet_ops_spkt(fd sock_packet_spkt, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_packet_ops_spkt": "connect$KGPT_packet_ops_spkt(fd sock_packet_spkt, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_packet_ops_spkt": "accept4$KGPT_packet_ops_spkt(fd sock_packet_spkt, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_packet_spkt",
+    "sendto$KGPT_packet_ops_spkt": "sendto$KGPT_packet_ops_spkt(fd sock_packet_spkt, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_packet_ops_spkt": "recvfrom$KGPT_packet_ops_spkt(fd sock_packet_spkt, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_packet_spkt"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/pfkey_ops#net_key_af_key.c:3750.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/pfkey_ops#net_key_af_key.c:3750.json
@@ -1,0 +1,48 @@
+{
+  "socket": {
+    "domain": "PF_KEY",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_pfkey(domain const[PF_KEY], type const[SOCK_RAW], proto const[PF_KEY_V2]) sock_pfkey"
+  },
+  "resources": {
+    "sock_pfkey": {
+      "type": "sock",
+      "spec": "resource sock_pfkey[sock]"
+    }
+  },
+  "types": {
+    "PF_KEY_V2": "define PF_KEY_V2 2"
+  },
+  "socket_addr": "sockaddr",
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "pfkey_sendmsg",
+    "recvmsg": "pfkey_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/key/af_key.c:3750",
+  "ops_name": "pfkey_ops",
+  "syscall_specs": {
+    "socket$KGPT_pfkey": "socket$KGPT_pfkey(domain const[PF_KEY], type const[SOCK_RAW], proto const[PF_KEY_V2]) sock_pfkey",
+    "bind$KGPT_pfkey_ops": "bind$KGPT_pfkey_ops(fd sock_pfkey, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_pfkey_ops": "connect$KGPT_pfkey_ops(fd sock_pfkey, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_pfkey_ops": "accept4$KGPT_pfkey_ops(fd sock_pfkey, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_pfkey",
+    "sendto$KGPT_pfkey_ops": "sendto$KGPT_pfkey_ops(fd sock_pfkey, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_pfkey_ops": "recvfrom$KGPT_pfkey_ops(fd sock_pfkey, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_pfkey"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h",
+    "uapi/linux/pfkeyv2.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/phonet_dgram_ops#net_phonet_socket.c:428.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/phonet_dgram_ops#net_phonet_socket.c:428.json
@@ -1,0 +1,164 @@
+{
+  "socket": {
+    "domain": "AF_PHONET",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_phonet(domain const[AF_PHONET], type const[SOCK_DGRAM], proto const[0]) sock_phonet"
+  },
+  "resources": {
+    "sock_phonet": {
+      "type": "sock",
+      "spec": "resource sock_phonet[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_pn",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCPNGETOBJECT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user",
+          "put_user"
+        ],
+        "type": [
+          "__u16"
+        ],
+        "usage": [
+          "if (get_user(handle, (__u16 __user *)arg))",
+          "return put_user(handle, (__u16 __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(karg, (int __user *)arg))\n\t\treturn -EFAULT;",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "pn_socket_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "pn_socket_ioctl",
+    "sendmsg": "pn_socket_sendmsg",
+    "recvmsg": "sock_common_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/phonet/socket.c:428",
+  "ops_name": "phonet_dgram_ops",
+  "syscall_specs": {
+    "socket$KGPT_phonet": "socket$KGPT_phonet(domain const[AF_PHONET], type const[SOCK_DGRAM], proto const[0]) sock_phonet",
+    "bind$KGPT_phonet_dgram_ops": "bind$KGPT_phonet_dgram_ops(fd sock_phonet, addr ptr[in, sockaddr_pn], addrlen len[addr])",
+    "connect$KGPT_phonet_dgram_ops": "connect$KGPT_phonet_dgram_ops(fd sock_phonet, addr ptr[in, sockaddr_pn], addrlen len[addr])",
+    "accept4$KGPT_phonet_dgram_ops": "accept4$KGPT_phonet_dgram_ops(fd sock_phonet, peer ptr[out, sockaddr_pn, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_phonet",
+    "sendto$KGPT_phonet_dgram_ops": "sendto$KGPT_phonet_dgram_ops(fd sock_phonet, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_pn, opt], addrlen len[addr])",
+    "recvfrom$KGPT_phonet_dgram_ops": "recvfrom$KGPT_phonet_dgram_ops(fd sock_phonet, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_pn, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_phonet, cmd const[SIOCPNADDRESOURCE], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_phonet"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {
+    "u16": "type u16 int16"
+  },
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/phonet_stream_ops#net_phonet_socket.c:446.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/phonet_stream_ops#net_phonet_socket.c:446.json
@@ -1,0 +1,166 @@
+{
+  "socket": {
+    "domain": "AF_PHONET",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_phonet(domain const[AF_PHONET], type const[SOCK_SEQPACKET], proto const[0]) sock_phonet"
+  },
+  "resources": {
+    "sock_phonet": {
+      "type": "sock",
+      "spec": "resource sock_phonet[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_pn",
+  "ioctls": {
+    "SIOCPNADDRESOURCE": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCPNGETOBJECT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user",
+          "put_user"
+        ],
+        "type": [
+          "__u16"
+        ],
+        "usage": [
+          "if (get_user(handle, (__u16 __user *)arg))",
+          "return put_user(handle, (__u16 __user *)arg);"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "struct sioc_vif_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "struct sioc_sg_req buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETMIFCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_mif_req6"
+        ],
+        "usage": [
+          "struct sioc_mif_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCGETSGCNT_IN6": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sock_ioctl_inout"
+        ],
+        "type": [
+          "sioc_sg_req6"
+        ],
+        "usage": [
+          "struct sioc_sg_req6 buffer;",
+          "return sock_ioctl_inout(sk, cmd, arg, &buffer, sizeof(buffer));"
+        ]
+      }
+    },
+    "SIOCPNDELRESOURCE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "sk->sk_prot->ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "if (get_user(karg, (int __user *)arg))\n\t\treturn -EFAULT;",
+          "return sk->sk_prot->ioctl(sk, cmd, &karg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "pn_socket_bind",
+    "connect": "pn_socket_connect",
+    "accept": "pn_socket_accept",
+    "poll": "pn_socket_poll",
+    "ioctl": "pn_socket_ioctl",
+    "sendmsg": "pn_socket_sendmsg",
+    "recvmsg": "sock_common_recvmsg",
+    "setsockopt": "sock_common_setsockopt",
+    "getsockopt": "sock_common_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/phonet/socket.c:446",
+  "ops_name": "phonet_stream_ops",
+  "syscall_specs": {
+    "socket$KGPT_phonet": "socket$KGPT_phonet(domain const[AF_PHONET], type const[SOCK_SEQPACKET], proto const[0]) sock_phonet",
+    "bind$KGPT_phonet_stream_ops": "bind$KGPT_phonet_stream_ops(fd sock_phonet, addr ptr[in, sockaddr_pn], addrlen len[addr])",
+    "connect$KGPT_phonet_stream_ops": "connect$KGPT_phonet_stream_ops(fd sock_phonet, addr ptr[in, sockaddr_pn], addrlen len[addr])",
+    "accept4$KGPT_phonet_stream_ops": "accept4$KGPT_phonet_stream_ops(fd sock_phonet, peer ptr[out, sockaddr_pn, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_phonet",
+    "sendto$KGPT_phonet_stream_ops": "sendto$KGPT_phonet_stream_ops(fd sock_phonet, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_pn, opt], addrlen len[addr])",
+    "recvfrom$KGPT_phonet_stream_ops": "recvfrom$KGPT_phonet_stream_ops(fd sock_phonet, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_pn, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCPNADDRESOURCE": "ioctl$KGPT_SIOCPNADDRESOURCE(fd sock_phonet, cmd const[SIOCPNADDRESOURCE], arg ptr[in, int32])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_phonet"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h",
+    "uapi/linux/phonet.h"
+  ],
+  "unused_types": {
+    "u16": "type u16 int16"
+  },
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/pppol2tp_ops#net_l2tp_l2tp_ppp.c:1649.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/pppol2tp_ops#net_l2tp_l2tp_ppp.c:1649.json
@@ -1,0 +1,141 @@
+{
+  "socket": {
+    "domain": "AF_PPPOX",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_pppol2tp(domain const[AF_PPPOX], type const[SOCK_STREAM], proto const[PX_PROTO_OL2TP]) sock_pppol2tp"
+  },
+  "resources": {
+    "sock_pppol2tp": {
+      "type": "sock",
+      "spec": "resource sock_pppol2tp[sock]"
+    }
+  },
+  "types": {
+    "PX_PROTO_OL2TP": "define PX_PROTO_OL2TP 1"
+  },
+  "socket_addr": "sockaddr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "PPPIOCGCHAN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [
+          "int __user *"
+        ],
+        "usage": [
+          "int index;",
+          "index = ppp_channel_index(&po->chan);",
+          "if (put_user(index , (int __user *) arg))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "PPPOL2TP_SO_RECVSEQ": {
+      "level": "SOL_PPPOL2TP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "PPPOL2TP_SO_SENDSEQ": {
+      "level": "SOL_PPPOL2TP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "PPPOL2TP_SO_LNSMODE": {
+      "level": "SOL_PPPOL2TP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "PPPOL2TP_SO_REORDERTO": {
+      "level": "SOL_PPPOL2TP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "PPPOL2TP_SO_RECVSEQ": {
+      "level": "SOL_PPPOL2TP",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "PPPOL2TP_SO_SENDSEQ": {
+      "level": "SOL_PPPOL2TP",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "PPPOL2TP_SO_LNSMODE": {
+      "level": "SOL_PPPOL2TP",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "PPPOL2TP_SO_REORDERTO": {
+      "level": "SOL_PPPOL2TP",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "PPPOL2TP_SO_DEBUG": {
+      "level": "SOL_PPPOL2TP",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "pppol2tp_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "pppox_ioctl",
+    "sendmsg": "pppol2tp_sendmsg",
+    "recvmsg": "pppol2tp_recvmsg",
+    "setsockopt": "pppol2tp_setsockopt",
+    "getsockopt": "pppol2tp_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/l2tp/l2tp_ppp.c:1649",
+  "ops_name": "pppol2tp_ops",
+  "syscall_specs": {
+    "socket$KGPT_pppol2tp": "socket$KGPT_pppol2tp(domain const[AF_PPPOX], type const[SOCK_STREAM], proto const[PX_PROTO_OL2TP]) sock_pppol2tp",
+    "bind$KGPT_pppol2tp_ops": "bind$KGPT_pppol2tp_ops(fd sock_pppol2tp, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_pppol2tp_ops": "connect$KGPT_pppol2tp_ops(fd sock_pppol2tp, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_pppol2tp_ops": "accept4$KGPT_pppol2tp_ops(fd sock_pppol2tp, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_pppol2tp",
+    "sendto$KGPT_pppol2tp_ops": "sendto$KGPT_pppol2tp_ops(fd sock_pppol2tp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_pppol2tp_ops": "recvfrom$KGPT_pppol2tp_ops(fd sock_pppol2tp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "getsockopt$KGPT_PPPOL2TP_SO_RECVSEQ": "getsockopt$KGPT_PPPOL2TP_SO_RECVSEQ(fd sock_pppol2tp, level const[SOL_PPPOL2TP], opt const[PPPOL2TP_SO_RECVSEQ], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_PPPOL2TP_SO_SENDSEQ": "getsockopt$KGPT_PPPOL2TP_SO_SENDSEQ(fd sock_pppol2tp, level const[SOL_PPPOL2TP], opt const[PPPOL2TP_SO_SENDSEQ], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_PPPOL2TP_SO_LNSMODE": "getsockopt$KGPT_PPPOL2TP_SO_LNSMODE(fd sock_pppol2tp, level const[SOL_PPPOL2TP], opt const[PPPOL2TP_SO_LNSMODE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_PPPOL2TP_SO_REORDERTO": "getsockopt$KGPT_PPPOL2TP_SO_REORDERTO(fd sock_pppol2tp, level const[SOL_PPPOL2TP], opt const[PPPOL2TP_SO_REORDERTO], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_PPPOL2TP_SO_DEBUG": "getsockopt$KGPT_PPPOL2TP_SO_DEBUG(fd sock_pppol2tp, level const[SOL_PPPOL2TP], opt const[PPPOL2TP_SO_DEBUG], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_PPPOL2TP_SO_RECVSEQ": "setsockopt$KGPT_PPPOL2TP_SO_RECVSEQ(fd sock_pppol2tp, level const[SOL_PPPOL2TP], opt const[PPPOL2TP_SO_RECVSEQ], val int32, len bytesize[val])",
+    "setsockopt$KGPT_PPPOL2TP_SO_SENDSEQ": "setsockopt$KGPT_PPPOL2TP_SO_SENDSEQ(fd sock_pppol2tp, level const[SOL_PPPOL2TP], opt const[PPPOL2TP_SO_SENDSEQ], val int32, len bytesize[val])",
+    "setsockopt$KGPT_PPPOL2TP_SO_LNSMODE": "setsockopt$KGPT_PPPOL2TP_SO_LNSMODE(fd sock_pppol2tp, level const[SOL_PPPOL2TP], opt const[PPPOL2TP_SO_LNSMODE], val int32, len bytesize[val])",
+    "setsockopt$KGPT_PPPOL2TP_SO_REORDERTO": "setsockopt$KGPT_PPPOL2TP_SO_REORDERTO(fd sock_pppol2tp, level const[SOL_PPPOL2TP], opt const[PPPOL2TP_SO_REORDERTO], val int32, len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_pppol2tp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/if_pppol2tp.h",
+    "uapi/linux/if_pppox.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING",
+    "PPPOL2TP_SO_DEBUG": "UNFOUND_MACRO"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/qrtr_proto_ops#net_qrtr_af_qrtr.c:1235.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/qrtr_proto_ops#net_qrtr_af_qrtr.c:1235.json
@@ -1,0 +1,144 @@
+{
+  "socket": {
+    "domain": "AF_QIPCRTR",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_qrtr(domain const[AF_QIPCRTR], type const[SOCK_DGRAM], proto const[0]) sock_qrtr"
+  },
+  "resources": {
+    "sock_qrtr": {
+      "type": "sock",
+      "spec": "resource sock_qrtr[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_qrtr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "TIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "rc = put_user(len, (int __user *)argp);"
+        ]
+      }
+    },
+    "TIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "rc = put_user(len, (int __user *)argp);"
+        ]
+      }
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "get_user_ifreq",
+          "put_user_ifreq"
+        ],
+        "type": [
+          "ifreq",
+          "sockaddr_qrtr"
+        ],
+        "usage": [
+          "if (get_user_ifreq(&ifr, NULL, argp)) {\n\t\t\trc = -EFAULT;\n\t\t\tbreak;\n\t\t}",
+          "sq = (struct sockaddr_qrtr *)&ifr.ifr_addr;\n\t\t*sq = ipc->us;\n\t\tif (put_user_ifreq(&ifr, argp)) {\n\t\t\trc = -EFAULT;\n\t\t\tbreak;\n\t\t}"
+        ]
+      }
+    },
+    "SIOCADDRT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCDELRT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "qrtr_bind",
+    "connect": "qrtr_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "qrtr_ioctl",
+    "sendmsg": "qrtr_sendmsg",
+    "recvmsg": "qrtr_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/qrtr/af_qrtr.c:1235",
+  "ops_name": "qrtr_proto_ops",
+  "syscall_specs": {
+    "socket$KGPT_qrtr": "socket$KGPT_qrtr(domain const[AF_QIPCRTR], type const[SOCK_DGRAM], proto const[0]) sock_qrtr",
+    "bind$KGPT_qrtr_proto_ops": "bind$KGPT_qrtr_proto_ops(fd sock_qrtr, addr ptr[in, sockaddr_qrtr], addrlen len[addr])",
+    "connect$KGPT_qrtr_proto_ops": "connect$KGPT_qrtr_proto_ops(fd sock_qrtr, addr ptr[in, sockaddr_qrtr], addrlen len[addr])",
+    "accept4$KGPT_qrtr_proto_ops": "accept4$KGPT_qrtr_proto_ops(fd sock_qrtr, peer ptr[out, sockaddr_qrtr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_qrtr",
+    "sendto$KGPT_qrtr_proto_ops": "sendto$KGPT_qrtr_proto_ops(fd sock_qrtr, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_qrtr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_qrtr_proto_ops": "recvfrom$KGPT_qrtr_proto_ops(fd sock_qrtr, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_qrtr, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_qrtr"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_qrtr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/raw_ops#net_can_raw.c:955.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/raw_ops#net_can_raw.c:955.json
@@ -1,0 +1,150 @@
+{
+  "socket": {
+    "domain": "AF_CAN",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_can_raw(domain const[AF_CAN], type const[SOCK_RAW], proto const[CAN_RAW]) sock_can_raw"
+  },
+  "resources": {
+    "sock_can_raw": {
+      "type": "sock",
+      "spec": "resource sock_can_raw[sock]"
+    }
+  },
+  "types": {
+    "can_err_mask_t": "type can_err_mask_t ptr[in, array[int8]]"
+  },
+  "socket_addr": "sockaddr_can",
+  "setsockopt": {
+    "CAN_RAW_FILTER": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[in, array[can_filter]]",
+      "len": "bytesize[val]"
+    },
+    "CAN_RAW_ERR_FILTER": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[in, can_err_mask_t]",
+      "len": "bytesize[val]"
+    },
+    "CAN_RAW_LOOPBACK": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "CAN_RAW_RECV_OWN_MSGS": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "CAN_RAW_FD_FRAMES": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "CAN_RAW_XL_FRAMES": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "CAN_RAW_JOIN_FILTERS": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "CAN_RAW_FILTER": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[out, array[can_filter]]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "CAN_RAW_ERR_FILTER": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[out, can_err_mask_t]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "CAN_RAW_LOOPBACK": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "CAN_RAW_RECV_OWN_MSGS": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "CAN_RAW_FD_FRAMES": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "CAN_RAW_XL_FRAMES": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "CAN_RAW_JOIN_FILTERS": {
+      "level": "SOL_CAN_RAW",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "raw_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "raw_sock_no_ioctlcmd",
+    "sendmsg": "raw_sendmsg",
+    "recvmsg": "raw_recvmsg",
+    "setsockopt": "raw_setsockopt",
+    "getsockopt": "raw_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/can/raw.c:955",
+  "ops_name": "raw_ops",
+  "syscall_specs": {
+    "socket$KGPT_can_raw": "socket$KGPT_can_raw(domain const[AF_CAN], type const[SOCK_RAW], proto const[CAN_RAW]) sock_can_raw",
+    "bind$KGPT_raw_ops": "bind$KGPT_raw_ops(fd sock_can_raw, addr ptr[in, sockaddr_can], addrlen len[addr])",
+    "connect$KGPT_raw_ops": "connect$KGPT_raw_ops(fd sock_can_raw, addr ptr[in, sockaddr_can], addrlen len[addr])",
+    "accept4$KGPT_raw_ops": "accept4$KGPT_raw_ops(fd sock_can_raw, peer ptr[out, sockaddr_can, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_can_raw",
+    "sendto$KGPT_raw_ops": "sendto$KGPT_raw_ops(fd sock_can_raw, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_can, opt], addrlen len[addr])",
+    "recvfrom$KGPT_raw_ops": "recvfrom$KGPT_raw_ops(fd sock_can_raw, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_can, opt], addrlen len[addr])",
+    "getsockopt$KGPT_CAN_RAW_FILTER": "getsockopt$KGPT_CAN_RAW_FILTER(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_FILTER], val ptr[out, array[can_filter]], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_CAN_RAW_ERR_FILTER": "getsockopt$KGPT_CAN_RAW_ERR_FILTER(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_ERR_FILTER], val ptr[out, can_err_mask_t], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_CAN_RAW_LOOPBACK": "getsockopt$KGPT_CAN_RAW_LOOPBACK(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_LOOPBACK], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_CAN_RAW_RECV_OWN_MSGS": "getsockopt$KGPT_CAN_RAW_RECV_OWN_MSGS(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_RECV_OWN_MSGS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_CAN_RAW_FD_FRAMES": "getsockopt$KGPT_CAN_RAW_FD_FRAMES(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_FD_FRAMES], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_CAN_RAW_XL_FRAMES": "getsockopt$KGPT_CAN_RAW_XL_FRAMES(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_XL_FRAMES], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_CAN_RAW_JOIN_FILTERS": "getsockopt$KGPT_CAN_RAW_JOIN_FILTERS(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_JOIN_FILTERS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_CAN_RAW_FILTER": "setsockopt$KGPT_CAN_RAW_FILTER(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_FILTER], val ptr[in, array[can_filter]], len bytesize[val])",
+    "setsockopt$KGPT_CAN_RAW_ERR_FILTER": "setsockopt$KGPT_CAN_RAW_ERR_FILTER(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_ERR_FILTER], val ptr[in, can_err_mask_t], len bytesize[val])",
+    "setsockopt$KGPT_CAN_RAW_LOOPBACK": "setsockopt$KGPT_CAN_RAW_LOOPBACK(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_LOOPBACK], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_CAN_RAW_RECV_OWN_MSGS": "setsockopt$KGPT_CAN_RAW_RECV_OWN_MSGS(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_RECV_OWN_MSGS], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_CAN_RAW_FD_FRAMES": "setsockopt$KGPT_CAN_RAW_FD_FRAMES(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_FD_FRAMES], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_CAN_RAW_XL_FRAMES": "setsockopt$KGPT_CAN_RAW_XL_FRAMES(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_XL_FRAMES], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_CAN_RAW_JOIN_FILTERS": "setsockopt$KGPT_CAN_RAW_JOIN_FILTERS(fd sock_can_raw, level const[SOL_CAN_RAW], opt const[CAN_RAW_JOIN_FILTERS], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_can_raw"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/can.h",
+    "uapi/linux/can/raw.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_can": "EXISTING",
+    "can_filter": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/raw_prot#net_ipv4_raw.c:918.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/raw_prot#net_ipv4_raw.c:918.json
@@ -1,0 +1,349 @@
+{
+  "socket": {
+    "domain": "AF_INET",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_inet_raw(domain const[AF_INET], type const[SOCK_RAW], proto const[IPPROTO_RAW]) sock_inet_raw"
+  },
+  "resources": {
+    "sock_inet_raw": {
+      "type": "sock",
+      "spec": "resource sock_inet_raw[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_RAW": "define IPPROTO_RAW 255"
+  },
+  "socket_addr": "sockaddr_in",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "*karg = sk_wmem_alloc_get(sk);"
+        ]
+      }
+    },
+    "SIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "struct sk_buff *skb;",
+          "skb = skb_peek(&sk->sk_receive_queue);",
+          "if (skb)",
+          "\t*karg = skb->len;",
+          "else",
+          "\t*karg = 0;"
+        ]
+      }
+    },
+    "SIOCGETVIFCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "sioc_vif_req"
+        ],
+        "usage": [
+          "vr = (struct sioc_vif_req *)arg;",
+          "if (vr->vifi >= mrt->maxvif)\n\t\t\treturn -EINVAL;",
+          "vr->vifi = array_index_nospec(vr->vifi, mrt->maxvif);",
+          "rcu_read_lock();",
+          "vif = &mrt->vif_table[vr->vifi];",
+          "if (VIF_EXISTS(mrt, vr->vifi)) {",
+          "\tvr->icount = READ_ONCE(vif->pkt_in);",
+          "\tvr->ocount = READ_ONCE(vif->pkt_out);",
+          "\tvr->ibytes = READ_ONCE(vif->bytes_in);",
+          "\tvr->obytes = READ_ONCE(vif->bytes_out);",
+          "\trcu_read_unlock();",
+          "\treturn 0;",
+          "}",
+          "rcu_read_unlock();",
+          "return -EADDRNOTAVAIL;"
+        ]
+      }
+    },
+    "SIOCGETSGCNT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "ipmr_cache_find"
+        ],
+        "type": [
+          "sioc_sg_req"
+        ],
+        "usage": [
+          "sr = (struct sioc_sg_req *)arg;",
+          "rcu_read_lock();",
+          "c = ipmr_cache_find(mrt, sr->src.s_addr, sr->grp.s_addr);",
+          "if (c) {",
+          "\tsr->pktcnt = c->_c.mfc_un.res.pkt;",
+          "\tsr->bytecnt = c->_c.mfc_un.res.bytes;",
+          "\tsr->wrong_if = c->_c.mfc_un.res.wrong_if;",
+          "\trcu_read_unlock();",
+          "\treturn 0;",
+          "}",
+          "rcu_read_unlock();",
+          "return -EADDRNOTAVAIL;"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "IP_HDRINCL": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_PKTINFO": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_RECVTTL": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_RECVOPTS": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_RECVTOS": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_RETOPTS": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_TOS": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_TTL": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_MTU_DISCOVER": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_RECVERR": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_ROUTER_ALERT": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_FREEBIND": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_PASSSEC": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_TRANSPARENT": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_MINTTL": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_NODEFRAG": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_BIND_ADDRESS_NO_PORT": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_UNICAST_IF": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_MULTICAST_TTL": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_MULTICAST_ALL": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_MULTICAST_LOOP": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_RECVORIGDSTADDR": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_CHECKSUM": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_RECVFRAGSIZE": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_RECVERR_RFC4884": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "IP_LOCAL_PORT_RANGE": {
+      "level": "SOL_IP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "ICMP_FILTER": {
+      "level": "SOL_RAW",
+      "val": "ptr[in, icmp_filter]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "MRT_BASE": {
+      "level": "IPPROTO_IP",
+      "val": "int",
+      "len": "",
+      "val_inference": null
+    },
+    "MRT_MAX": {
+      "level": "IPPROTO_IP",
+      "val": "int",
+      "len": "",
+      "val_inference": null
+    },
+    "IP_IPSEC_POLICY": {
+      "level": "SOL_IP",
+      "val": "ptr[in, array[int8]]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "IP_XFRM_POLICY": {
+      "level": "SOL_IP",
+      "val": "ptr[in, array[int8]]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "ICMP_FILTER": {
+      "level": "SOL_RAW",
+      "val": "ptr[in, icmp_filter]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "raw_bind",
+    "connect": "ip4_datagram_connect",
+    "ioctl": "raw_ioctl",
+    "sendmsg": "raw_sendmsg",
+    "recvmsg": "raw_recvmsg",
+    "setsockopt": "raw_setsockopt",
+    "getsockopt": "raw_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/ipv4/raw.c:918",
+  "ops_name": "raw_prot",
+  "syscall_specs": {
+    "socket$KGPT_inet_raw": "socket$KGPT_inet_raw(domain const[AF_INET], type const[SOCK_RAW], proto const[IPPROTO_RAW]) sock_inet_raw",
+    "bind$KGPT_raw_prot": "bind$KGPT_raw_prot(fd sock_inet_raw, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "connect$KGPT_raw_prot": "connect$KGPT_raw_prot(fd sock_inet_raw, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "sendto$KGPT_raw_prot": "sendto$KGPT_raw_prot(fd sock_inet_raw, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "recvfrom$KGPT_raw_prot": "recvfrom$KGPT_raw_prot(fd sock_inet_raw, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "getsockopt$KGPT_ICMP_FILTER": "getsockopt$KGPT_ICMP_FILTER(fd sock_inet_raw, level const[SOL_RAW], opt const[ICMP_FILTER], val ptr[in, icmp_filter], len len[val])",
+    "setsockopt$KGPT_IP_HDRINCL": "setsockopt$KGPT_IP_HDRINCL(fd sock_inet_raw, level const[SOL_IP], opt const[IP_HDRINCL], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_PKTINFO": "setsockopt$KGPT_IP_PKTINFO(fd sock_inet_raw, level const[SOL_IP], opt const[IP_PKTINFO], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_RECVTTL": "setsockopt$KGPT_IP_RECVTTL(fd sock_inet_raw, level const[SOL_IP], opt const[IP_RECVTTL], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_RECVOPTS": "setsockopt$KGPT_IP_RECVOPTS(fd sock_inet_raw, level const[SOL_IP], opt const[IP_RECVOPTS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_RECVTOS": "setsockopt$KGPT_IP_RECVTOS(fd sock_inet_raw, level const[SOL_IP], opt const[IP_RECVTOS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_RETOPTS": "setsockopt$KGPT_IP_RETOPTS(fd sock_inet_raw, level const[SOL_IP], opt const[IP_RETOPTS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_TOS": "setsockopt$KGPT_IP_TOS(fd sock_inet_raw, level const[SOL_IP], opt const[IP_TOS], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_TTL": "setsockopt$KGPT_IP_TTL(fd sock_inet_raw, level const[SOL_IP], opt const[IP_TTL], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_MTU_DISCOVER": "setsockopt$KGPT_IP_MTU_DISCOVER(fd sock_inet_raw, level const[SOL_IP], opt const[IP_MTU_DISCOVER], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_RECVERR": "setsockopt$KGPT_IP_RECVERR(fd sock_inet_raw, level const[SOL_IP], opt const[IP_RECVERR], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_ROUTER_ALERT": "setsockopt$KGPT_IP_ROUTER_ALERT(fd sock_inet_raw, level const[SOL_IP], opt const[IP_ROUTER_ALERT], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_FREEBIND": "setsockopt$KGPT_IP_FREEBIND(fd sock_inet_raw, level const[SOL_IP], opt const[IP_FREEBIND], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_PASSSEC": "setsockopt$KGPT_IP_PASSSEC(fd sock_inet_raw, level const[SOL_IP], opt const[IP_PASSSEC], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_TRANSPARENT": "setsockopt$KGPT_IP_TRANSPARENT(fd sock_inet_raw, level const[SOL_IP], opt const[IP_TRANSPARENT], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_MINTTL": "setsockopt$KGPT_IP_MINTTL(fd sock_inet_raw, level const[SOL_IP], opt const[IP_MINTTL], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_NODEFRAG": "setsockopt$KGPT_IP_NODEFRAG(fd sock_inet_raw, level const[SOL_IP], opt const[IP_NODEFRAG], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_BIND_ADDRESS_NO_PORT": "setsockopt$KGPT_IP_BIND_ADDRESS_NO_PORT(fd sock_inet_raw, level const[SOL_IP], opt const[IP_BIND_ADDRESS_NO_PORT], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_UNICAST_IF": "setsockopt$KGPT_IP_UNICAST_IF(fd sock_inet_raw, level const[SOL_IP], opt const[IP_UNICAST_IF], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_MULTICAST_TTL": "setsockopt$KGPT_IP_MULTICAST_TTL(fd sock_inet_raw, level const[SOL_IP], opt const[IP_MULTICAST_TTL], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_MULTICAST_ALL": "setsockopt$KGPT_IP_MULTICAST_ALL(fd sock_inet_raw, level const[SOL_IP], opt const[IP_MULTICAST_ALL], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_MULTICAST_LOOP": "setsockopt$KGPT_IP_MULTICAST_LOOP(fd sock_inet_raw, level const[SOL_IP], opt const[IP_MULTICAST_LOOP], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_RECVORIGDSTADDR": "setsockopt$KGPT_IP_RECVORIGDSTADDR(fd sock_inet_raw, level const[SOL_IP], opt const[IP_RECVORIGDSTADDR], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_CHECKSUM": "setsockopt$KGPT_IP_CHECKSUM(fd sock_inet_raw, level const[SOL_IP], opt const[IP_CHECKSUM], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_RECVFRAGSIZE": "setsockopt$KGPT_IP_RECVFRAGSIZE(fd sock_inet_raw, level const[SOL_IP], opt const[IP_RECVFRAGSIZE], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_RECVERR_RFC4884": "setsockopt$KGPT_IP_RECVERR_RFC4884(fd sock_inet_raw, level const[SOL_IP], opt const[IP_RECVERR_RFC4884], val int32, len bytesize[val])",
+    "setsockopt$KGPT_IP_LOCAL_PORT_RANGE": "setsockopt$KGPT_IP_LOCAL_PORT_RANGE(fd sock_inet_raw, level const[SOL_IP], opt const[IP_LOCAL_PORT_RANGE], val int32, len bytesize[val])",
+    "setsockopt$KGPT_ICMP_FILTER": "setsockopt$KGPT_ICMP_FILTER(fd sock_inet_raw, level const[SOL_RAW], opt const[ICMP_FILTER], val ptr[in, icmp_filter], len len[val])",
+    "setsockopt$KGPT_MRT_BASE": "setsockopt$KGPT_MRT_BASE(fd sock_inet_raw, level const[IPPROTO_IP], opt const[MRT_BASE], val ptr[in, int32], len len[val])",
+    "setsockopt$KGPT_MRT_MAX": "setsockopt$KGPT_MRT_MAX(fd sock_inet_raw, level const[IPPROTO_IP], opt const[MRT_MAX], val ptr[in, int32], len len[val])",
+    "setsockopt$KGPT_IP_IPSEC_POLICY": "setsockopt$KGPT_IP_IPSEC_POLICY(fd sock_inet_raw, level const[SOL_IP], opt const[IP_IPSEC_POLICY], val ptr[in, array[int8]], len len[val])",
+    "setsockopt$KGPT_IP_XFRM_POLICY": "setsockopt$KGPT_IP_XFRM_POLICY(fd sock_inet_raw, level const[SOL_IP], opt const[IP_XFRM_POLICY], val ptr[in, array[int8]], len len[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet_raw"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/mroute.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/icmp.h",
+    "uapi/linux/in.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/rawsock_ops#net_nfc_rawsock.c:268.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/rawsock_ops#net_nfc_rawsock.c:268.json
@@ -1,0 +1,45 @@
+{
+  "socket": {
+    "domain": "PF_NFC",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_NFC(domain const[PF_NFC], type const[SOCK_SEQPACKET], proto const[0]) sock_nfc"
+  },
+  "resources": {
+    "sock_nfc": {
+      "type": "sock",
+      "spec": "resource sock_nfc[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr",
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "rawsock_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "rawsock_sendmsg",
+    "recvmsg": "rawsock_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/nfc/rawsock.c:268",
+  "ops_name": "rawsock_ops",
+  "syscall_specs": {
+    "socket$KGPT_NFC": "socket$KGPT_NFC(domain const[PF_NFC], type const[SOCK_SEQPACKET], proto const[0]) sock_nfc",
+    "bind$KGPT_rawsock_ops": "bind$KGPT_rawsock_ops(fd sock_nfc, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_rawsock_ops": "connect$KGPT_rawsock_ops(fd sock_nfc, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_rawsock_ops": "accept4$KGPT_rawsock_ops(fd sock_nfc, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_nfc",
+    "sendto$KGPT_rawsock_ops": "sendto$KGPT_rawsock_ops(fd sock_nfc, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_rawsock_ops": "recvfrom$KGPT_rawsock_ops(fd sock_nfc, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_NFC"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/rawsock_raw_ops#net_nfc_rawsock.c:286.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/rawsock_raw_ops#net_nfc_rawsock.c:286.json
@@ -1,0 +1,45 @@
+{
+  "socket": {
+    "domain": "AF_NFC",
+    "type": "SOCK_RAW",
+    "spec": "socket$KGPT_NFC(domain const[AF_NFC], type const[SOCK_RAW], proto const[0]) sock_nfc"
+  },
+  "resources": {
+    "sock_nfc": {
+      "type": "sock",
+      "spec": "resource sock_nfc[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr",
+  "proto_ops": {
+    "bind": "sock_no_bind",
+    "connect": "sock_no_connect",
+    "accept": "sock_no_accept",
+    "poll": "datagram_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "sock_no_sendmsg",
+    "recvmsg": "rawsock_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/nfc/rawsock.c:286",
+  "ops_name": "rawsock_raw_ops",
+  "syscall_specs": {
+    "socket$KGPT_NFC": "socket$KGPT_NFC(domain const[AF_NFC], type const[SOCK_RAW], proto const[0]) sock_nfc",
+    "bind$KGPT_rawsock_raw_ops": "bind$KGPT_rawsock_raw_ops(fd sock_nfc, addr ptr[in, sockaddr], addrlen len[addr])",
+    "connect$KGPT_rawsock_raw_ops": "connect$KGPT_rawsock_raw_ops(fd sock_nfc, addr ptr[in, sockaddr], addrlen len[addr])",
+    "accept4$KGPT_rawsock_raw_ops": "accept4$KGPT_rawsock_raw_ops(fd sock_nfc, peer ptr[out, sockaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_nfc",
+    "sendto$KGPT_rawsock_raw_ops": "sendto$KGPT_rawsock_raw_ops(fd sock_nfc, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_rawsock_raw_ops": "recvfrom$KGPT_rawsock_raw_ops(fd sock_nfc, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_NFC"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/rds_proto_ops#net_rds_af_rds.c:638.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/rds_proto_ops#net_rds_af_rds.c:638.json
@@ -1,0 +1,164 @@
+{
+  "socket": {
+    "domain": "AF_RDS",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_RDS(domain const[AF_RDS], type const[SOCK_SEQPACKET], proto const[0]) sock_rds"
+  },
+  "resources": {
+    "sock_rds": {
+      "type": "sock",
+      "spec": "resource sock_rds[sock]"
+    }
+  },
+  "types": {
+    "sockaddr_rds": "sockaddr_rds {\n\tsa_family\tint16\n\tsin_port\tint16\n\tsin_addr\tarray[int8, 4]\n\tsin6_addr\tarray[int8, 16]\n\tsin6_scope_id\tint32\n} [align[4]]",
+    "rds_tos_t": "type rds_tos_t ptr[in, array[int8]]"
+  },
+  "socket_addr": "sockaddr_rds",
+  "ioctls": {
+    "SIOCRDSSETTOS": {
+      "arg": "ptr[inout, rds_tos_t]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "SIOCRDSGETTOS": {
+      "arg": "ptr[out, rds_tos_t]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "RDS_CANCEL_SENT_TO": {
+      "level": "SOL_RDS",
+      "val": "ptr[in, sockaddr_in6]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "RDS_GET_MR": {
+      "level": "SOL_RDS",
+      "val": "ptr[in, rds_get_mr_args]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "RDS_GET_MR_FOR_DEST": {
+      "level": "SOL_RDS",
+      "val": "ptr[in, rds_get_mr_for_dest_args]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "RDS_FREE_MR": {
+      "level": "SOL_RDS",
+      "val": "ptr[in, rds_free_mr_args]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "RDS_RECVERR": {
+      "level": "SOL_RDS",
+      "val": "ptr[in, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "RDS_CONG_MONITOR": {
+      "level": "SOL_RDS",
+      "val": "ptr[in, bool32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SO_RDS_TRANSPORT": {
+      "level": "SOL_RDS",
+      "val": "ptr[in, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SO_TIMESTAMP_OLD": {
+      "level": "SOL_SOCKET",
+      "val": "ptr[in, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SO_TIMESTAMP_NEW": {
+      "level": "SOL_SOCKET",
+      "val": "ptr[in, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SO_RDS_MSG_RXPATH_LATENCY": {
+      "level": "SOL_RDS",
+      "val": "ptr[in, rds_rx_trace_so]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "RDS_RECVERR": {
+      "level": "SOL_RDS",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_RDS_TRANSPORT": {
+      "level": "SOL_RDS",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "rds_bind",
+    "connect": "rds_connect",
+    "accept": "sock_no_accept",
+    "poll": "rds_poll",
+    "ioctl": "rds_ioctl",
+    "sendmsg": "rds_sendmsg",
+    "recvmsg": "rds_recvmsg",
+    "setsockopt": "rds_setsockopt",
+    "getsockopt": "rds_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/rds/af_rds.c:638",
+  "ops_name": "rds_proto_ops",
+  "syscall_specs": {
+    "socket$KGPT_RDS": "socket$KGPT_RDS(domain const[AF_RDS], type const[SOCK_SEQPACKET], proto const[0]) sock_rds",
+    "bind$KGPT_rds_proto_ops": "bind$KGPT_rds_proto_ops(fd sock_rds, addr ptr[in, sockaddr_rds], addrlen len[addr])",
+    "connect$KGPT_rds_proto_ops": "connect$KGPT_rds_proto_ops(fd sock_rds, addr ptr[in, sockaddr_rds], addrlen len[addr])",
+    "accept4$KGPT_rds_proto_ops": "accept4$KGPT_rds_proto_ops(fd sock_rds, peer ptr[out, sockaddr_rds, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_rds",
+    "sendto$KGPT_rds_proto_ops": "sendto$KGPT_rds_proto_ops(fd sock_rds, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_rds, opt], addrlen len[addr])",
+    "recvfrom$KGPT_rds_proto_ops": "recvfrom$KGPT_rds_proto_ops(fd sock_rds, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_rds, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCRDSSETTOS": "ioctl$KGPT_SIOCRDSSETTOS(fd sock_rds, cmd const[SIOCRDSSETTOS], arg ptr[inout, rds_tos_t])",
+    "ioctl$KGPT_SIOCRDSGETTOS": "ioctl$KGPT_SIOCRDSGETTOS(fd sock_rds, cmd const[SIOCRDSGETTOS], arg ptr[out, rds_tos_t])",
+    "getsockopt$KGPT_RDS_RECVERR": "getsockopt$KGPT_RDS_RECVERR(fd sock_rds, level const[SOL_RDS], opt const[RDS_RECVERR], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_RDS_TRANSPORT": "getsockopt$KGPT_SO_RDS_TRANSPORT(fd sock_rds, level const[SOL_RDS], opt const[SO_RDS_TRANSPORT], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_RDS_CANCEL_SENT_TO": "setsockopt$KGPT_RDS_CANCEL_SENT_TO(fd sock_rds, level const[SOL_RDS], opt const[RDS_CANCEL_SENT_TO], val ptr[in, sockaddr_in6], len len[val])",
+    "setsockopt$KGPT_RDS_GET_MR": "setsockopt$KGPT_RDS_GET_MR(fd sock_rds, level const[SOL_RDS], opt const[RDS_GET_MR], val ptr[in, rds_get_mr_args], len len[val])",
+    "setsockopt$KGPT_RDS_GET_MR_FOR_DEST": "setsockopt$KGPT_RDS_GET_MR_FOR_DEST(fd sock_rds, level const[SOL_RDS], opt const[RDS_GET_MR_FOR_DEST], val ptr[in, rds_get_mr_for_dest_args], len len[val])",
+    "setsockopt$KGPT_RDS_FREE_MR": "setsockopt$KGPT_RDS_FREE_MR(fd sock_rds, level const[SOL_RDS], opt const[RDS_FREE_MR], val ptr[in, rds_free_mr_args], len len[val])",
+    "setsockopt$KGPT_RDS_RECVERR": "setsockopt$KGPT_RDS_RECVERR(fd sock_rds, level const[SOL_RDS], opt const[RDS_RECVERR], val ptr[in, int32], len len[val])",
+    "setsockopt$KGPT_RDS_CONG_MONITOR": "setsockopt$KGPT_RDS_CONG_MONITOR(fd sock_rds, level const[SOL_RDS], opt const[RDS_CONG_MONITOR], val ptr[in, bool32], len len[val])",
+    "setsockopt$KGPT_SO_RDS_TRANSPORT": "setsockopt$KGPT_SO_RDS_TRANSPORT(fd sock_rds, level const[SOL_RDS], opt const[SO_RDS_TRANSPORT], val ptr[in, int32], len len[val])",
+    "setsockopt$KGPT_SO_TIMESTAMP_OLD": "setsockopt$KGPT_SO_TIMESTAMP_OLD(fd sock_rds, level const[SOL_SOCKET], opt const[SO_TIMESTAMP_OLD], val ptr[in, int32], len len[val])",
+    "setsockopt$KGPT_SO_TIMESTAMP_NEW": "setsockopt$KGPT_SO_TIMESTAMP_NEW(fd sock_rds, level const[SOL_SOCKET], opt const[SO_TIMESTAMP_NEW], val ptr[in, int32], len len[val])",
+    "setsockopt$KGPT_SO_RDS_MSG_RXPATH_LATENCY": "setsockopt$KGPT_SO_RDS_MSG_RXPATH_LATENCY(fd sock_rds, level const[SOL_RDS], opt const[SO_RDS_MSG_RXPATH_LATENCY], val ptr[in, rds_rx_trace_so], len len[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_RDS"
+  ],
+  "includes": [
+    "uapi/linux/rds.h",
+    "linux/net.h",
+    "linux/socket.h",
+    "uapi/asm-generic/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in6": "EXISTING",
+    "rds_get_mr_args": "EXISTING",
+    "rds_get_mr_for_dest_args": "EXISTING",
+    "rds_free_mr_args": "EXISTING",
+    "int32": "PRIMITIVE",
+    "rds_rx_trace_so": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/rfcomm_sock_ops#net_bluetooth_rfcomm_sock.c:1008.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/rfcomm_sock_ops#net_bluetooth_rfcomm_sock.c:1008.json
@@ -1,0 +1,131 @@
+{
+  "socket": {
+    "domain": "AF_BLUETOOTH",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_rfcomm(domain const[AF_BLUETOOTH], type const[SOCK_STREAM], proto const[0]) sock_rfcomm"
+  },
+  "resources": {
+    "sock_rfcomm": {
+      "type": "sock",
+      "spec": "resource sock_rfcomm[sock]"
+    }
+  },
+  "types": {
+    "rfcomm_dev_req": "rfcomm_dev_req {\n\tdev_id\tint16\n\tflags\tint32\n\tsrc\tbdaddr_t\n\tdst\tbdaddr_t\n\tchannel\tint8\n}",
+    "rfcomm_dev_list_req": "rfcomm_dev_list_req {\n\tdev_num\tint16\n\tdev_info\tarray[rfcomm_dev_info]\n}",
+    "rfcomm_dev_info": "rfcomm_dev_info {\n\tid\tint16\n\tflags\tint32\n\tstate\tint16\n\tsrc\tbdaddr_t\n\tdst\tbdaddr_t\n\tchannel\tint8\n}",
+    "rfcomm_conninfo": "rfcomm_conninfo {\n\thci_handle\tint16\n\tdev_class\tarray[int8, 3]\n}"
+  },
+  "socket_addr": "sockaddr_rc",
+  "ioctls": {
+    "RFCOMMCREATEDEV": {
+      "arg": "ptr[in, rfcomm_dev_req]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "RFCOMMRELEASEDEV": {
+      "arg": "ptr[in, int32]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "RFCOMMGETDEVLIST": {
+      "arg": "ptr[inout, rfcomm_dev_list_req]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "RFCOMMGETDEVINFO": {
+      "arg": "ptr[inout, rfcomm_dev_info]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {},
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "BT_SECURITY": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[in, bt_security]",
+      "len": "bytesize[val]"
+    },
+    "BT_DEFER_SETUP": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "BT_SECURITY": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[out, bt_security]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "BT_DEFER_SETUP": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "RFCOMM_LM": {
+      "level": "SOL_RFCOMM",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "RFCOMM_CONNINFO": {
+      "level": "SOL_RFCOMM",
+      "val": "ptr[out, rfcomm_conninfo]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "rfcomm_sock_bind",
+    "connect": "rfcomm_sock_connect",
+    "accept": "rfcomm_sock_accept",
+    "poll": "bt_sock_poll",
+    "ioctl": "rfcomm_sock_ioctl",
+    "sendmsg": "rfcomm_sock_sendmsg",
+    "recvmsg": "rfcomm_sock_recvmsg",
+    "setsockopt": "rfcomm_sock_setsockopt",
+    "getsockopt": "rfcomm_sock_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/bluetooth/rfcomm/sock.c:1008",
+  "ops_name": "rfcomm_sock_ops",
+  "syscall_specs": {
+    "socket$KGPT_rfcomm": "socket$KGPT_rfcomm(domain const[AF_BLUETOOTH], type const[SOCK_STREAM], proto const[0]) sock_rfcomm",
+    "bind$KGPT_rfcomm_sock_ops": "bind$KGPT_rfcomm_sock_ops(fd sock_rfcomm, addr ptr[in, sockaddr_rc], addrlen len[addr])",
+    "connect$KGPT_rfcomm_sock_ops": "connect$KGPT_rfcomm_sock_ops(fd sock_rfcomm, addr ptr[in, sockaddr_rc], addrlen len[addr])",
+    "accept4$KGPT_rfcomm_sock_ops": "accept4$KGPT_rfcomm_sock_ops(fd sock_rfcomm, peer ptr[out, sockaddr_rc, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_rfcomm",
+    "sendto$KGPT_rfcomm_sock_ops": "sendto$KGPT_rfcomm_sock_ops(fd sock_rfcomm, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_rc, opt], addrlen len[addr])",
+    "recvfrom$KGPT_rfcomm_sock_ops": "recvfrom$KGPT_rfcomm_sock_ops(fd sock_rfcomm, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_rc, opt], addrlen len[addr])",
+    "ioctl$KGPT_RFCOMMCREATEDEV": "ioctl$KGPT_RFCOMMCREATEDEV(fd sock_rfcomm, cmd const[RFCOMMCREATEDEV], arg ptr[in, rfcomm_dev_req])",
+    "ioctl$KGPT_RFCOMMRELEASEDEV": "ioctl$KGPT_RFCOMMRELEASEDEV(fd sock_rfcomm, cmd const[RFCOMMRELEASEDEV], arg ptr[in, int32])",
+    "ioctl$KGPT_RFCOMMGETDEVLIST": "ioctl$KGPT_RFCOMMGETDEVLIST(fd sock_rfcomm, cmd const[RFCOMMGETDEVLIST], arg ptr[inout, rfcomm_dev_list_req])",
+    "ioctl$KGPT_RFCOMMGETDEVINFO": "ioctl$KGPT_RFCOMMGETDEVINFO(fd sock_rfcomm, cmd const[RFCOMMGETDEVINFO], arg ptr[inout, rfcomm_dev_info])",
+    "getsockopt$KGPT_BT_SECURITY": "getsockopt$KGPT_BT_SECURITY(fd sock_rfcomm, level const[SOL_BLUETOOTH], opt const[BT_SECURITY], val ptr[out, bt_security], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_BT_DEFER_SETUP": "getsockopt$KGPT_BT_DEFER_SETUP(fd sock_rfcomm, level const[SOL_BLUETOOTH], opt const[BT_DEFER_SETUP], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_RFCOMM_LM": "getsockopt$KGPT_RFCOMM_LM(fd sock_rfcomm, level const[SOL_RFCOMM], opt const[RFCOMM_LM], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_RFCOMM_CONNINFO": "getsockopt$KGPT_RFCOMM_CONNINFO(fd sock_rfcomm, level const[SOL_RFCOMM], opt const[RFCOMM_CONNINFO], val ptr[out, rfcomm_conninfo], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_BT_SECURITY": "setsockopt$KGPT_BT_SECURITY(fd sock_rfcomm, level const[SOL_BLUETOOTH], opt const[BT_SECURITY], val ptr[in, bt_security], len bytesize[val])",
+    "setsockopt$KGPT_BT_DEFER_SETUP": "setsockopt$KGPT_BT_DEFER_SETUP(fd sock_rfcomm, level const[SOL_BLUETOOTH], opt const[BT_DEFER_SETUP], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_rfcomm"
+  ],
+  "includes": [
+    "linux/net.h",
+    "net/bluetooth/bluetooth.h",
+    "net/bluetooth/rfcomm.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_rc": "EXISTING",
+    "bt_security": "EXISTING",
+    "bdaddr_t": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/rose_proto_ops#net_rose_af_rose.c:1480.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/rose_proto_ops#net_rose_af_rose.c:1480.json
@@ -1,0 +1,320 @@
+{
+  "socket": {
+    "domain": "AF_ROSE",
+    "type": "SOCK_SEQPACKET",
+    "spec": "syz_init_net_socket$KGPT_rose(domain const[AF_ROSE], type const[SOCK_SEQPACKET], proto const[0]) sock_rose"
+  },
+  "resources": {
+    "sock_rose": {
+      "type": "sock",
+      "spec": "resource sock_rose[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_rose_any",
+  "ioctls": {
+    "SIOCGIFMETRIC": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFMETRIC": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "TIOCOUTQ": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "TIOCINQ": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "rose_rt_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return rose_rt_ioctl(cmd, argp);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "rose_rt_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "return rose_rt_ioctl(cmd, argp);"
+        ]
+      }
+    },
+    "SIOCRSCLRRT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCRSGCAUSE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "rose_cause_struct"
+        ],
+        "usage": [
+          "struct rose_cause_struct rose_cause;\nrose_cause.cause = rose->cause;\nrose_cause.diagnostic = rose->diagnostic;\nreturn copy_to_user(argp, &rose_cause, sizeof(struct rose_cause_struct)) ? -EFAULT : 0;"
+        ]
+      }
+    },
+    "SIOCRSSCAUSE": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "rose_cause_struct"
+        ],
+        "usage": [
+          "struct rose_cause_struct rose_cause;\nif (copy_from_user(&rose_cause, argp, sizeof(struct rose_cause_struct)))\n\treturn -EFAULT;\nrose->cause = rose_cause.cause;\nrose->diagnostic = rose_cause.diagnostic;\nreturn 0;"
+        ]
+      }
+    },
+    "SIOCRSSL2CALL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [
+          "ax25_listen_release",
+          "ax25_listen_register"
+        ],
+        "type": [
+          "ax25_address"
+        ],
+        "usage": [
+          "if (ax25cmp(&rose_callsign, &null_ax25_address) != 0)\n\tax25_listen_release(&rose_callsign, NULL);\nif (copy_from_user(&rose_callsign, argp, sizeof(ax25_address)))\n\treturn -EFAULT;\nif (ax25cmp(&rose_callsign, &null_ax25_address) != 0)\n\treturn ax25_listen_register(&rose_callsign, NULL);"
+        ]
+      }
+    },
+    "SIOCRSGL2CALL": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "ax25_address"
+        ],
+        "usage": [
+          "return copy_to_user(argp, &rose_callsign, sizeof(ax25_address)) ? -EFAULT : 0;"
+        ]
+      }
+    },
+    "SIOCRSACCEPT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "ROSE_DEFER": {
+      "level": "SOL_ROSE",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "ROSE_T1": {
+      "level": "SOL_ROSE",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "ROSE_T2": {
+      "level": "SOL_ROSE",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "ROSE_T3": {
+      "level": "SOL_ROSE",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "ROSE_HOLDBACK": {
+      "level": "SOL_ROSE",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "ROSE_IDLE": {
+      "level": "SOL_ROSE",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "ROSE_QBITINCL": {
+      "level": "SOL_ROSE",
+      "val": "int32",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "ROSE_DEFER": {
+      "level": "SOL_ROSE",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "ROSE_T1": {
+      "level": "SOL_ROSE",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "ROSE_T2": {
+      "level": "SOL_ROSE",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "ROSE_T3": {
+      "level": "SOL_ROSE",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "ROSE_HOLDBACK": {
+      "level": "SOL_ROSE",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "ROSE_IDLE": {
+      "level": "SOL_ROSE",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "ROSE_QBITINCL": {
+      "level": "SOL_ROSE",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "rose_bind",
+    "connect": "rose_connect",
+    "accept": "rose_accept",
+    "poll": "datagram_poll",
+    "ioctl": "rose_ioctl",
+    "sendmsg": "rose_sendmsg",
+    "recvmsg": "rose_recvmsg",
+    "setsockopt": "rose_setsockopt",
+    "getsockopt": "rose_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/rose/af_rose.c:1480",
+  "ops_name": "rose_proto_ops",
+  "syscall_specs": {
+    "syz_init_net_socket$KGPT_rose": "syz_init_net_socket$KGPT_rose(domain const[AF_ROSE], type const[SOCK_SEQPACKET], proto const[0]) sock_rose",
+    "bind$KGPT_rose_proto_ops": "bind$KGPT_rose_proto_ops(fd sock_rose, addr ptr[in, sockaddr_rose_any], addrlen len[addr])",
+    "connect$KGPT_rose_proto_ops": "connect$KGPT_rose_proto_ops(fd sock_rose, addr ptr[in, sockaddr_rose_any], addrlen len[addr])",
+    "accept4$KGPT_rose_proto_ops": "accept4$KGPT_rose_proto_ops(fd sock_rose, peer ptr[out, sockaddr_rose_any, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_rose",
+    "sendto$KGPT_rose_proto_ops": "sendto$KGPT_rose_proto_ops(fd sock_rose, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_rose_any, opt], addrlen len[addr])",
+    "recvfrom$KGPT_rose_proto_ops": "recvfrom$KGPT_rose_proto_ops(fd sock_rose, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_rose_any, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCGIFMETRIC": "ioctl$KGPT_SIOCGIFMETRIC(fd sock_rose, cmd const[SIOCGIFMETRIC], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SIOCSIFMETRIC": "ioctl$KGPT_SIOCSIFMETRIC(fd sock_rose, cmd const[SIOCSIFMETRIC], arg ptr[in, array[int8]])",
+    "getsockopt$KGPT_ROSE_DEFER": "getsockopt$KGPT_ROSE_DEFER(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_DEFER], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_ROSE_T1": "getsockopt$KGPT_ROSE_T1(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_T1], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_ROSE_T2": "getsockopt$KGPT_ROSE_T2(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_T2], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_ROSE_T3": "getsockopt$KGPT_ROSE_T3(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_T3], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_ROSE_HOLDBACK": "getsockopt$KGPT_ROSE_HOLDBACK(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_HOLDBACK], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_ROSE_IDLE": "getsockopt$KGPT_ROSE_IDLE(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_IDLE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_ROSE_QBITINCL": "getsockopt$KGPT_ROSE_QBITINCL(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_QBITINCL], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_ROSE_DEFER": "setsockopt$KGPT_ROSE_DEFER(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_DEFER], val int32, len bytesize[val])",
+    "setsockopt$KGPT_ROSE_T1": "setsockopt$KGPT_ROSE_T1(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_T1], val int32, len bytesize[val])",
+    "setsockopt$KGPT_ROSE_T2": "setsockopt$KGPT_ROSE_T2(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_T2], val int32, len bytesize[val])",
+    "setsockopt$KGPT_ROSE_T3": "setsockopt$KGPT_ROSE_T3(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_T3], val int32, len bytesize[val])",
+    "setsockopt$KGPT_ROSE_HOLDBACK": "setsockopt$KGPT_ROSE_HOLDBACK(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_HOLDBACK], val int32, len bytesize[val])",
+    "setsockopt$KGPT_ROSE_IDLE": "setsockopt$KGPT_ROSE_IDLE(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_IDLE], val int32, len bytesize[val])",
+    "setsockopt$KGPT_ROSE_QBITINCL": "setsockopt$KGPT_ROSE_QBITINCL(fd sock_rose, level const[SOL_ROSE], opt const[ROSE_QBITINCL], val int32, len bytesize[val])"
+  },
+  "init_syscalls": [
+    "syz_init_net_socket$KGPT_rose"
+  ],
+  "includes": [
+    "uapi/linux/sockios.h",
+    "linux/net.h",
+    "uapi/linux/rose.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_rose_any": "EXISTING",
+    "sockaddr_rose": "EXISTING",
+    "full_sockaddr_rose": "EXISTING",
+    "ax25_address": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/rxrpc_rpc_ops#net_rxrpc_af_rxrpc.c:939.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/rxrpc_rpc_ops#net_rxrpc_af_rxrpc.c:939.json
@@ -1,0 +1,92 @@
+{
+  "socket": {
+    "domain": "AF_RXRPC",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_rxrpc(domain const[AF_RXRPC], type const[SOCK_DGRAM], proto const[0]) sock_rxrpc"
+  },
+  "resources": {
+    "sock_rxrpc": {
+      "type": "sock",
+      "spec": "resource sock_rxrpc[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_rxrpc",
+  "setsockopt": {
+    "RXRPC_EXCLUSIVE_CONNECTION": {
+      "level": "SOL_RXRPC",
+      "val": "int32",
+      "len": "0"
+    },
+    "RXRPC_MIN_SECURITY_LEVEL": {
+      "level": "SOL_RXRPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "RXRPC_UPGRADEABLE_SERVICE": {
+      "level": "SOL_RXRPC",
+      "val": "ptr[in, array[int16, 2]]",
+      "len": "bytesize[val]"
+    },
+    "RXRPC_SECURITY_KEY": {
+      "level": "SOL_RXRPC",
+      "val": "ptr[in, string]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "RXRPC_SECURITY_KEYRING": {
+      "level": "SOL_RXRPC",
+      "val": "ptr[in, string]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "RXRPC_SUPPORTED_CMSG": {
+      "level": "SOL_RXRPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "rxrpc_bind",
+    "connect": "rxrpc_connect",
+    "accept": "sock_no_accept",
+    "poll": "rxrpc_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "rxrpc_sendmsg",
+    "recvmsg": "rxrpc_recvmsg",
+    "setsockopt": "rxrpc_setsockopt",
+    "getsockopt": "rxrpc_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/rxrpc/af_rxrpc.c:939",
+  "ops_name": "rxrpc_rpc_ops",
+  "syscall_specs": {
+    "socket$KGPT_rxrpc": "socket$KGPT_rxrpc(domain const[AF_RXRPC], type const[SOCK_DGRAM], proto const[0]) sock_rxrpc",
+    "bind$KGPT_rxrpc_rpc_ops": "bind$KGPT_rxrpc_rpc_ops(fd sock_rxrpc, addr ptr[in, sockaddr_rxrpc], addrlen len[addr])",
+    "connect$KGPT_rxrpc_rpc_ops": "connect$KGPT_rxrpc_rpc_ops(fd sock_rxrpc, addr ptr[in, sockaddr_rxrpc], addrlen len[addr])",
+    "accept4$KGPT_rxrpc_rpc_ops": "accept4$KGPT_rxrpc_rpc_ops(fd sock_rxrpc, peer ptr[out, sockaddr_rxrpc, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_rxrpc",
+    "sendto$KGPT_rxrpc_rpc_ops": "sendto$KGPT_rxrpc_rpc_ops(fd sock_rxrpc, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_rxrpc, opt], addrlen len[addr])",
+    "recvfrom$KGPT_rxrpc_rpc_ops": "recvfrom$KGPT_rxrpc_rpc_ops(fd sock_rxrpc, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_rxrpc, opt], addrlen len[addr])",
+    "getsockopt$KGPT_RXRPC_SUPPORTED_CMSG": "getsockopt$KGPT_RXRPC_SUPPORTED_CMSG(fd sock_rxrpc, level const[SOL_RXRPC], opt const[RXRPC_SUPPORTED_CMSG], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_RXRPC_EXCLUSIVE_CONNECTION": "setsockopt$KGPT_RXRPC_EXCLUSIVE_CONNECTION(fd sock_rxrpc, level const[SOL_RXRPC], opt const[RXRPC_EXCLUSIVE_CONNECTION], val ptr[in, int32], len len[val])",
+    "setsockopt$KGPT_RXRPC_MIN_SECURITY_LEVEL": "setsockopt$KGPT_RXRPC_MIN_SECURITY_LEVEL(fd sock_rxrpc, level const[SOL_RXRPC], opt const[RXRPC_MIN_SECURITY_LEVEL], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_RXRPC_UPGRADEABLE_SERVICE": "setsockopt$KGPT_RXRPC_UPGRADEABLE_SERVICE(fd sock_rxrpc, level const[SOL_RXRPC], opt const[RXRPC_UPGRADEABLE_SERVICE], val ptr[in, array[int16, 2]], len bytesize[val])",
+    "setsockopt$KGPT_RXRPC_SECURITY_KEY": "setsockopt$KGPT_RXRPC_SECURITY_KEY(fd sock_rxrpc, level const[SOL_RXRPC], opt const[RXRPC_SECURITY_KEY], val ptr[in, string], len len[val])",
+    "setsockopt$KGPT_RXRPC_SECURITY_KEYRING": "setsockopt$KGPT_RXRPC_SECURITY_KEYRING(fd sock_rxrpc, level const[SOL_RXRPC], opt const[RXRPC_SECURITY_KEYRING], val ptr[in, string], len len[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_rxrpc"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/rxrpc.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/sco_sock_ops#net_bluetooth_sco.c:1418.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/sco_sock_ops#net_bluetooth_sco.c:1418.json
@@ -1,0 +1,180 @@
+{
+  "socket": {
+    "domain": "AF_BLUETOOTH",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_bluetooth(domain const[AF_BLUETOOTH], type const[SOCK_SEQPACKET], proto const[0]) sock_sco"
+  },
+  "resources": {
+    "sock_sco": {
+      "type": "sock",
+      "spec": "resource sock_sco[sock]"
+    }
+  },
+  "types": {
+    "bt_voice": "bt_voice {\n\tsetting\tint16\n}",
+    "bt_codecs": "bt_codecs {\n\tnum_codecs\tint8\n\tcodecs\tarray[bt_codec]\n}",
+    "bt_codec": "bt_codec {\n\tid\tint8\n\tcid\tint16\n\tvid\tint16\n\tdata_path\tint8\n\tnum_caps\tint8\n}"
+  },
+  "socket_addr": "sockaddr_sco",
+  "ioctls": {},
+  "existing_ioctls": {
+    "TIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "long amount;",
+          "amount = sk->sk_sndbuf - sk_wmem_alloc_get(sk);",
+          "if (amount < 0)\n\tamount = 0;",
+          "err = put_user(amount, (int __user *)arg);"
+        ]
+      }
+    },
+    "TIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "struct sk_buff *skb;",
+          "long amount;",
+          "lock_sock(sk);",
+          "skb = skb_peek(&sk->sk_receive_queue);",
+          "amount = skb ? skb->len : 0;",
+          "release_sock(sk);",
+          "err = put_user(amount, (int __user *)arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "BT_DEFER_SETUP": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "BT_VOICE": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[in, bt_voice]",
+      "len": "bytesize[val]"
+    },
+    "BT_PKT_STATUS": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "BT_CODEC": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[in, bt_codecs]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "BT_DEFER_SETUP": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "BT_VOICE": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[out, bt_voice]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "BT_PHY": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "BT_PKT_STATUS": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "BT_SNDMTU": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "BT_RCVMTU": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "BT_CODEC": {
+      "level": "SOL_BLUETOOTH",
+      "val": "ptr[in, bt_codec]",
+      "len": "bytesize[val]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "sco_sock_bind",
+    "connect": "sco_sock_connect",
+    "accept": "sco_sock_accept",
+    "poll": "bt_sock_poll",
+    "ioctl": "bt_sock_ioctl",
+    "sendmsg": "sco_sock_sendmsg",
+    "recvmsg": "sco_sock_recvmsg",
+    "setsockopt": "sco_sock_setsockopt",
+    "getsockopt": "sco_sock_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/bluetooth/sco.c:1418",
+  "ops_name": "sco_sock_ops",
+  "syscall_specs": {
+    "socket$KGPT_bluetooth": "socket$KGPT_bluetooth(domain const[AF_BLUETOOTH], type const[SOCK_SEQPACKET], proto const[0]) sock_sco",
+    "bind$KGPT_sco_sock_ops": "bind$KGPT_sco_sock_ops(fd sock_sco, addr ptr[in, sockaddr_sco], addrlen len[addr])",
+    "connect$KGPT_sco_sock_ops": "connect$KGPT_sco_sock_ops(fd sock_sco, addr ptr[in, sockaddr_sco], addrlen len[addr])",
+    "accept4$KGPT_sco_sock_ops": "accept4$KGPT_sco_sock_ops(fd sock_sco, peer ptr[out, sockaddr_sco, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_sco",
+    "sendto$KGPT_sco_sock_ops": "sendto$KGPT_sco_sock_ops(fd sock_sco, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_sco, opt], addrlen len[addr])",
+    "recvfrom$KGPT_sco_sock_ops": "recvfrom$KGPT_sco_sock_ops(fd sock_sco, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_sco, opt], addrlen len[addr])",
+    "getsockopt$KGPT_BT_DEFER_SETUP": "getsockopt$KGPT_BT_DEFER_SETUP(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_DEFER_SETUP], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_BT_VOICE": "getsockopt$KGPT_BT_VOICE(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_VOICE], val ptr[out, bt_voice], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_BT_PHY": "getsockopt$KGPT_BT_PHY(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_PHY], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_BT_PKT_STATUS": "getsockopt$KGPT_BT_PKT_STATUS(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_PKT_STATUS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_BT_SNDMTU": "getsockopt$KGPT_BT_SNDMTU(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_SNDMTU], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_BT_RCVMTU": "getsockopt$KGPT_BT_RCVMTU(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_RCVMTU], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_BT_CODEC": "getsockopt$KGPT_BT_CODEC(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_CODEC], val ptr[in, bt_codec], len bytesize[val])",
+    "setsockopt$KGPT_BT_DEFER_SETUP": "setsockopt$KGPT_BT_DEFER_SETUP(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_DEFER_SETUP], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_BT_VOICE": "setsockopt$KGPT_BT_VOICE(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_VOICE], val ptr[in, bt_voice], len bytesize[val])",
+    "setsockopt$KGPT_BT_PKT_STATUS": "setsockopt$KGPT_BT_PKT_STATUS(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_PKT_STATUS], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_BT_CODEC": "setsockopt$KGPT_BT_CODEC(fd sock_sco, level const[SOL_BLUETOOTH], opt const[BT_CODEC], val ptr[in, bt_codecs], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_bluetooth"
+  ],
+  "includes": [
+    "linux/net.h",
+    "net/bluetooth/bluetooth.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {
+    "codec_list": "codec_list {\n\tlist\tlist_head\n\tid\tint8\n\tcid\tint16\n\tvid\tint16\n\ttransport\tint8\n\tnum_caps\tint8\n\tlen\tint32\n\tcaps\tarray[hci_codec_caps, num_caps]\n}",
+    "hci_codec_caps": "hci_codec_caps {\n\tlen\tint8\n\tdata\tarray[int8]\n}",
+    "list_head": "list_head {\n\tnext\t*list_head\n\tprev\t*list_head\n}",
+    "hci_dev": "UNKNOWN"
+  },
+  "ignored_types": {
+    "sockaddr_sco": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/sctp_prot#net_sctp_socket.c:9658.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/sctp_prot#net_sctp_socket.c:9658.json
@@ -1,0 +1,815 @@
+{
+  "socket": {
+    "domain": "AF_INET",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_inet_sctp(domain const[AF_INET], type const[SOCK_SEQPACKET], proto const[IPPROTO_SCTP]) sock_inet_sctp"
+  },
+  "resources": {
+    "sock_inet_sctp": {
+      "type": "sock",
+      "spec": "resource sock_inet_sctp[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_SCTP": "define IPPROTO_SCTP 132",
+    "sctp_addr": "sctp_addr [\n\tv4\tsockaddr_in\n\tv6\tsockaddr_in6\n\tsa\tsockaddr\n]",
+    "sctp_peeloff_flags_arg_t": "sctp_peeloff_flags_arg_t {\n\tp_arg\tsctp_peeloff_arg_t\n\tflags\tint32\n}",
+    "sctp_paddrthlds_v2": "sctp_paddrthlds_v2 {\n\tspt_assoc_id\tsctp_assoc_t\n\tspt_address\tsockaddr_storage\n\tspt_pathmaxrxt\tint16\n\tspt_pathpfthld\tint16\n\tspt_pathcpthld\tint16\n}",
+    "sctp_udpencaps": "sctp_udpencaps {\n\tsue_assoc_id\tsctp_assoc_t\n\tsue_address\tsockaddr_storage\n\tsue_port\tint16\n}",
+    "sctp_probeinterval": "sctp_probeinterval {\n\tspi_assoc_id\tsctp_assoc_t\n\tspi_address\tsockaddr_storage\n\tspi_interval\tint32\n}",
+    "sctp_assoc_t": "type sctp_assoc_t ptr[in, array[int8]]"
+  },
+  "socket_addr": "sctp_addr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "int rc = -ENOTCONN;",
+          "lock_sock(sk);",
+          "if (sctp_style(sk, TCP) && sctp_sstate(sk, LISTENING))",
+          "goto out;",
+          "switch (cmd) {",
+          "case SIOCINQ: {",
+          "struct sk_buff *skb;",
+          "*karg = 0;",
+          "skb = skb_peek(&sk->sk_receive_queue);",
+          "if (skb != NULL) {",
+          "*karg = skb->len;",
+          "}",
+          "rc = 0;",
+          "break;",
+          "}",
+          "default:",
+          "rc = -ENOIOCTLCMD;",
+          "break;",
+          "}",
+          "out:",
+          "release_sock(sk);",
+          "return rc;"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "SCTP_DISABLE_FRAGMENTS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]",
+      "SCTP_EVENTS": {
+        "level": "SOL_SCTP",
+        "val": "ptr[in, sctp_event_subscribe]",
+        "len": "bytesize[val]",
+        "SCTP_AUTOCLOSE": {
+          "level": "SOL_SCTP",
+          "val": "ptr[in, int32]",
+          "len": "bytesize[val]",
+          "SCTP_PEER_ADDR_PARAMS": {
+            "level": "SOL_SCTP",
+            "val": "ptr[in, sctp_paddrparams]",
+            "len": "bytesize[val]",
+            "SCTP_DELAYED_SACK": {
+              "level": "SOL_SCTP",
+              "val": "ptr[in, sctp_sack_info]",
+              "len": "bytesize[val]",
+              "SCTP_PARTIAL_DELIVERY_POINT": {
+                "level": "SOL_SCTP",
+                "val": "ptr[in, int32]",
+                "len": "bytesize[val]",
+                "SCTP_INITMSG": {
+                  "level": "SOL_SCTP",
+                  "val": "ptr[in, sctp_initmsg]",
+                  "len": "bytesize[val]",
+                  "SCTP_DEFAULT_SEND_PARAM": {
+                    "level": "SOL_SCTP",
+                    "val": "ptr[in, sctp_sndrcvinfo]",
+                    "len": "bytesize[val]",
+                    "SCTP_DEFAULT_SNDINFO": {
+                      "level": "SOL_SCTP",
+                      "val": "ptr[in, sctp_sndinfo]",
+                      "len": "bytesize[val]",
+                      "SCTP_PRIMARY_ADDR": {
+                        "level": "SOL_SCTP",
+                        "val": "ptr[in, sctp_setpeerprim]",
+                        "len": "bytesize[val]",
+                        "SCTP_SET_PEER_PRIMARY_ADDR": {
+                          "level": "SOL_SCTP",
+                          "val": "ptr[in, sctp_prim]",
+                          "len": "bytesize[val]",
+                          "SCTP_NODELAY": {
+                            "level": "SOL_SCTP",
+                            "val": "ptr[in, int32]",
+                            "len": "bytesize[val]",
+                            "SCTP_RTOINFO": {
+                              "level": "SOL_SCTP",
+                              "val": "ptr[in, sctp_rtoinfo]",
+                              "len": "bytesize[val]",
+                              "SCTP_ASSOCINFO": {
+                                "level": "SOL_SCTP",
+                                "val": "ptr[in, sctp_assocparams]",
+                                "len": "bytesize[val]",
+                                "SCTP_I_WANT_MAPPED_V4_ADDR": {
+                                  "level": "SOL_SCTP",
+                                  "val": "ptr[in, int32]",
+                                  "len": "bytesize[val]",
+                                  "SCTP_MAXSEG": {
+                                    "level": "SOL_SCTP",
+                                    "val": "ptr[in, int32]",
+                                    "len": "bytesize[val]",
+                                    "SCTP_ADAPTATION_LAYER": {
+                                      "level": "SOL_SCTP",
+                                      "val": "ptr[in, sctp_setadaptation]",
+                                      "len": "bytesize[val]",
+                                      "SCTP_CONTEXT": {
+                                        "level": "SOL_SCTP",
+                                        "val": "ptr[in, int32]",
+                                        "len": "bytesize[val]",
+                                        "SCTP_FRAGMENT_INTERLEAVE": {
+                                          "level": "SOL_SCTP",
+                                          "val": "ptr[in, int32]",
+                                          "len": "bytesize[val]",
+                                          "SCTP_MAX_BURST": {
+                                            "level": "SOL_SCTP",
+                                            "val": "ptr[in, int32]",
+                                            "len": "bytesize[val]",
+                                            "SCTP_AUTH_CHUNK": {
+                                              "level": "SOL_SCTP",
+                                              "val": "ptr[in, sctp_authchunk]",
+                                              "len": "bytesize[val]",
+                                              "SCTP_HMAC_IDENT": {
+                                                "level": "SOL_SCTP",
+                                                "val": "ptr[in, sctp_hmacalgo]",
+                                                "len": "bytesize[val]",
+                                                "SCTP_AUTH_KEY": {
+                                                  "level": "SOL_SCTP",
+                                                  "val": "ptr[in, sctp_authkey]",
+                                                  "len": "bytesize[val]",
+                                                  "SCTP_AUTH_ACTIVE_KEY": {
+                                                    "level": "SOL_SCTP",
+                                                    "val": "ptr[in, sctp_authkeyid]",
+                                                    "len": "bytesize[val]",
+                                                    "SCTP_AUTH_DELETE_KEY": {
+                                                      "level": "SOL_SCTP",
+                                                      "val": "ptr[in, sctp_authkeyid]",
+                                                      "len": "bytesize[val]",
+                                                      "SCTP_AUTH_DEACTIVATE_KEY": {
+                                                        "level": "SOL_SCTP",
+                                                        "val": "ptr[in, sctp_authkeyid]",
+                                                        "len": "bytesize[val]",
+                                                        "SCTP_AUTO_ASCONF": {
+                                                          "level": "SOL_SCTP",
+                                                          "val": "ptr[in, int32]",
+                                                          "len": "bytesize[val]",
+                                                          "SCTP_PEER_ADDR_THLDS": {
+                                                            "level": "SOL_SCTP",
+                                                            "val": "ptr[in, sctp_paddrthlds]",
+                                                            "len": "bytesize[val]",
+                                                            "SCTP_PEER_ADDR_THLDS_V2": {
+                                                              "level": "SOL_SCTP",
+                                                              "val": "ptr[in, sctp_paddrthlds_v2]",
+                                                              "len": "bytesize[val]",
+                                                              "SCTP_RECVRCVINFO": {
+                                                                "level": "SOL_SCTP",
+                                                                "val": "ptr[in, int32]",
+                                                                "len": "bytesize[val]",
+                                                                "SCTP_RECVNXTINFO": {
+                                                                  "level": "SOL_SCTP",
+                                                                  "val": "ptr[in, int32]",
+                                                                  "len": "bytesize[val]",
+                                                                  "SCTP_PR_SUPPORTED": {
+                                                                    "level": "SOL_SCTP",
+                                                                    "val": "ptr[in, int32]",
+                                                                    "len": "bytesize[val]",
+                                                                    "SCTP_DEFAULT_PRINFO": {
+                                                                      "level": "SOL_SCTP",
+                                                                      "val": "ptr[in, sctp_default_prinfo]",
+                                                                      "len": "bytesize[val]",
+                                                                      "SCTP_RECONFIG_SUPPORTED": {
+                                                                        "level": "SOL_SCTP",
+                                                                        "val": "ptr[in, int32]",
+                                                                        "len": "bytesize[val]",
+                                                                        "SCTP_ENABLE_STREAM_RESET": {
+                                                                          "level": "SOL_SCTP",
+                                                                          "val": "ptr[in, sctp_enable_strreset]",
+                                                                          "len": "bytesize[val]",
+                                                                          "SCTP_RESET_STREAMS": {
+                                                                            "level": "SOL_SCTP",
+                                                                            "val": "ptr[in, sctp_reset_streams]",
+                                                                            "len": "bytesize[val]",
+                                                                            "SCTP_RESET_ASSOC": {
+                                                                              "level": "SOL_SCTP",
+                                                                              "val": "ptr[in, sctp_assoc_value]",
+                                                                              "len": "bytesize[val]",
+                                                                              "SCTP_ADD_STREAMS": {
+                                                                                "level": "SOL_SCTP",
+                                                                                "val": "ptr[in, sctp_add_streams]",
+                                                                                "len": "bytesize[val]",
+                                                                                "SCTP_STREAM_SCHEDULER": {
+                                                                                  "level": "SOL_SCTP",
+                                                                                  "val": "ptr[in, int32]",
+                                                                                  "len": "bytesize[val]",
+                                                                                  "SCTP_STREAM_SCHEDULER_VALUE": {
+                                                                                    "level": "SOL_SCTP",
+                                                                                    "val": "ptr[in, sctp_stream_value]",
+                                                                                    "len": "bytesize[val]",
+                                                                                    "SCTP_INTERLEAVING_SUPPORTED": {
+                                                                                      "level": "SOL_SCTP",
+                                                                                      "val": "ptr[in, int32]",
+                                                                                      "len": "bytesize[val]",
+                                                                                      "SCTP_REUSE_PORT": {
+                                                                                        "level": "SOL_SCTP",
+                                                                                        "val": "ptr[in, int32]",
+                                                                                        "len": "bytesize[val]",
+                                                                                        "SCTP_EVENT": {
+                                                                                          "level": "SOL_SCTP",
+                                                                                          "val": "ptr[in, sctp_event_subscribe]",
+                                                                                          "len": "bytesize[val]",
+                                                                                          "SCTP_ASCONF_SUPPORTED": {
+                                                                                            "level": "SOL_SCTP",
+                                                                                            "val": "ptr[in, int32]",
+                                                                                            "len": "bytesize[val]",
+                                                                                            "SCTP_AUTH_SUPPORTED": {
+                                                                                              "level": "SOL_SCTP",
+                                                                                              "val": "ptr[in, int32]",
+                                                                                              "len": "bytesize[val]",
+                                                                                              "SCTP_ECN_SUPPORTED": {
+                                                                                                "level": "SOL_SCTP",
+                                                                                                "val": "ptr[in, int32]",
+                                                                                                "len": "bytesize[val]",
+                                                                                                "SCTP_EXPOSE_POTENTIALLY_FAILED_STATE": {
+                                                                                                  "level": "SOL_SCTP",
+                                                                                                  "val": "ptr[in, int32]",
+                                                                                                  "len": "bytesize[val]",
+                                                                                                  "SCTP_REMOTE_UDP_ENCAPS_PORT": {
+                                                                                                    "level": "SOL_SCTP",
+                                                                                                    "val": "ptr[in, sctp_udpencaps]",
+                                                                                                    "len": "bytesize[val]",
+                                                                                                    "SCTP_PLPMTUD_PROBE_INTERVAL": {
+                                                                                                      "level": "SOL_SCTP",
+                                                                                                      "val": "ptr[in, int32]",
+                                                                                                      "len": "bytesize[val]",
+                                                                                                      "unknown": [],
+                                                                                                      "types": {
+                                                                                                        "sctp_event_subscribe": "UNKNOWN",
+                                                                                                        "sctp_paddrparams": "UNKNOWN",
+                                                                                                        "sctp_sack_info": "UNKNOWN",
+                                                                                                        "sctp_initmsg": "UNKNOWN",
+                                                                                                        "sctp_sndrcvinfo": "UNKNOWN",
+                                                                                                        "sctp_sndinfo": "UNKNOWN",
+                                                                                                        "sctp_setpeerprim": "UNKNOWN",
+                                                                                                        "sctp_prim": "UNKNOWN",
+                                                                                                        "sctp_rtoinfo": "UNKNOWN",
+                                                                                                        "sctp_assocparams": "UNKNOWN",
+                                                                                                        "sctp_setadaptation": "UNKNOWN",
+                                                                                                        "sctp_authchunk": "UNKNOWN",
+                                                                                                        "sctp_hmacalgo": "UNKNOWN",
+                                                                                                        "sctp_authkey": "UNKNOWN",
+                                                                                                        "sctp_authkeyid": "UNKNOWN",
+                                                                                                        "sctp_paddrthlds": "UNKNOWN",
+                                                                                                        "sctp_paddrthlds_v2": "UNKNOWN",
+                                                                                                        "sctp_default_prinfo": "UNKNOWN",
+                                                                                                        "sctp_enable_strreset": "UNKNOWN",
+                                                                                                        "sctp_reset_streams": "UNKNOWN",
+                                                                                                        "sctp_assoc_value": "UNKNOWN",
+                                                                                                        "sctp_add_streams": "UNKNOWN",
+                                                                                                        "sctp_stream_value": "UNKNOWN",
+                                                                                                        "sctp_udpencaps": "UNKNOWN"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "SCTP_SOCKOPT_BINDX_ADD": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, array[sockaddr_storage]]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_BINDX_REM": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, array[sockaddr_storage]]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_CONNECTX_OLD": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, array[sockaddr_storage]]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_CONNECTX": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, array[sockaddr_storage]]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "SCTP_STATUS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_status]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_DISABLE_FRAGMENTS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_EVENTS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_event_subscribe]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_AUTOCLOSE": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_PEELOFF": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_peeloff_arg_t]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_PEELOFF_FLAGS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_peeloff_flags_arg_t]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PEER_ADDR_PARAMS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_paddrparams]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_DELAYED_SACK": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_sack_info]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_INITMSG": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_initmsg]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_PEER_ADDRS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_getaddrs]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_LOCAL_ADDRS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_getaddrs]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_CONNECTX3": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_getaddrs_old]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_DEFAULT_SEND_PARAM": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_sndrcvinfo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_DEFAULT_SNDINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_sndinfo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PRIMARY_ADDR": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_prim]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_NODELAY": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_RTOINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_rtoinfo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_ASSOCINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_assocparams]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_I_WANT_MAPPED_V4_ADDR": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_MAXSEG": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_PEER_ADDR_INFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_paddrinfo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_ADAPTATION_LAYER": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_setadaptation]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_CONTEXT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_FRAGMENT_INTERLEAVE": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PARTIAL_DELIVERY_POINT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_MAX_BURST": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_HMAC_IDENT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_hmacalgo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_AUTH_ACTIVE_KEY": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_authkeyid]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PEER_AUTH_CHUNKS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_authchunks]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_LOCAL_AUTH_CHUNKS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_authchunks]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_ASSOC_NUMBER": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_ASSOC_ID_LIST": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_assoc_ids]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_AUTO_ASCONF": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PEER_ADDR_THLDS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_paddrthlds_v2]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PEER_ADDR_THLDS_V2": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_paddrthlds_v2]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_ASSOC_STATS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_stats]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_RECVRCVINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_RECVNXTINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PR_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_DEFAULT_PRINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_default_prinfo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PR_ASSOC_STATUS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_prstatus]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PR_STREAM_STATUS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_prstatus]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_RECONFIG_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_ENABLE_STREAM_RESET": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_STREAM_SCHEDULER": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_STREAM_SCHEDULER_VALUE": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_stream_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_INTERLEAVING_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_REUSE_PORT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_EVENT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_event_subscribe]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_ASCONF_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_AUTH_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_ECN_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_EXPOSE_POTENTIALLY_FAILED_STATE": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_REMOTE_UDP_ENCAPS_PORT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_udpencaps]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PLPMTUD_PROBE_INTERVAL": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_probeinterval]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "sctp_bind",
+    "accept": "sctp_accept",
+    "ioctl": "sctp_ioctl",
+    "sendmsg": "sctp_sendmsg",
+    "recvmsg": "sctp_recvmsg",
+    "setsockopt": "sctp_setsockopt",
+    "getsockopt": "sctp_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/sctp/socket.c:9658",
+  "ops_name": "sctp_prot",
+  "syscall_specs": {
+    "socket$KGPT_inet_sctp": "socket$KGPT_inet_sctp(domain const[AF_INET], type const[SOCK_SEQPACKET], proto const[IPPROTO_SCTP]) sock_inet_sctp",
+    "bind$KGPT_sctp_prot": "bind$KGPT_sctp_prot(fd sock_inet_sctp, addr ptr[in, sctp_addr], addrlen len[addr])",
+    "accept4$KGPT_sctp_prot": "accept4$KGPT_sctp_prot(fd sock_inet_sctp, peer ptr[out, sctp_addr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet_sctp",
+    "sendto$KGPT_sctp_prot": "sendto$KGPT_sctp_prot(fd sock_inet_sctp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sctp_addr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_sctp_prot": "recvfrom$KGPT_sctp_prot(fd sock_inet_sctp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sctp_addr, opt], addrlen len[addr])",
+    "getsockopt$KGPT_SCTP_STATUS": "getsockopt$KGPT_SCTP_STATUS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_STATUS], val ptr[inout, sctp_status], len len[val])",
+    "getsockopt$KGPT_SCTP_DISABLE_FRAGMENTS": "getsockopt$KGPT_SCTP_DISABLE_FRAGMENTS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_DISABLE_FRAGMENTS], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_EVENTS": "getsockopt$KGPT_SCTP_EVENTS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_EVENTS], val ptr[out, sctp_event_subscribe], len len[val])",
+    "getsockopt$KGPT_SCTP_AUTOCLOSE": "getsockopt$KGPT_SCTP_AUTOCLOSE(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_AUTOCLOSE], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_SOCKOPT_PEELOFF": "getsockopt$KGPT_SCTP_SOCKOPT_PEELOFF(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_PEELOFF], val ptr[in, sctp_peeloff_arg_t], len len[val])",
+    "getsockopt$KGPT_SCTP_SOCKOPT_PEELOFF_FLAGS": "getsockopt$KGPT_SCTP_SOCKOPT_PEELOFF_FLAGS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_PEELOFF_FLAGS], val ptr[in, sctp_peeloff_flags_arg_t], len len[val])",
+    "getsockopt$KGPT_SCTP_PEER_ADDR_PARAMS": "getsockopt$KGPT_SCTP_PEER_ADDR_PARAMS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_PEER_ADDR_PARAMS], val ptr[inout, sctp_paddrparams], len len[val])",
+    "getsockopt$KGPT_SCTP_DELAYED_SACK": "getsockopt$KGPT_SCTP_DELAYED_SACK(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_DELAYED_SACK], val ptr[in, sctp_sack_info], len len[val])",
+    "getsockopt$KGPT_SCTP_INITMSG": "getsockopt$KGPT_SCTP_INITMSG(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_INITMSG], val ptr[out, sctp_initmsg], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_PEER_ADDRS": "getsockopt$KGPT_SCTP_GET_PEER_ADDRS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_GET_PEER_ADDRS], val ptr[inout, sctp_getaddrs], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_LOCAL_ADDRS": "getsockopt$KGPT_SCTP_GET_LOCAL_ADDRS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_GET_LOCAL_ADDRS], val ptr[out, sctp_getaddrs], len len[val])",
+    "getsockopt$KGPT_SCTP_SOCKOPT_CONNECTX3": "getsockopt$KGPT_SCTP_SOCKOPT_CONNECTX3(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_CONNECTX3], val ptr[in, sctp_getaddrs_old], len len[val])",
+    "getsockopt$KGPT_SCTP_DEFAULT_SEND_PARAM": "getsockopt$KGPT_SCTP_DEFAULT_SEND_PARAM(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_DEFAULT_SEND_PARAM], val ptr[inout, sctp_sndrcvinfo], len len[val])",
+    "getsockopt$KGPT_SCTP_DEFAULT_SNDINFO": "getsockopt$KGPT_SCTP_DEFAULT_SNDINFO(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_DEFAULT_SNDINFO], val ptr[in, sctp_sndinfo], len len[val])",
+    "getsockopt$KGPT_SCTP_PRIMARY_ADDR": "getsockopt$KGPT_SCTP_PRIMARY_ADDR(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_PRIMARY_ADDR], val ptr[inout, sctp_prim], len len[val])",
+    "getsockopt$KGPT_SCTP_NODELAY": "getsockopt$KGPT_SCTP_NODELAY(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_NODELAY], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_RTOINFO": "getsockopt$KGPT_SCTP_RTOINFO(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_RTOINFO], val ptr[in, sctp_rtoinfo], len len[val])",
+    "getsockopt$KGPT_SCTP_ASSOCINFO": "getsockopt$KGPT_SCTP_ASSOCINFO(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_ASSOCINFO], val ptr[in, sctp_assocparams], len len[val])",
+    "getsockopt$KGPT_SCTP_I_WANT_MAPPED_V4_ADDR": "getsockopt$KGPT_SCTP_I_WANT_MAPPED_V4_ADDR(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_I_WANT_MAPPED_V4_ADDR], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_MAXSEG": "getsockopt$KGPT_SCTP_MAXSEG(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_MAXSEG], val ptr[in, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_PEER_ADDR_INFO": "getsockopt$KGPT_SCTP_GET_PEER_ADDR_INFO(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_GET_PEER_ADDR_INFO], val ptr[inout, sctp_paddrinfo], len len[val])",
+    "getsockopt$KGPT_SCTP_ADAPTATION_LAYER": "getsockopt$KGPT_SCTP_ADAPTATION_LAYER(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_ADAPTATION_LAYER], val ptr[out, sctp_setadaptation], len len[val])",
+    "getsockopt$KGPT_SCTP_CONTEXT": "getsockopt$KGPT_SCTP_CONTEXT(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_CONTEXT], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_FRAGMENT_INTERLEAVE": "getsockopt$KGPT_SCTP_FRAGMENT_INTERLEAVE(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_FRAGMENT_INTERLEAVE], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_PARTIAL_DELIVERY_POINT": "getsockopt$KGPT_SCTP_PARTIAL_DELIVERY_POINT(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_PARTIAL_DELIVERY_POINT], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_MAX_BURST": "getsockopt$KGPT_SCTP_MAX_BURST(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_MAX_BURST], val ptr[in, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_HMAC_IDENT": "getsockopt$KGPT_SCTP_HMAC_IDENT(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_HMAC_IDENT], val ptr[out, sctp_hmacalgo], len len[val])",
+    "getsockopt$KGPT_SCTP_AUTH_ACTIVE_KEY": "getsockopt$KGPT_SCTP_AUTH_ACTIVE_KEY(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_AUTH_ACTIVE_KEY], val ptr[inout, sctp_authkeyid], len len[val])",
+    "getsockopt$KGPT_SCTP_PEER_AUTH_CHUNKS": "getsockopt$KGPT_SCTP_PEER_AUTH_CHUNKS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_PEER_AUTH_CHUNKS], val ptr[inout, sctp_authchunks], len len[val])",
+    "getsockopt$KGPT_SCTP_LOCAL_AUTH_CHUNKS": "getsockopt$KGPT_SCTP_LOCAL_AUTH_CHUNKS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_LOCAL_AUTH_CHUNKS], val ptr[in, sctp_authchunks], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_ASSOC_NUMBER": "getsockopt$KGPT_SCTP_GET_ASSOC_NUMBER(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_GET_ASSOC_NUMBER], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_ASSOC_ID_LIST": "getsockopt$KGPT_SCTP_GET_ASSOC_ID_LIST(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_GET_ASSOC_ID_LIST], val ptr[out, sctp_assoc_ids], len len[val])",
+    "getsockopt$KGPT_SCTP_AUTO_ASCONF": "getsockopt$KGPT_SCTP_AUTO_ASCONF(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_AUTO_ASCONF], val ptr[in, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_PEER_ADDR_THLDS": "getsockopt$KGPT_SCTP_PEER_ADDR_THLDS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_PEER_ADDR_THLDS], val ptr[inout, sctp_paddrthlds_v2], len len[val])",
+    "getsockopt$KGPT_SCTP_PEER_ADDR_THLDS_V2": "getsockopt$KGPT_SCTP_PEER_ADDR_THLDS_V2(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_PEER_ADDR_THLDS_V2], val ptr[in, sctp_paddrthlds_v2], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_ASSOC_STATS": "getsockopt$KGPT_SCTP_GET_ASSOC_STATS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_GET_ASSOC_STATS], val ptr[inout, sctp_assoc_stats], len len[val])",
+    "getsockopt$KGPT_SCTP_RECVRCVINFO": "getsockopt$KGPT_SCTP_RECVRCVINFO(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_RECVRCVINFO], val ptr[in, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_RECVNXTINFO": "getsockopt$KGPT_SCTP_RECVNXTINFO(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_RECVNXTINFO], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_PR_SUPPORTED": "getsockopt$KGPT_SCTP_PR_SUPPORTED(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_PR_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_DEFAULT_PRINFO": "getsockopt$KGPT_SCTP_DEFAULT_PRINFO(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_DEFAULT_PRINFO], val ptr[inout, sctp_default_prinfo], len len[val])",
+    "getsockopt$KGPT_SCTP_PR_ASSOC_STATUS": "getsockopt$KGPT_SCTP_PR_ASSOC_STATUS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_PR_ASSOC_STATUS], val ptr[in, sctp_prstatus], len len[val])",
+    "getsockopt$KGPT_SCTP_PR_STREAM_STATUS": "getsockopt$KGPT_SCTP_PR_STREAM_STATUS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_PR_STREAM_STATUS], val ptr[inout, sctp_prstatus], len len[val])",
+    "getsockopt$KGPT_SCTP_RECONFIG_SUPPORTED": "getsockopt$KGPT_SCTP_RECONFIG_SUPPORTED(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_RECONFIG_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_ENABLE_STREAM_RESET": "getsockopt$KGPT_SCTP_ENABLE_STREAM_RESET(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_ENABLE_STREAM_RESET], val ptr[in, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_STREAM_SCHEDULER": "getsockopt$KGPT_SCTP_STREAM_SCHEDULER(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_STREAM_SCHEDULER], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_STREAM_SCHEDULER_VALUE": "getsockopt$KGPT_SCTP_STREAM_SCHEDULER_VALUE(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_STREAM_SCHEDULER_VALUE], val ptr[inout, sctp_stream_value], len len[val])",
+    "getsockopt$KGPT_SCTP_INTERLEAVING_SUPPORTED": "getsockopt$KGPT_SCTP_INTERLEAVING_SUPPORTED(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_INTERLEAVING_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_REUSE_PORT": "getsockopt$KGPT_SCTP_REUSE_PORT(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_REUSE_PORT], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_EVENT": "getsockopt$KGPT_SCTP_EVENT(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_EVENT], val ptr[inout, sctp_event_subscribe], len len[val])",
+    "getsockopt$KGPT_SCTP_ASCONF_SUPPORTED": "getsockopt$KGPT_SCTP_ASCONF_SUPPORTED(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_ASCONF_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_AUTH_SUPPORTED": "getsockopt$KGPT_SCTP_AUTH_SUPPORTED(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_AUTH_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_ECN_SUPPORTED": "getsockopt$KGPT_SCTP_ECN_SUPPORTED(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_ECN_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_EXPOSE_POTENTIALLY_FAILED_STATE": "getsockopt$KGPT_SCTP_EXPOSE_POTENTIALLY_FAILED_STATE(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_EXPOSE_POTENTIALLY_FAILED_STATE], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_REMOTE_UDP_ENCAPS_PORT": "getsockopt$KGPT_SCTP_REMOTE_UDP_ENCAPS_PORT(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_REMOTE_UDP_ENCAPS_PORT], val ptr[in, sctp_udpencaps], len len[val])",
+    "getsockopt$KGPT_SCTP_PLPMTUD_PROBE_INTERVAL": "getsockopt$KGPT_SCTP_PLPMTUD_PROBE_INTERVAL(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_PLPMTUD_PROBE_INTERVAL], val ptr[in, sctp_probeinterval], len len[val])",
+    "setsockopt$KGPT_SCTP_DISABLE_FRAGMENTS": "setsockopt$KGPT_SCTP_DISABLE_FRAGMENTS(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_DISABLE_FRAGMENTS], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_SCTP_SOCKOPT_BINDX_ADD": "setsockopt$KGPT_SCTP_SOCKOPT_BINDX_ADD(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_BINDX_ADD], val ptr[in, array[sockaddr_storage]], len len[val])",
+    "setsockopt$KGPT_SCTP_SOCKOPT_BINDX_REM": "setsockopt$KGPT_SCTP_SOCKOPT_BINDX_REM(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_BINDX_REM], val ptr[in, array[sockaddr_storage]], len len[val])",
+    "setsockopt$KGPT_SCTP_SOCKOPT_CONNECTX_OLD": "setsockopt$KGPT_SCTP_SOCKOPT_CONNECTX_OLD(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_CONNECTX_OLD], val ptr[in, array[sockaddr_storage]], len len[val])",
+    "setsockopt$KGPT_SCTP_SOCKOPT_CONNECTX": "setsockopt$KGPT_SCTP_SOCKOPT_CONNECTX(fd sock_inet_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_CONNECTX], val ptr[in, array[sockaddr_storage]], len len[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet_sctp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/sctp.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_storage": "EXISTING",
+    "sctp_status": "EXISTING",
+    "sctp_event_subscribe": "EXISTING",
+    "sctp_peeloff_arg_t": "EXISTING",
+    "sctp_paddrparams": "EXISTING",
+    "sctp_sack_info": "EXISTING",
+    "sctp_initmsg": "EXISTING",
+    "sctp_getaddrs": "EXISTING",
+    "sctp_getaddrs_old": "EXISTING",
+    "sctp_sndrcvinfo": "EXISTING",
+    "sctp_sndinfo": "EXISTING",
+    "sctp_prim": "EXISTING",
+    "sctp_rtoinfo": "EXISTING",
+    "sctp_assocparams": "EXISTING",
+    "sctp_assoc_value": "EXISTING",
+    "sctp_paddrinfo": "EXISTING",
+    "sctp_setadaptation": "EXISTING",
+    "sctp_hmacalgo": "EXISTING",
+    "sctp_authkeyid": "EXISTING",
+    "sctp_authchunks": "EXISTING",
+    "sctp_assoc_ids": "EXISTING",
+    "sctp_assoc_stats": "EXISTING",
+    "sctp_default_prinfo": "EXISTING",
+    "sctp_prstatus": "EXISTING",
+    "sctp_stream_value": "EXISTING",
+    "sockaddr_in": "EXISTING",
+    "sockaddr_in6": "EXISTING",
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/sctpv6_prot#net_sctp_socket.c:9714.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/sctpv6_prot#net_sctp_socket.c:9714.json
@@ -1,0 +1,815 @@
+{
+  "socket": {
+    "domain": "AF_INET6",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_inet6_sctp(domain const[AF_INET6], type const[SOCK_SEQPACKET], proto const[IPPROTO_SCTP]) sock_inet6_sctp"
+  },
+  "resources": {
+    "sock_inet6_sctp": {
+      "type": "sock",
+      "spec": "resource sock_inet6_sctp[sock]"
+    }
+  },
+  "types": {
+    "IPPROTO_SCTP": "define IPPROTO_SCTP 132",
+    "sctp_addr": "sctp_addr [\n\tv4\tsockaddr_in\n\tv6\tsockaddr_in6\n\tsa\tsockaddr\n]",
+    "sctp_peeloff_flags_arg_t": "sctp_peeloff_flags_arg_t {\n\tp_arg\tsctp_peeloff_arg_t\n\tflags\tint32\n}",
+    "sctp_paddrthlds_v2": "sctp_paddrthlds_v2 {\n\tspt_assoc_id\tsctp_assoc_t\n\tspt_address\tsockaddr_storage\n\tspt_pathmaxrxt\tint16\n\tspt_pathpfthld\tint16\n\tspt_pathcpthld\tint16\n}",
+    "sctp_udpencaps": "sctp_udpencaps {\n\tsue_assoc_id\tsctp_assoc_t\n\tsue_address\tsockaddr_storage\n\tsue_port\tint16\n}",
+    "sctp_probeinterval": "sctp_probeinterval {\n\tspi_assoc_id\tsctp_assoc_t\n\tspi_address\tsockaddr_storage\n\tspi_interval\tint32\n}",
+    "sctp_assoc_t": "type sctp_assoc_t ptr[in, array[int8]]"
+  },
+  "socket_addr": "sctp_addr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "karg"
+      ],
+      "arg_inference": {
+        "function": [],
+        "type": [
+          "int"
+        ],
+        "usage": [
+          "int rc = -ENOTCONN;",
+          "lock_sock(sk);",
+          "if (sctp_style(sk, TCP) && sctp_sstate(sk, LISTENING))",
+          "goto out;",
+          "switch (cmd) {",
+          "case SIOCINQ: {",
+          "struct sk_buff *skb;",
+          "*karg = 0;",
+          "skb = skb_peek(&sk->sk_receive_queue);",
+          "if (skb != NULL) {",
+          "*karg = skb->len;",
+          "}",
+          "rc = 0;",
+          "break;",
+          "}",
+          "default:",
+          "rc = -ENOIOCTLCMD;",
+          "break;",
+          "}",
+          "out:",
+          "release_sock(sk);",
+          "return rc;"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "SCTP_DISABLE_FRAGMENTS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]",
+      "SCTP_EVENTS": {
+        "level": "SOL_SCTP",
+        "val": "ptr[in, sctp_event_subscribe]",
+        "len": "bytesize[val]",
+        "SCTP_AUTOCLOSE": {
+          "level": "SOL_SCTP",
+          "val": "ptr[in, int32]",
+          "len": "bytesize[val]",
+          "SCTP_PEER_ADDR_PARAMS": {
+            "level": "SOL_SCTP",
+            "val": "ptr[in, sctp_paddrparams]",
+            "len": "bytesize[val]",
+            "SCTP_DELAYED_SACK": {
+              "level": "SOL_SCTP",
+              "val": "ptr[in, sctp_sack_info]",
+              "len": "bytesize[val]",
+              "SCTP_PARTIAL_DELIVERY_POINT": {
+                "level": "SOL_SCTP",
+                "val": "ptr[in, int32]",
+                "len": "bytesize[val]",
+                "SCTP_INITMSG": {
+                  "level": "SOL_SCTP",
+                  "val": "ptr[in, sctp_initmsg]",
+                  "len": "bytesize[val]",
+                  "SCTP_DEFAULT_SEND_PARAM": {
+                    "level": "SOL_SCTP",
+                    "val": "ptr[in, sctp_sndrcvinfo]",
+                    "len": "bytesize[val]",
+                    "SCTP_DEFAULT_SNDINFO": {
+                      "level": "SOL_SCTP",
+                      "val": "ptr[in, sctp_sndinfo]",
+                      "len": "bytesize[val]",
+                      "SCTP_PRIMARY_ADDR": {
+                        "level": "SOL_SCTP",
+                        "val": "ptr[in, sctp_setpeerprim]",
+                        "len": "bytesize[val]",
+                        "SCTP_SET_PEER_PRIMARY_ADDR": {
+                          "level": "SOL_SCTP",
+                          "val": "ptr[in, sctp_prim]",
+                          "len": "bytesize[val]",
+                          "SCTP_NODELAY": {
+                            "level": "SOL_SCTP",
+                            "val": "ptr[in, int32]",
+                            "len": "bytesize[val]",
+                            "SCTP_RTOINFO": {
+                              "level": "SOL_SCTP",
+                              "val": "ptr[in, sctp_rtoinfo]",
+                              "len": "bytesize[val]",
+                              "SCTP_ASSOCINFO": {
+                                "level": "SOL_SCTP",
+                                "val": "ptr[in, sctp_assocparams]",
+                                "len": "bytesize[val]",
+                                "SCTP_I_WANT_MAPPED_V4_ADDR": {
+                                  "level": "SOL_SCTP",
+                                  "val": "ptr[in, int32]",
+                                  "len": "bytesize[val]",
+                                  "SCTP_MAXSEG": {
+                                    "level": "SOL_SCTP",
+                                    "val": "ptr[in, int32]",
+                                    "len": "bytesize[val]",
+                                    "SCTP_ADAPTATION_LAYER": {
+                                      "level": "SOL_SCTP",
+                                      "val": "ptr[in, sctp_setadaptation]",
+                                      "len": "bytesize[val]",
+                                      "SCTP_CONTEXT": {
+                                        "level": "SOL_SCTP",
+                                        "val": "ptr[in, int32]",
+                                        "len": "bytesize[val]",
+                                        "SCTP_FRAGMENT_INTERLEAVE": {
+                                          "level": "SOL_SCTP",
+                                          "val": "ptr[in, int32]",
+                                          "len": "bytesize[val]",
+                                          "SCTP_MAX_BURST": {
+                                            "level": "SOL_SCTP",
+                                            "val": "ptr[in, int32]",
+                                            "len": "bytesize[val]",
+                                            "SCTP_AUTH_CHUNK": {
+                                              "level": "SOL_SCTP",
+                                              "val": "ptr[in, sctp_authchunk]",
+                                              "len": "bytesize[val]",
+                                              "SCTP_HMAC_IDENT": {
+                                                "level": "SOL_SCTP",
+                                                "val": "ptr[in, sctp_hmacalgo]",
+                                                "len": "bytesize[val]",
+                                                "SCTP_AUTH_KEY": {
+                                                  "level": "SOL_SCTP",
+                                                  "val": "ptr[in, sctp_authkey]",
+                                                  "len": "bytesize[val]",
+                                                  "SCTP_AUTH_ACTIVE_KEY": {
+                                                    "level": "SOL_SCTP",
+                                                    "val": "ptr[in, sctp_authkeyid]",
+                                                    "len": "bytesize[val]",
+                                                    "SCTP_AUTH_DELETE_KEY": {
+                                                      "level": "SOL_SCTP",
+                                                      "val": "ptr[in, sctp_authkeyid]",
+                                                      "len": "bytesize[val]",
+                                                      "SCTP_AUTH_DEACTIVATE_KEY": {
+                                                        "level": "SOL_SCTP",
+                                                        "val": "ptr[in, sctp_authkeyid]",
+                                                        "len": "bytesize[val]",
+                                                        "SCTP_AUTO_ASCONF": {
+                                                          "level": "SOL_SCTP",
+                                                          "val": "ptr[in, int32]",
+                                                          "len": "bytesize[val]",
+                                                          "SCTP_PEER_ADDR_THLDS": {
+                                                            "level": "SOL_SCTP",
+                                                            "val": "ptr[in, sctp_paddrthlds]",
+                                                            "len": "bytesize[val]",
+                                                            "SCTP_PEER_ADDR_THLDS_V2": {
+                                                              "level": "SOL_SCTP",
+                                                              "val": "ptr[in, sctp_paddrthlds_v2]",
+                                                              "len": "bytesize[val]",
+                                                              "SCTP_RECVRCVINFO": {
+                                                                "level": "SOL_SCTP",
+                                                                "val": "ptr[in, int32]",
+                                                                "len": "bytesize[val]",
+                                                                "SCTP_RECVNXTINFO": {
+                                                                  "level": "SOL_SCTP",
+                                                                  "val": "ptr[in, int32]",
+                                                                  "len": "bytesize[val]",
+                                                                  "SCTP_PR_SUPPORTED": {
+                                                                    "level": "SOL_SCTP",
+                                                                    "val": "ptr[in, int32]",
+                                                                    "len": "bytesize[val]",
+                                                                    "SCTP_DEFAULT_PRINFO": {
+                                                                      "level": "SOL_SCTP",
+                                                                      "val": "ptr[in, sctp_default_prinfo]",
+                                                                      "len": "bytesize[val]",
+                                                                      "SCTP_RECONFIG_SUPPORTED": {
+                                                                        "level": "SOL_SCTP",
+                                                                        "val": "ptr[in, int32]",
+                                                                        "len": "bytesize[val]",
+                                                                        "SCTP_ENABLE_STREAM_RESET": {
+                                                                          "level": "SOL_SCTP",
+                                                                          "val": "ptr[in, sctp_enable_strreset]",
+                                                                          "len": "bytesize[val]",
+                                                                          "SCTP_RESET_STREAMS": {
+                                                                            "level": "SOL_SCTP",
+                                                                            "val": "ptr[in, sctp_reset_streams]",
+                                                                            "len": "bytesize[val]",
+                                                                            "SCTP_RESET_ASSOC": {
+                                                                              "level": "SOL_SCTP",
+                                                                              "val": "ptr[in, sctp_assoc_value]",
+                                                                              "len": "bytesize[val]",
+                                                                              "SCTP_ADD_STREAMS": {
+                                                                                "level": "SOL_SCTP",
+                                                                                "val": "ptr[in, sctp_add_streams]",
+                                                                                "len": "bytesize[val]",
+                                                                                "SCTP_STREAM_SCHEDULER": {
+                                                                                  "level": "SOL_SCTP",
+                                                                                  "val": "ptr[in, int32]",
+                                                                                  "len": "bytesize[val]",
+                                                                                  "SCTP_STREAM_SCHEDULER_VALUE": {
+                                                                                    "level": "SOL_SCTP",
+                                                                                    "val": "ptr[in, sctp_stream_value]",
+                                                                                    "len": "bytesize[val]",
+                                                                                    "SCTP_INTERLEAVING_SUPPORTED": {
+                                                                                      "level": "SOL_SCTP",
+                                                                                      "val": "ptr[in, int32]",
+                                                                                      "len": "bytesize[val]",
+                                                                                      "SCTP_REUSE_PORT": {
+                                                                                        "level": "SOL_SCTP",
+                                                                                        "val": "ptr[in, int32]",
+                                                                                        "len": "bytesize[val]",
+                                                                                        "SCTP_EVENT": {
+                                                                                          "level": "SOL_SCTP",
+                                                                                          "val": "ptr[in, sctp_event_subscribe]",
+                                                                                          "len": "bytesize[val]",
+                                                                                          "SCTP_ASCONF_SUPPORTED": {
+                                                                                            "level": "SOL_SCTP",
+                                                                                            "val": "ptr[in, int32]",
+                                                                                            "len": "bytesize[val]",
+                                                                                            "SCTP_AUTH_SUPPORTED": {
+                                                                                              "level": "SOL_SCTP",
+                                                                                              "val": "ptr[in, int32]",
+                                                                                              "len": "bytesize[val]",
+                                                                                              "SCTP_ECN_SUPPORTED": {
+                                                                                                "level": "SOL_SCTP",
+                                                                                                "val": "ptr[in, int32]",
+                                                                                                "len": "bytesize[val]",
+                                                                                                "SCTP_EXPOSE_POTENTIALLY_FAILED_STATE": {
+                                                                                                  "level": "SOL_SCTP",
+                                                                                                  "val": "ptr[in, int32]",
+                                                                                                  "len": "bytesize[val]",
+                                                                                                  "SCTP_REMOTE_UDP_ENCAPS_PORT": {
+                                                                                                    "level": "SOL_SCTP",
+                                                                                                    "val": "ptr[in, sctp_udpencaps]",
+                                                                                                    "len": "bytesize[val]",
+                                                                                                    "SCTP_PLPMTUD_PROBE_INTERVAL": {
+                                                                                                      "level": "SOL_SCTP",
+                                                                                                      "val": "ptr[in, int32]",
+                                                                                                      "len": "bytesize[val]",
+                                                                                                      "unknown": [],
+                                                                                                      "types": {
+                                                                                                        "sctp_event_subscribe": "UNKNOWN",
+                                                                                                        "sctp_paddrparams": "UNKNOWN",
+                                                                                                        "sctp_sack_info": "UNKNOWN",
+                                                                                                        "sctp_initmsg": "UNKNOWN",
+                                                                                                        "sctp_sndrcvinfo": "UNKNOWN",
+                                                                                                        "sctp_sndinfo": "UNKNOWN",
+                                                                                                        "sctp_setpeerprim": "UNKNOWN",
+                                                                                                        "sctp_prim": "UNKNOWN",
+                                                                                                        "sctp_rtoinfo": "UNKNOWN",
+                                                                                                        "sctp_assocparams": "UNKNOWN",
+                                                                                                        "sctp_setadaptation": "UNKNOWN",
+                                                                                                        "sctp_authchunk": "UNKNOWN",
+                                                                                                        "sctp_hmacalgo": "UNKNOWN",
+                                                                                                        "sctp_authkey": "UNKNOWN",
+                                                                                                        "sctp_authkeyid": "UNKNOWN",
+                                                                                                        "sctp_paddrthlds": "UNKNOWN",
+                                                                                                        "sctp_paddrthlds_v2": "UNKNOWN",
+                                                                                                        "sctp_default_prinfo": "UNKNOWN",
+                                                                                                        "sctp_enable_strreset": "UNKNOWN",
+                                                                                                        "sctp_reset_streams": "UNKNOWN",
+                                                                                                        "sctp_assoc_value": "UNKNOWN",
+                                                                                                        "sctp_add_streams": "UNKNOWN",
+                                                                                                        "sctp_stream_value": "UNKNOWN",
+                                                                                                        "sctp_udpencaps": "UNKNOWN"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "SCTP_SOCKOPT_BINDX_ADD": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, array[sockaddr_storage]]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_BINDX_REM": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, array[sockaddr_storage]]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_CONNECTX_OLD": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, array[sockaddr_storage]]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_CONNECTX": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, array[sockaddr_storage]]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "SCTP_STATUS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_status]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_DISABLE_FRAGMENTS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_EVENTS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_event_subscribe]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_AUTOCLOSE": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_PEELOFF": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_peeloff_arg_t]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_PEELOFF_FLAGS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_peeloff_flags_arg_t]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PEER_ADDR_PARAMS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_paddrparams]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_DELAYED_SACK": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_sack_info]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_INITMSG": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_initmsg]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_PEER_ADDRS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_getaddrs]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_LOCAL_ADDRS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_getaddrs]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_SOCKOPT_CONNECTX3": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_getaddrs_old]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_DEFAULT_SEND_PARAM": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_sndrcvinfo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_DEFAULT_SNDINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_sndinfo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PRIMARY_ADDR": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_prim]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_NODELAY": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_RTOINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_rtoinfo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_ASSOCINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_assocparams]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_I_WANT_MAPPED_V4_ADDR": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_MAXSEG": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_PEER_ADDR_INFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_paddrinfo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_ADAPTATION_LAYER": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_setadaptation]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_CONTEXT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_FRAGMENT_INTERLEAVE": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PARTIAL_DELIVERY_POINT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_MAX_BURST": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_HMAC_IDENT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_hmacalgo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_AUTH_ACTIVE_KEY": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_authkeyid]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PEER_AUTH_CHUNKS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_authchunks]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_LOCAL_AUTH_CHUNKS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_authchunks]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_ASSOC_NUMBER": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_ASSOC_ID_LIST": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, sctp_assoc_ids]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_AUTO_ASCONF": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PEER_ADDR_THLDS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_paddrthlds_v2]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PEER_ADDR_THLDS_V2": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_paddrthlds_v2]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_GET_ASSOC_STATS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_stats]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_RECVRCVINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_RECVNXTINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PR_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_DEFAULT_PRINFO": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_default_prinfo]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PR_ASSOC_STATUS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_prstatus]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PR_STREAM_STATUS": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_prstatus]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_RECONFIG_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_ENABLE_STREAM_RESET": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_STREAM_SCHEDULER": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_STREAM_SCHEDULER_VALUE": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_stream_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_INTERLEAVING_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_REUSE_PORT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[out, int32]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_EVENT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_event_subscribe]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_ASCONF_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_AUTH_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_ECN_SUPPORTED": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_EXPOSE_POTENTIALLY_FAILED_STATE": {
+      "level": "SOL_SCTP",
+      "val": "ptr[inout, sctp_assoc_value]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_REMOTE_UDP_ENCAPS_PORT": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_udpencaps]",
+      "len": "len[val]",
+      "val_inference": null
+    },
+    "SCTP_PLPMTUD_PROBE_INTERVAL": {
+      "level": "SOL_SCTP",
+      "val": "ptr[in, sctp_probeinterval]",
+      "len": "len[val]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "sctp_bind",
+    "accept": "sctp_accept",
+    "ioctl": "sctp_ioctl",
+    "sendmsg": "sctp_sendmsg",
+    "recvmsg": "sctp_recvmsg",
+    "setsockopt": "sctp_setsockopt",
+    "getsockopt": "sctp_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/sctp/socket.c:9714",
+  "ops_name": "sctpv6_prot",
+  "syscall_specs": {
+    "socket$KGPT_inet6_sctp": "socket$KGPT_inet6_sctp(domain const[AF_INET6], type const[SOCK_SEQPACKET], proto const[IPPROTO_SCTP]) sock_inet6_sctp",
+    "bind$KGPT_sctpv6_prot": "bind$KGPT_sctpv6_prot(fd sock_inet6_sctp, addr ptr[in, sctp_addr], addrlen len[addr])",
+    "accept4$KGPT_sctpv6_prot": "accept4$KGPT_sctpv6_prot(fd sock_inet6_sctp, peer ptr[out, sctp_addr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_inet6_sctp",
+    "sendto$KGPT_sctpv6_prot": "sendto$KGPT_sctpv6_prot(fd sock_inet6_sctp, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sctp_addr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_sctpv6_prot": "recvfrom$KGPT_sctpv6_prot(fd sock_inet6_sctp, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sctp_addr, opt], addrlen len[addr])",
+    "getsockopt$KGPT_SCTP_STATUS": "getsockopt$KGPT_SCTP_STATUS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_STATUS], val ptr[inout, sctp_status], len len[val])",
+    "getsockopt$KGPT_SCTP_DISABLE_FRAGMENTS": "getsockopt$KGPT_SCTP_DISABLE_FRAGMENTS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_DISABLE_FRAGMENTS], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_EVENTS": "getsockopt$KGPT_SCTP_EVENTS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_EVENTS], val ptr[out, sctp_event_subscribe], len len[val])",
+    "getsockopt$KGPT_SCTP_AUTOCLOSE": "getsockopt$KGPT_SCTP_AUTOCLOSE(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_AUTOCLOSE], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_SOCKOPT_PEELOFF": "getsockopt$KGPT_SCTP_SOCKOPT_PEELOFF(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_PEELOFF], val ptr[in, sctp_peeloff_arg_t], len len[val])",
+    "getsockopt$KGPT_SCTP_SOCKOPT_PEELOFF_FLAGS": "getsockopt$KGPT_SCTP_SOCKOPT_PEELOFF_FLAGS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_PEELOFF_FLAGS], val ptr[in, sctp_peeloff_flags_arg_t], len len[val])",
+    "getsockopt$KGPT_SCTP_PEER_ADDR_PARAMS": "getsockopt$KGPT_SCTP_PEER_ADDR_PARAMS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_PEER_ADDR_PARAMS], val ptr[inout, sctp_paddrparams], len len[val])",
+    "getsockopt$KGPT_SCTP_DELAYED_SACK": "getsockopt$KGPT_SCTP_DELAYED_SACK(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_DELAYED_SACK], val ptr[in, sctp_sack_info], len len[val])",
+    "getsockopt$KGPT_SCTP_INITMSG": "getsockopt$KGPT_SCTP_INITMSG(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_INITMSG], val ptr[out, sctp_initmsg], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_PEER_ADDRS": "getsockopt$KGPT_SCTP_GET_PEER_ADDRS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_GET_PEER_ADDRS], val ptr[inout, sctp_getaddrs], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_LOCAL_ADDRS": "getsockopt$KGPT_SCTP_GET_LOCAL_ADDRS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_GET_LOCAL_ADDRS], val ptr[out, sctp_getaddrs], len len[val])",
+    "getsockopt$KGPT_SCTP_SOCKOPT_CONNECTX3": "getsockopt$KGPT_SCTP_SOCKOPT_CONNECTX3(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_CONNECTX3], val ptr[in, sctp_getaddrs_old], len len[val])",
+    "getsockopt$KGPT_SCTP_DEFAULT_SEND_PARAM": "getsockopt$KGPT_SCTP_DEFAULT_SEND_PARAM(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_DEFAULT_SEND_PARAM], val ptr[inout, sctp_sndrcvinfo], len len[val])",
+    "getsockopt$KGPT_SCTP_DEFAULT_SNDINFO": "getsockopt$KGPT_SCTP_DEFAULT_SNDINFO(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_DEFAULT_SNDINFO], val ptr[in, sctp_sndinfo], len len[val])",
+    "getsockopt$KGPT_SCTP_PRIMARY_ADDR": "getsockopt$KGPT_SCTP_PRIMARY_ADDR(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_PRIMARY_ADDR], val ptr[inout, sctp_prim], len len[val])",
+    "getsockopt$KGPT_SCTP_NODELAY": "getsockopt$KGPT_SCTP_NODELAY(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_NODELAY], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_RTOINFO": "getsockopt$KGPT_SCTP_RTOINFO(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_RTOINFO], val ptr[in, sctp_rtoinfo], len len[val])",
+    "getsockopt$KGPT_SCTP_ASSOCINFO": "getsockopt$KGPT_SCTP_ASSOCINFO(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_ASSOCINFO], val ptr[in, sctp_assocparams], len len[val])",
+    "getsockopt$KGPT_SCTP_I_WANT_MAPPED_V4_ADDR": "getsockopt$KGPT_SCTP_I_WANT_MAPPED_V4_ADDR(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_I_WANT_MAPPED_V4_ADDR], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_MAXSEG": "getsockopt$KGPT_SCTP_MAXSEG(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_MAXSEG], val ptr[in, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_PEER_ADDR_INFO": "getsockopt$KGPT_SCTP_GET_PEER_ADDR_INFO(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_GET_PEER_ADDR_INFO], val ptr[inout, sctp_paddrinfo], len len[val])",
+    "getsockopt$KGPT_SCTP_ADAPTATION_LAYER": "getsockopt$KGPT_SCTP_ADAPTATION_LAYER(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_ADAPTATION_LAYER], val ptr[out, sctp_setadaptation], len len[val])",
+    "getsockopt$KGPT_SCTP_CONTEXT": "getsockopt$KGPT_SCTP_CONTEXT(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_CONTEXT], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_FRAGMENT_INTERLEAVE": "getsockopt$KGPT_SCTP_FRAGMENT_INTERLEAVE(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_FRAGMENT_INTERLEAVE], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_PARTIAL_DELIVERY_POINT": "getsockopt$KGPT_SCTP_PARTIAL_DELIVERY_POINT(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_PARTIAL_DELIVERY_POINT], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_MAX_BURST": "getsockopt$KGPT_SCTP_MAX_BURST(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_MAX_BURST], val ptr[in, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_HMAC_IDENT": "getsockopt$KGPT_SCTP_HMAC_IDENT(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_HMAC_IDENT], val ptr[out, sctp_hmacalgo], len len[val])",
+    "getsockopt$KGPT_SCTP_AUTH_ACTIVE_KEY": "getsockopt$KGPT_SCTP_AUTH_ACTIVE_KEY(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_AUTH_ACTIVE_KEY], val ptr[inout, sctp_authkeyid], len len[val])",
+    "getsockopt$KGPT_SCTP_PEER_AUTH_CHUNKS": "getsockopt$KGPT_SCTP_PEER_AUTH_CHUNKS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_PEER_AUTH_CHUNKS], val ptr[inout, sctp_authchunks], len len[val])",
+    "getsockopt$KGPT_SCTP_LOCAL_AUTH_CHUNKS": "getsockopt$KGPT_SCTP_LOCAL_AUTH_CHUNKS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_LOCAL_AUTH_CHUNKS], val ptr[in, sctp_authchunks], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_ASSOC_NUMBER": "getsockopt$KGPT_SCTP_GET_ASSOC_NUMBER(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_GET_ASSOC_NUMBER], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_ASSOC_ID_LIST": "getsockopt$KGPT_SCTP_GET_ASSOC_ID_LIST(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_GET_ASSOC_ID_LIST], val ptr[out, sctp_assoc_ids], len len[val])",
+    "getsockopt$KGPT_SCTP_AUTO_ASCONF": "getsockopt$KGPT_SCTP_AUTO_ASCONF(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_AUTO_ASCONF], val ptr[in, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_PEER_ADDR_THLDS": "getsockopt$KGPT_SCTP_PEER_ADDR_THLDS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_PEER_ADDR_THLDS], val ptr[inout, sctp_paddrthlds_v2], len len[val])",
+    "getsockopt$KGPT_SCTP_PEER_ADDR_THLDS_V2": "getsockopt$KGPT_SCTP_PEER_ADDR_THLDS_V2(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_PEER_ADDR_THLDS_V2], val ptr[in, sctp_paddrthlds_v2], len len[val])",
+    "getsockopt$KGPT_SCTP_GET_ASSOC_STATS": "getsockopt$KGPT_SCTP_GET_ASSOC_STATS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_GET_ASSOC_STATS], val ptr[inout, sctp_assoc_stats], len len[val])",
+    "getsockopt$KGPT_SCTP_RECVRCVINFO": "getsockopt$KGPT_SCTP_RECVRCVINFO(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_RECVRCVINFO], val ptr[in, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_RECVNXTINFO": "getsockopt$KGPT_SCTP_RECVNXTINFO(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_RECVNXTINFO], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_PR_SUPPORTED": "getsockopt$KGPT_SCTP_PR_SUPPORTED(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_PR_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_DEFAULT_PRINFO": "getsockopt$KGPT_SCTP_DEFAULT_PRINFO(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_DEFAULT_PRINFO], val ptr[inout, sctp_default_prinfo], len len[val])",
+    "getsockopt$KGPT_SCTP_PR_ASSOC_STATUS": "getsockopt$KGPT_SCTP_PR_ASSOC_STATUS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_PR_ASSOC_STATUS], val ptr[in, sctp_prstatus], len len[val])",
+    "getsockopt$KGPT_SCTP_PR_STREAM_STATUS": "getsockopt$KGPT_SCTP_PR_STREAM_STATUS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_PR_STREAM_STATUS], val ptr[inout, sctp_prstatus], len len[val])",
+    "getsockopt$KGPT_SCTP_RECONFIG_SUPPORTED": "getsockopt$KGPT_SCTP_RECONFIG_SUPPORTED(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_RECONFIG_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_ENABLE_STREAM_RESET": "getsockopt$KGPT_SCTP_ENABLE_STREAM_RESET(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_ENABLE_STREAM_RESET], val ptr[in, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_STREAM_SCHEDULER": "getsockopt$KGPT_SCTP_STREAM_SCHEDULER(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_STREAM_SCHEDULER], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_STREAM_SCHEDULER_VALUE": "getsockopt$KGPT_SCTP_STREAM_SCHEDULER_VALUE(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_STREAM_SCHEDULER_VALUE], val ptr[inout, sctp_stream_value], len len[val])",
+    "getsockopt$KGPT_SCTP_INTERLEAVING_SUPPORTED": "getsockopt$KGPT_SCTP_INTERLEAVING_SUPPORTED(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_INTERLEAVING_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_REUSE_PORT": "getsockopt$KGPT_SCTP_REUSE_PORT(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_REUSE_PORT], val ptr[out, int32], len len[val])",
+    "getsockopt$KGPT_SCTP_EVENT": "getsockopt$KGPT_SCTP_EVENT(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_EVENT], val ptr[inout, sctp_event_subscribe], len len[val])",
+    "getsockopt$KGPT_SCTP_ASCONF_SUPPORTED": "getsockopt$KGPT_SCTP_ASCONF_SUPPORTED(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_ASCONF_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_AUTH_SUPPORTED": "getsockopt$KGPT_SCTP_AUTH_SUPPORTED(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_AUTH_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_ECN_SUPPORTED": "getsockopt$KGPT_SCTP_ECN_SUPPORTED(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_ECN_SUPPORTED], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_EXPOSE_POTENTIALLY_FAILED_STATE": "getsockopt$KGPT_SCTP_EXPOSE_POTENTIALLY_FAILED_STATE(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_EXPOSE_POTENTIALLY_FAILED_STATE], val ptr[inout, sctp_assoc_value], len len[val])",
+    "getsockopt$KGPT_SCTP_REMOTE_UDP_ENCAPS_PORT": "getsockopt$KGPT_SCTP_REMOTE_UDP_ENCAPS_PORT(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_REMOTE_UDP_ENCAPS_PORT], val ptr[in, sctp_udpencaps], len len[val])",
+    "getsockopt$KGPT_SCTP_PLPMTUD_PROBE_INTERVAL": "getsockopt$KGPT_SCTP_PLPMTUD_PROBE_INTERVAL(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_PLPMTUD_PROBE_INTERVAL], val ptr[in, sctp_probeinterval], len len[val])",
+    "setsockopt$KGPT_SCTP_DISABLE_FRAGMENTS": "setsockopt$KGPT_SCTP_DISABLE_FRAGMENTS(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_DISABLE_FRAGMENTS], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_SCTP_SOCKOPT_BINDX_ADD": "setsockopt$KGPT_SCTP_SOCKOPT_BINDX_ADD(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_BINDX_ADD], val ptr[in, array[sockaddr_storage]], len len[val])",
+    "setsockopt$KGPT_SCTP_SOCKOPT_BINDX_REM": "setsockopt$KGPT_SCTP_SOCKOPT_BINDX_REM(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_BINDX_REM], val ptr[in, array[sockaddr_storage]], len len[val])",
+    "setsockopt$KGPT_SCTP_SOCKOPT_CONNECTX_OLD": "setsockopt$KGPT_SCTP_SOCKOPT_CONNECTX_OLD(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_CONNECTX_OLD], val ptr[in, array[sockaddr_storage]], len len[val])",
+    "setsockopt$KGPT_SCTP_SOCKOPT_CONNECTX": "setsockopt$KGPT_SCTP_SOCKOPT_CONNECTX(fd sock_inet6_sctp, level const[SOL_SCTP], opt const[SCTP_SOCKOPT_CONNECTX], val ptr[in, array[sockaddr_storage]], len len[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_inet6_sctp"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/sctp.h",
+    "samples/bpf/net_shared.h",
+    "uapi/linux/in.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_storage": "EXISTING",
+    "sctp_status": "EXISTING",
+    "sctp_event_subscribe": "EXISTING",
+    "sctp_peeloff_arg_t": "EXISTING",
+    "sctp_paddrparams": "EXISTING",
+    "sctp_sack_info": "EXISTING",
+    "sctp_initmsg": "EXISTING",
+    "sctp_getaddrs": "EXISTING",
+    "sctp_getaddrs_old": "EXISTING",
+    "sctp_sndrcvinfo": "EXISTING",
+    "sctp_sndinfo": "EXISTING",
+    "sctp_prim": "EXISTING",
+    "sctp_rtoinfo": "EXISTING",
+    "sctp_assocparams": "EXISTING",
+    "sctp_assoc_value": "EXISTING",
+    "sctp_paddrinfo": "EXISTING",
+    "sctp_setadaptation": "EXISTING",
+    "sctp_hmacalgo": "EXISTING",
+    "sctp_authkeyid": "EXISTING",
+    "sctp_authchunks": "EXISTING",
+    "sctp_assoc_ids": "EXISTING",
+    "sctp_assoc_stats": "EXISTING",
+    "sctp_default_prinfo": "EXISTING",
+    "sctp_prstatus": "EXISTING",
+    "sctp_stream_value": "EXISTING",
+    "sockaddr_in": "EXISTING",
+    "sockaddr_in6": "EXISTING",
+    "sockaddr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/smc_sock_ops#net_smc_af_smc.c:3261.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/smc_sock_ops#net_smc_af_smc.c:3261.json
@@ -1,0 +1,142 @@
+{
+  "socket": {
+    "domain": "AF_SMC",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_smc(domain const[AF_SMC], type const[SOCK_STREAM], proto const[0]) sock_smc"
+  },
+  "resources": {
+    "sock_smc": {
+      "type": "sock",
+      "spec": "resource sock_smc[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_in",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCINQ": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCOUTQ": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCOUTQNSD": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SIOCATMARK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "TCP_ULP": {
+      "level": "SOL_TCP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "TCP_FASTOPEN": {
+      "level": "SOL_TCP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "TCP_FASTOPEN_CONNECT": {
+      "level": "SOL_TCP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "TCP_FASTOPEN_KEY": {
+      "level": "SOL_TCP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "TCP_FASTOPEN_NO_COOKIE": {
+      "level": "SOL_TCP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "TCP_NODELAY": {
+      "level": "SOL_TCP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "TCP_CORK": {
+      "level": "SOL_TCP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "TCP_DEFER_ACCEPT": {
+      "level": "SOL_TCP",
+      "val": "int32",
+      "len": "bytesize[val]"
+    },
+    "SMC_LIMIT_HS": {
+      "level": "SOL_SMC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]",
+      "unknown": []
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "SMC_LIMIT_HS": {
+      "level": "SOL_SMC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "smc_bind",
+    "connect": "smc_connect",
+    "accept": "smc_accept",
+    "poll": "smc_poll",
+    "ioctl": "smc_ioctl",
+    "sendmsg": "smc_sendmsg",
+    "recvmsg": "smc_recvmsg",
+    "setsockopt": "smc_setsockopt",
+    "getsockopt": "smc_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/smc/af_smc.c:3261",
+  "ops_name": "smc_sock_ops",
+  "syscall_specs": {
+    "socket$KGPT_smc": "socket$KGPT_smc(domain const[AF_SMC], type const[SOCK_STREAM], proto const[0]) sock_smc",
+    "bind$KGPT_smc_sock_ops": "bind$KGPT_smc_sock_ops(fd sock_smc, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "connect$KGPT_smc_sock_ops": "connect$KGPT_smc_sock_ops(fd sock_smc, addr ptr[in, sockaddr_in], addrlen len[addr])",
+    "accept4$KGPT_smc_sock_ops": "accept4$KGPT_smc_sock_ops(fd sock_smc, peer ptr[out, sockaddr_in, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_smc",
+    "sendto$KGPT_smc_sock_ops": "sendto$KGPT_smc_sock_ops(fd sock_smc, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "recvfrom$KGPT_smc_sock_ops": "recvfrom$KGPT_smc_sock_ops(fd sock_smc, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_in, opt], addrlen len[addr])",
+    "getsockopt$KGPT_SMC_LIMIT_HS": "getsockopt$KGPT_SMC_LIMIT_HS(fd sock_smc, level const[SOL_SMC], opt const[SMC_LIMIT_HS], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_TCP_ULP": "setsockopt$KGPT_TCP_ULP(fd sock_smc, level const[SOL_TCP], opt const[TCP_ULP], val int32, len bytesize[val])",
+    "setsockopt$KGPT_TCP_FASTOPEN": "setsockopt$KGPT_TCP_FASTOPEN(fd sock_smc, level const[SOL_TCP], opt const[TCP_FASTOPEN], val int32, len bytesize[val])",
+    "setsockopt$KGPT_TCP_FASTOPEN_CONNECT": "setsockopt$KGPT_TCP_FASTOPEN_CONNECT(fd sock_smc, level const[SOL_TCP], opt const[TCP_FASTOPEN_CONNECT], val int32, len bytesize[val])",
+    "setsockopt$KGPT_TCP_FASTOPEN_KEY": "setsockopt$KGPT_TCP_FASTOPEN_KEY(fd sock_smc, level const[SOL_TCP], opt const[TCP_FASTOPEN_KEY], val int32, len bytesize[val])",
+    "setsockopt$KGPT_TCP_FASTOPEN_NO_COOKIE": "setsockopt$KGPT_TCP_FASTOPEN_NO_COOKIE(fd sock_smc, level const[SOL_TCP], opt const[TCP_FASTOPEN_NO_COOKIE], val int32, len bytesize[val])",
+    "setsockopt$KGPT_TCP_NODELAY": "setsockopt$KGPT_TCP_NODELAY(fd sock_smc, level const[SOL_TCP], opt const[TCP_NODELAY], val int32, len bytesize[val])",
+    "setsockopt$KGPT_TCP_CORK": "setsockopt$KGPT_TCP_CORK(fd sock_smc, level const[SOL_TCP], opt const[TCP_CORK], val int32, len bytesize[val])",
+    "setsockopt$KGPT_TCP_DEFER_ACCEPT": "setsockopt$KGPT_TCP_DEFER_ACCEPT(fd sock_smc, level const[SOL_TCP], opt const[TCP_DEFER_ACCEPT], val int32, len bytesize[val])",
+    "setsockopt$KGPT_SMC_LIMIT_HS": "setsockopt$KGPT_SMC_LIMIT_HS(fd sock_smc, level const[SOL_SMC], opt const[SMC_LIMIT_HS], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_smc"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/tcp.h",
+    "linux/socket.h",
+    "uapi/linux/smc.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_in": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/stream_ops#net_tipc_socket.c:3400.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/stream_ops#net_tipc_socket.c:3400.json
@@ -1,0 +1,230 @@
+{
+  "socket": {
+    "domain": "AF_TIPC",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_tipc(domain const[AF_TIPC], type const[SOCK_STREAM], proto const[0]) sock_tipc_stream"
+  },
+  "resources": {
+    "sock_tipc_stream": {
+      "type": "sock",
+      "spec": "resource sock_tipc_stream[sock]"
+    }
+  },
+  "types": {
+    "tipc_uaddr": "tipc_uaddr {\n\tfamily\tint16\n\taddrtype\tint8\n\tscope\tint8\n\tu\ttipc_uaddr_union\n}",
+    "tipc_uaddr_union": "tipc_uaddr_union [\n\tsa\ttipc_service_addr\n\tlookup_node\tint32\n\tsr\ttipc_service_range\n\tsk\ttipc_socket_addr\n]"
+  },
+  "socket_addr": "tipc_uaddr",
+  "ioctls": {},
+  "existing_ioctls": {
+    "SIOCGETLINKNAME": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp",
+        "lnr"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "tipc_node_get_linkname",
+          "copy_to_user"
+        ],
+        "type": [
+          "tipc_sioc_ln_req"
+        ],
+        "usage": [
+          "struct tipc_sioc_ln_req lnr;",
+          "if (copy_from_user(&lnr, argp, sizeof(lnr)))",
+          "if (!tipc_node_get_linkname(net, lnr.bearer_id & 0xffff, lnr.peer, lnr.linkname, TIPC_MAX_LINK_NAME))",
+          "if (copy_to_user(argp, &lnr, sizeof(lnr)))"
+        ]
+      }
+    },
+    "SIOCGETNODEID": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp",
+        "nr"
+      ],
+      "arg_inference": {
+        "function": [
+          "copy_from_user",
+          "tipc_node_get_id",
+          "copy_to_user"
+        ],
+        "type": [
+          "tipc_sioc_nodeid_req"
+        ],
+        "usage": [
+          "struct tipc_sioc_nodeid_req nr;",
+          "if (copy_from_user(&nr, argp, sizeof(nr)))",
+          "if (!tipc_node_get_id(net, nr.peer, nr.node_id))",
+          "if (copy_to_user(argp, &nr, sizeof(nr)))"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "TIPC_IMPORTANCE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_SRC_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_DEST_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_CONN_TIMEOUT": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_NODELAY": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_GROUP_JOIN": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, tipc_group_req]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_MCAST_BROADCAST": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_MCAST_REPLICAST": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "TIPC_GROUP_LEAVE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "TIPC_IMPORTANCE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_SRC_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_DEST_DROPPABLE": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_CONN_TIMEOUT": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_NODE_RECVQ_DEPTH": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_SOCK_RECVQ_DEPTH": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_SOCK_RECVQ_USED": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "TIPC_GROUP_JOIN": {
+      "level": "SOL_TIPC",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": {
+        "function": [
+          "tipc_group_self"
+        ],
+        "type": [
+          "tipc_service_range"
+        ],
+        "usage": [
+          "tipc_group_self(tsk->group, &seq, &scope);\nvalue = seq.type;"
+        ]
+      }
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "tipc_bind",
+    "connect": "tipc_connect",
+    "accept": "tipc_accept",
+    "poll": "tipc_poll",
+    "ioctl": "tipc_ioctl",
+    "sendmsg": "tipc_sendstream",
+    "recvmsg": "tipc_recvstream",
+    "setsockopt": "tipc_setsockopt",
+    "getsockopt": "tipc_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/tipc/socket.c:3400",
+  "ops_name": "stream_ops",
+  "syscall_specs": {
+    "socket$KGPT_tipc": "socket$KGPT_tipc(domain const[AF_TIPC], type const[SOCK_STREAM], proto const[0]) sock_tipc_stream",
+    "bind$KGPT_stream_ops": "bind$KGPT_stream_ops(fd sock_tipc_stream, addr ptr[in, tipc_uaddr], addrlen len[addr])",
+    "connect$KGPT_stream_ops": "connect$KGPT_stream_ops(fd sock_tipc_stream, addr ptr[in, tipc_uaddr], addrlen len[addr])",
+    "accept4$KGPT_stream_ops": "accept4$KGPT_stream_ops(fd sock_tipc_stream, peer ptr[out, tipc_uaddr, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_tipc_stream",
+    "sendto$KGPT_stream_ops": "sendto$KGPT_stream_ops(fd sock_tipc_stream, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, tipc_uaddr, opt], addrlen len[addr])",
+    "recvfrom$KGPT_stream_ops": "recvfrom$KGPT_stream_ops(fd sock_tipc_stream, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, tipc_uaddr, opt], addrlen len[addr])",
+    "getsockopt$KGPT_TIPC_IMPORTANCE": "getsockopt$KGPT_TIPC_IMPORTANCE(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_IMPORTANCE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_SRC_DROPPABLE": "getsockopt$KGPT_TIPC_SRC_DROPPABLE(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_SRC_DROPPABLE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_DEST_DROPPABLE": "getsockopt$KGPT_TIPC_DEST_DROPPABLE(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_DEST_DROPPABLE], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_CONN_TIMEOUT": "getsockopt$KGPT_TIPC_CONN_TIMEOUT(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_CONN_TIMEOUT], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_NODE_RECVQ_DEPTH": "getsockopt$KGPT_TIPC_NODE_RECVQ_DEPTH(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_NODE_RECVQ_DEPTH], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_SOCK_RECVQ_DEPTH": "getsockopt$KGPT_TIPC_SOCK_RECVQ_DEPTH(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_SOCK_RECVQ_DEPTH], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_SOCK_RECVQ_USED": "getsockopt$KGPT_TIPC_SOCK_RECVQ_USED(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_SOCK_RECVQ_USED], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_TIPC_GROUP_JOIN": "getsockopt$KGPT_TIPC_GROUP_JOIN(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_GROUP_JOIN], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_TIPC_IMPORTANCE": "setsockopt$KGPT_TIPC_IMPORTANCE(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_IMPORTANCE], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_SRC_DROPPABLE": "setsockopt$KGPT_TIPC_SRC_DROPPABLE(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_SRC_DROPPABLE], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_DEST_DROPPABLE": "setsockopt$KGPT_TIPC_DEST_DROPPABLE(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_DEST_DROPPABLE], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_CONN_TIMEOUT": "setsockopt$KGPT_TIPC_CONN_TIMEOUT(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_CONN_TIMEOUT], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_NODELAY": "setsockopt$KGPT_TIPC_NODELAY(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_NODELAY], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_GROUP_JOIN": "setsockopt$KGPT_TIPC_GROUP_JOIN(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_GROUP_JOIN], val ptr[in, tipc_group_req], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_MCAST_BROADCAST": "setsockopt$KGPT_TIPC_MCAST_BROADCAST(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_MCAST_BROADCAST], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_MCAST_REPLICAST": "setsockopt$KGPT_TIPC_MCAST_REPLICAST(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_MCAST_REPLICAST], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_TIPC_GROUP_LEAVE": "setsockopt$KGPT_TIPC_GROUP_LEAVE(fd sock_tipc_stream, level const[SOL_TIPC], opt const[TIPC_GROUP_LEAVE], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_tipc"
+  ],
+  "includes": [
+    "uapi/linux/tipc.h",
+    "linux/net.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "tipc_group_req": "EXISTING",
+    "tipc_service_addr": "EXISTING",
+    "tipc_service_range": "EXISTING",
+    "tipc_socket_addr": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/svc_proto_ops#net_atm_svc.c:634.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/svc_proto_ops#net_atm_svc.c:634.json
@@ -1,0 +1,352 @@
+{
+  "socket": {
+    "domain": "AF_ATMSVC",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_atmsvc(domain const[AF_ATMSVC], type const[SOCK_DGRAM], proto const[0]) sock_atmsvc"
+  },
+  "resources": {
+    "sock_atmsvc": {
+      "type": "sock",
+      "spec": "resource sock_atmsvc[sock]"
+    }
+  },
+  "types": {
+    "atm_backend_t": "type atm_backend_t ptr[in, array[int8]]",
+    "atm_dev_stats": "atm_dev_stats {\n\taal0\tatm_aal_stats\n\taal34\tatm_aal_stats\n\taal5\tatm_aal_stats\n}",
+    "atm_ci_range": "type atm_ci_range ptr[in, array[int8]]",
+    "atm_link_rate": "type atm_link_rate ptr[in, array[int8]]",
+    "atm_sap": "atm_sap {\n\tbhli\tatm_bhli\n\tblli\tarray[atm_blli, ATM_MAX_BLLI]\n}",
+    "atm_qos": "atm_qos {\n\ttxtp\tatm_trafprm\n\trxtp\tatm_trafprm\n\taal\tint8\n}",
+    "sockaddr_atmpvc": "sockaddr_atmpvc {\n\tsap_family\tconst[AF_ATMPVC, int16]\n\tsap_addr\tatmpvc_addr\n}",
+    "SOL_SOCKET": "define SOL_SOCKET 1",
+    "SO_ATMQOS": "define SO_ATMQOS 28674",
+    "sockaddr_atmsvc": "sockaddr_atmsvc {\n\tsas_family\tconst[AF_ATMSVC, int16]\n\tsas_addr\tsockaddr_atmsvc_addr\n}",
+    "atm_iobuf": "atm_iobuf {\n\tlength\tint32\n\tbuffer\tptr[inout, array[int8]]\n}",
+    "atm_aal_stats": "type atm_aal_stats ptr[in, array[int8]]",
+    "atm_bhli": "atm_bhli {\n\thl_type\tint8\n\thl_length\tint8\n\thl_info\tarray[int8, ATM_MAX_HLI]\n}",
+    "atm_blli": "atm_blli {\n\tl2_proto\tint8\n\tl2\tatm_blli_l2_union\n\tl3_proto\tint8\n\tl3\tatm_blli_l3_union\n}",
+    "atm_blli_l2_union": "atm_blli_l2_union [\n\titu\tatm_blli_l2_itu\n\tuser\tint8\n]",
+    "atm_blli_l2_itu": "atm_blli_l2_itu {\n\tmode\tint8\n\twindow\tint8\n}",
+    "atm_blli_l3_union": "atm_blli_l3_union [\n\titu\tatm_blli_l3_itu\n\tuser\tint8\n\th310\tatm_blli_l3_h310\n\ttr9577\tatm_blli_l3_tr9577\n]",
+    "atm_blli_l3_itu": "atm_blli_l3_itu {\n\tmode\tint8\n\tdef_size\tint8\n\twindow\tint8\n}",
+    "atm_blli_l3_h310": "atm_blli_l3_h310 {\n\tterm_type\tint8\n\tfw_mpx_cap\tint8\n\tbw_mpx_cap\tint8\n}",
+    "atm_blli_l3_tr9577": "atm_blli_l3_tr9577 {\n\tipi\tint8\n\tsnap\tarray[int8, 5]\n}",
+    "atmpvc_addr": "atmpvc_addr {\n\titf\tint16\n\tvpi\tint16\n\tvci\tint32\n}",
+    "atm_trafprm": "atm_trafprm {\n\ttraffic_class\tint8\n\tmax_pcr\tint32\n\tpcr\tint32\n\tmin_pcr\tint32\n\tmax_cdv\tint32\n\tmax_sdu\tint32\n\ticr\tint32\n\ttbe\tint32\n\tfrtt\tint32:24\n\trif\tint32:4\n\trdf\tint32:4\n\tnrm_pres\tint32:1\n\ttrm_pres\tint32:1\n\tadtf_pres\tint32:1\n\tcdf_pres\tint32:1\n\tnrm\tint32:3\n\ttrm\tint32:3\n\tadtf\tint32:10\n\tcdf\tint32:3\n\tspare\tint32:9\n}",
+    "sockaddr_atmsvc_addr": "sockaddr_atmsvc_addr {\n\tprv\tarray[int8, ATM_ESA_LEN]\n\tpub\tarray[int8, ATM_E164_LEN_ADD_ONE]\n\tlij_type\tint8\n\tlij_id\tint32\n}",
+    "ATM_E164_LEN_ADD_ONE": "define ATM_E164_LEN_ADD_ONE 16",
+    "ATM_ESA_LEN": "define ATM_ESA_LEN 20"
+  },
+  "socket_addr": "sockaddr_atmsvc",
+  "ioctls": {
+    "ATM_SETSC": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ATMSIGD_CTRL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ATMMPC_CTRL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ATMMPC_DATA": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ATMARPD_CTRL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ATMLEC_CTRL": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ATM_RSTADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ATM_SETCIRANGE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SONET_GETSTATZ": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SONET_SETDIAG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SONET_CLRDIAG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "SONET_SETFRAMING": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    },
+    "ATM_ADDPARTY": {
+      "arg": "ptr[in, sockaddr_atmsvc]",
+      "arg_name_in_usage": "arg",
+      "arg_inference": null
+    },
+    "ATM_DROPPARTY": {
+      "arg": "intptr",
+      "arg_name_in_usage": "ep_ref",
+      "arg_inference": null
+    },
+    "ATM_SETBACKEND": {
+      "arg": "intptr",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "ATM_NEWBACKENDIF": {
+      "arg": "ptr[in, atm_backend_t]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "ATM_GETNAMES": {
+      "arg": "ptr[inout, atm_iobuf]",
+      "arg_name_in_usage": "argp",
+      "arg_inference": null
+    },
+    "ATM_GETTYPE": {
+      "arg": "ptr[out, array[int8]]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_GETESI": {
+      "arg": "ptr[out, array[int8]]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_SETESI": {
+      "arg": "ptr[in, array[int8, ESI_LEN]]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_SETESIF": {
+      "arg": "ptr[in, array[int8]]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_GETSTATZ": {
+      "arg": "ptr[out, atm_dev_stats]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_GETSTAT": {
+      "arg": "ptr[out, atm_dev_stats]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_GETCIRANGE": {
+      "arg": "ptr[out, atm_ci_range]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_GETLINKRATE": {
+      "arg": "ptr[out, atm_link_rate]",
+      "arg_name_in_usage": "",
+      "arg_inference": null
+    },
+    "ATM_ADDADDR": {
+      "arg": "ptr[in, sockaddr_atmsvc]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_DELADDR": {
+      "arg": "ptr[in, sockaddr_atmsvc]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_ADDLECSADDR": {
+      "arg": "ptr[in, sockaddr_atmsvc]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_DELLECSADDR": {
+      "arg": "ptr[in, sockaddr_atmsvc]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_GETADDR": {
+      "arg": "ptr[out, array[sockaddr_atmsvc]]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_GETLECSADDR": {
+      "arg": "ptr[out, array[sockaddr_atmsvc]]",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    },
+    "ATM_SETLOOP": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": "buf",
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCOUTQ": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": null
+    },
+    "SIOCINQ": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "arg_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "SO_ATMSAP": {
+      "level": "SOL_ATM",
+      "val": "ptr[in, atm_sap]",
+      "len": "bytesize[val]"
+    },
+    "SO_MULTIPOINT": {
+      "level": "SOL_ATM",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    },
+    "SO_ATMQOS": {
+      "level": "",
+      "val": "ptr[in, atm_qos]",
+      "len": "bytesize[val]",
+      "SO_SETCLP": {
+        "level": "",
+        "val": "ptr[in, int32]",
+        "len": "bytesize[val]",
+        "unknown": []
+      },
+      "types": {
+        "atm_qos": "UNKNOWN"
+      }
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "SO_ATMSAP": {
+      "level": "SOL_ATM",
+      "val": "ptr[out, atm_sap]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_ATMQOS": {
+      "level": "SOL_ATM",
+      "val": "ptr[out, atm_qos]",
+      "len": "ptr[in, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_SETCLP": {
+      "level": "SOL_ATM",
+      "val": "ptr[out, int32]",
+      "len": "ptr[in, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_ATMPVC": {
+      "level": "SOL_ATM",
+      "val": "ptr[out, sockaddr_atmpvc]",
+      "len": "ptr[in, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "svc_bind",
+    "connect": "svc_connect",
+    "accept": "svc_accept",
+    "poll": "vcc_poll",
+    "ioctl": "svc_ioctl",
+    "sendmsg": "vcc_sendmsg",
+    "recvmsg": "vcc_recvmsg",
+    "setsockopt": "svc_setsockopt",
+    "getsockopt": "svc_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/atm/svc.c:634",
+  "ops_name": "svc_proto_ops",
+  "syscall_specs": {
+    "socket$KGPT_atmsvc": "socket$KGPT_atmsvc(domain const[AF_ATMSVC], type const[SOCK_DGRAM], proto const[0]) sock_atmsvc",
+    "bind$KGPT_svc_proto_ops": "bind$KGPT_svc_proto_ops(fd sock_atmsvc, addr ptr[in, sockaddr_atmsvc], addrlen len[addr])",
+    "connect$KGPT_svc_proto_ops": "connect$KGPT_svc_proto_ops(fd sock_atmsvc, addr ptr[in, sockaddr_atmsvc], addrlen len[addr])",
+    "accept4$KGPT_svc_proto_ops": "accept4$KGPT_svc_proto_ops(fd sock_atmsvc, peer ptr[out, sockaddr_atmsvc, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_atmsvc",
+    "sendto$KGPT_svc_proto_ops": "sendto$KGPT_svc_proto_ops(fd sock_atmsvc, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_atmsvc, opt], addrlen len[addr])",
+    "recvfrom$KGPT_svc_proto_ops": "recvfrom$KGPT_svc_proto_ops(fd sock_atmsvc, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_atmsvc, opt], addrlen len[addr])",
+    "ioctl$KGPT_ATM_SETSC": "ioctl$KGPT_ATM_SETSC(fd sock_atmsvc, cmd const[ATM_SETSC], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ATMSIGD_CTRL": "ioctl$KGPT_ATMSIGD_CTRL(fd sock_atmsvc, cmd const[ATMSIGD_CTRL], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ATMMPC_CTRL": "ioctl$KGPT_ATMMPC_CTRL(fd sock_atmsvc, cmd const[ATMMPC_CTRL], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ATMMPC_DATA": "ioctl$KGPT_ATMMPC_DATA(fd sock_atmsvc, cmd const[ATMMPC_DATA], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ATMARPD_CTRL": "ioctl$KGPT_ATMARPD_CTRL(fd sock_atmsvc, cmd const[ATMARPD_CTRL], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ATMLEC_CTRL": "ioctl$KGPT_ATMLEC_CTRL(fd sock_atmsvc, cmd const[ATMLEC_CTRL], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ATM_RSTADDR": "ioctl$KGPT_ATM_RSTADDR(fd sock_atmsvc, cmd const[ATM_RSTADDR], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ATM_SETCIRANGE": "ioctl$KGPT_ATM_SETCIRANGE(fd sock_atmsvc, cmd const[ATM_SETCIRANGE], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SONET_GETSTATZ": "ioctl$KGPT_SONET_GETSTATZ(fd sock_atmsvc, cmd const[SONET_GETSTATZ], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SONET_SETDIAG": "ioctl$KGPT_SONET_SETDIAG(fd sock_atmsvc, cmd const[SONET_SETDIAG], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SONET_CLRDIAG": "ioctl$KGPT_SONET_CLRDIAG(fd sock_atmsvc, cmd const[SONET_CLRDIAG], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SONET_SETFRAMING": "ioctl$KGPT_SONET_SETFRAMING(fd sock_atmsvc, cmd const[SONET_SETFRAMING], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ATM_ADDPARTY": "ioctl$KGPT_ATM_ADDPARTY(fd sock_atmsvc, cmd const[ATM_ADDPARTY], arg ptr[in, sockaddr_atmsvc])",
+    "ioctl$KGPT_ATM_DROPPARTY": "ioctl$KGPT_ATM_DROPPARTY(fd sock_atmsvc, cmd const[ATM_DROPPARTY], arg intptr)",
+    "ioctl$KGPT_ATM_SETBACKEND": "ioctl$KGPT_ATM_SETBACKEND(fd sock_atmsvc, cmd const[ATM_SETBACKEND], arg intptr)",
+    "ioctl$KGPT_ATM_NEWBACKENDIF": "ioctl$KGPT_ATM_NEWBACKENDIF(fd sock_atmsvc, cmd const[ATM_NEWBACKENDIF], arg ptr[in, atm_backend_t])",
+    "ioctl$KGPT_ATM_GETNAMES": "ioctl$KGPT_ATM_GETNAMES(fd sock_atmsvc, cmd const[ATM_GETNAMES], arg ptr[inout, atm_iobuf])",
+    "ioctl$KGPT_ATM_GETTYPE": "ioctl$KGPT_ATM_GETTYPE(fd sock_atmsvc, cmd const[ATM_GETTYPE], arg ptr[out, array[int8]])",
+    "ioctl$KGPT_ATM_GETESI": "ioctl$KGPT_ATM_GETESI(fd sock_atmsvc, cmd const[ATM_GETESI], arg ptr[out, array[int8]])",
+    "ioctl$KGPT_ATM_SETESI": "ioctl$KGPT_ATM_SETESI(fd sock_atmsvc, cmd const[ATM_SETESI], arg ptr[in, array[int8, ESI_LEN]])",
+    "ioctl$KGPT_ATM_SETESIF": "ioctl$KGPT_ATM_SETESIF(fd sock_atmsvc, cmd const[ATM_SETESIF], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_ATM_GETSTATZ": "ioctl$KGPT_ATM_GETSTATZ(fd sock_atmsvc, cmd const[ATM_GETSTATZ], arg ptr[out, atm_dev_stats])",
+    "ioctl$KGPT_ATM_GETSTAT": "ioctl$KGPT_ATM_GETSTAT(fd sock_atmsvc, cmd const[ATM_GETSTAT], arg ptr[out, atm_dev_stats])",
+    "ioctl$KGPT_ATM_GETCIRANGE": "ioctl$KGPT_ATM_GETCIRANGE(fd sock_atmsvc, cmd const[ATM_GETCIRANGE], arg ptr[out, atm_ci_range])",
+    "ioctl$KGPT_ATM_GETLINKRATE": "ioctl$KGPT_ATM_GETLINKRATE(fd sock_atmsvc, cmd const[ATM_GETLINKRATE], arg ptr[out, atm_link_rate])",
+    "ioctl$KGPT_ATM_ADDADDR": "ioctl$KGPT_ATM_ADDADDR(fd sock_atmsvc, cmd const[ATM_ADDADDR], arg ptr[in, sockaddr_atmsvc])",
+    "ioctl$KGPT_ATM_DELADDR": "ioctl$KGPT_ATM_DELADDR(fd sock_atmsvc, cmd const[ATM_DELADDR], arg ptr[in, sockaddr_atmsvc])",
+    "ioctl$KGPT_ATM_ADDLECSADDR": "ioctl$KGPT_ATM_ADDLECSADDR(fd sock_atmsvc, cmd const[ATM_ADDLECSADDR], arg ptr[in, sockaddr_atmsvc])",
+    "ioctl$KGPT_ATM_DELLECSADDR": "ioctl$KGPT_ATM_DELLECSADDR(fd sock_atmsvc, cmd const[ATM_DELLECSADDR], arg ptr[in, sockaddr_atmsvc])",
+    "ioctl$KGPT_ATM_GETADDR": "ioctl$KGPT_ATM_GETADDR(fd sock_atmsvc, cmd const[ATM_GETADDR], arg ptr[out, array[sockaddr_atmsvc]])",
+    "ioctl$KGPT_ATM_GETLECSADDR": "ioctl$KGPT_ATM_GETLECSADDR(fd sock_atmsvc, cmd const[ATM_GETLECSADDR], arg ptr[out, array[sockaddr_atmsvc]])",
+    "ioctl$KGPT_ATM_SETLOOP": "ioctl$KGPT_ATM_SETLOOP(fd sock_atmsvc, cmd const[ATM_SETLOOP], arg ptr[in, array[int8]])",
+    "getsockopt$KGPT_SO_ATMSAP": "getsockopt$KGPT_SO_ATMSAP(fd sock_atmsvc, level const[SOL_ATM], opt const[SO_ATMSAP], val ptr[out, atm_sap], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_ATMQOS": "getsockopt$KGPT_SO_ATMQOS(fd sock_atmsvc, level const[SOL_ATM], opt const[SO_ATMQOS], val ptr[out, atm_qos], len ptr[in, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_SETCLP": "getsockopt$KGPT_SO_SETCLP(fd sock_atmsvc, level const[SOL_ATM], opt const[SO_SETCLP], val ptr[out, int32], len ptr[in, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_ATMPVC": "getsockopt$KGPT_SO_ATMPVC(fd sock_atmsvc, level const[SOL_ATM], opt const[SO_ATMPVC], val ptr[out, sockaddr_atmpvc], len ptr[in, bytesize[val, int32]])",
+    "setsockopt$KGPT_SO_ATMSAP": "setsockopt$KGPT_SO_ATMSAP(fd sock_atmsvc, level const[SOL_ATM], opt const[SO_ATMSAP], val ptr[in, atm_sap], len bytesize[val])",
+    "setsockopt$KGPT_SO_MULTIPOINT": "setsockopt$KGPT_SO_MULTIPOINT(fd sock_atmsvc, level const[SOL_ATM], opt const[SO_MULTIPOINT], val ptr[in, int32], len bytesize[val])",
+    "setsockopt$KGPT_SO_ATMQOS": "setsockopt$KGPT_SO_ATMQOS(fd sock_atmsvc, level const[SOL_SOCKET], opt const[SO_ATMQOS], val ptr[in, atm_qos], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_atmsvc"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/atm.h",
+    "uapi/linux/sonet.h",
+    "uapi/linux/atmsvc.h",
+    "uapi/linux/atmarp.h",
+    "uapi/linux/atmmpc.h",
+    "uapi/linux/atmlec.h",
+    "uapi/linux/atmsap.h",
+    "uapi/linux/atmdev.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {}
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/unix_dgram_ops#net_unix_af_unix.c:871.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/unix_dgram_ops#net_unix_af_unix.c:871.json
@@ -1,0 +1,102 @@
+{
+  "socket": {
+    "domain": "AF_UNIX",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_unix(domain const[AF_UNIX], type const[SOCK_DGRAM], proto const[0]) sock_unix_dgram"
+  },
+  "resources": {
+    "sock_unix_dgram": {
+      "type": "sock",
+      "spec": "resource sock_unix_dgram[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_un",
+  "ioctls": {
+    "SIOCUNIXFILE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "err = put_user(amount, (int __user *)arg);"
+        ]
+      }
+    },
+    "SIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "err = put_user(amount, (int __user *)arg);"
+        ]
+      }
+    },
+    "SIOCATMARK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "err = put_user(answ, (int __user *)arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "unix_bind",
+    "connect": "unix_dgram_connect",
+    "accept": "sock_no_accept",
+    "poll": "unix_dgram_poll",
+    "ioctl": "unix_ioctl",
+    "sendmsg": "unix_dgram_sendmsg",
+    "recvmsg": "unix_dgram_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/unix/af_unix.c:871",
+  "ops_name": "unix_dgram_ops",
+  "syscall_specs": {
+    "socket$KGPT_unix": "socket$KGPT_unix(domain const[AF_UNIX], type const[SOCK_DGRAM], proto const[0]) sock_unix_dgram",
+    "bind$KGPT_unix_dgram_ops": "bind$KGPT_unix_dgram_ops(fd sock_unix_dgram, addr ptr[in, sockaddr_un], addrlen len[addr])",
+    "connect$KGPT_unix_dgram_ops": "connect$KGPT_unix_dgram_ops(fd sock_unix_dgram, addr ptr[in, sockaddr_un], addrlen len[addr])",
+    "accept4$KGPT_unix_dgram_ops": "accept4$KGPT_unix_dgram_ops(fd sock_unix_dgram, peer ptr[out, sockaddr_un, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_unix_dgram",
+    "sendto$KGPT_unix_dgram_ops": "sendto$KGPT_unix_dgram_ops(fd sock_unix_dgram, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_un, opt], addrlen len[addr])",
+    "recvfrom$KGPT_unix_dgram_ops": "recvfrom$KGPT_unix_dgram_ops(fd sock_unix_dgram, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_un, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCUNIXFILE": "ioctl$KGPT_SIOCUNIXFILE(fd sock_unix_dgram, cmd const[SIOCUNIXFILE], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_unix"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/un.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_un": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/unix_seqpacket_ops#net_unix_af_unix.c:895.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/unix_seqpacket_ops#net_unix_af_unix.c:895.json
@@ -1,0 +1,102 @@
+{
+  "socket": {
+    "domain": "AF_UNIX",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_unix(domain const[AF_UNIX], type const[SOCK_SEQPACKET], proto const[0]) sock_unix"
+  },
+  "resources": {
+    "sock_unix": {
+      "type": "sock",
+      "spec": "resource sock_unix[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_un",
+  "ioctls": {
+    "SIOCUNIXFILE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "err = put_user(amount, (int __user *)arg);"
+        ]
+      }
+    },
+    "SIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "err = put_user(amount, (int __user *)arg);"
+        ]
+      }
+    },
+    "SIOCATMARK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "err = put_user(answ, (int __user *)arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "unix_bind",
+    "connect": "unix_stream_connect",
+    "accept": "unix_accept",
+    "poll": "unix_dgram_poll",
+    "ioctl": "unix_ioctl",
+    "sendmsg": "unix_seqpacket_sendmsg",
+    "recvmsg": "unix_seqpacket_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/unix/af_unix.c:895",
+  "ops_name": "unix_seqpacket_ops",
+  "syscall_specs": {
+    "socket$KGPT_unix": "socket$KGPT_unix(domain const[AF_UNIX], type const[SOCK_SEQPACKET], proto const[0]) sock_unix",
+    "bind$KGPT_unix_seqpacket_ops": "bind$KGPT_unix_seqpacket_ops(fd sock_unix, addr ptr[in, sockaddr_un], addrlen len[addr])",
+    "connect$KGPT_unix_seqpacket_ops": "connect$KGPT_unix_seqpacket_ops(fd sock_unix, addr ptr[in, sockaddr_un], addrlen len[addr])",
+    "accept4$KGPT_unix_seqpacket_ops": "accept4$KGPT_unix_seqpacket_ops(fd sock_unix, peer ptr[out, sockaddr_un, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_unix",
+    "sendto$KGPT_unix_seqpacket_ops": "sendto$KGPT_unix_seqpacket_ops(fd sock_unix, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_un, opt], addrlen len[addr])",
+    "recvfrom$KGPT_unix_seqpacket_ops": "recvfrom$KGPT_unix_seqpacket_ops(fd sock_unix, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_un, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCUNIXFILE": "ioctl$KGPT_SIOCUNIXFILE(fd sock_unix, cmd const[SIOCUNIXFILE], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_unix"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/un.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_un": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/unix_stream_ops#net_unix_af_unix.c:846.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/unix_stream_ops#net_unix_af_unix.c:846.json
@@ -1,0 +1,103 @@
+{
+  "socket": {
+    "domain": "AF_UNIX",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_unix(domain const[AF_UNIX], type const[SOCK_STREAM], proto const[0]) sock_unix_stream",
+    "resources": {
+      "sock_unix_stream": {
+        "type": "sock",
+        "spec": "resource sock_unix_stream[sock]"
+      }
+    },
+    "types": {}
+  },
+  "socket_addr": "sockaddr_un",
+  "types": {},
+  "ioctls": {
+    "SIOCUNIXFILE": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "arg_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "SIOCOUTQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "err = put_user(amount, (int __user *)arg);"
+        ]
+      }
+    },
+    "SIOCINQ": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "err = put_user(amount, (int __user *)arg);"
+        ]
+      }
+    },
+    "SIOCATMARK": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "arg"
+      ],
+      "arg_inference": {
+        "function": [
+          "put_user"
+        ],
+        "type": [],
+        "usage": [
+          "err = put_user(answ, (int __user *)arg);"
+        ]
+      }
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "proto_ops": {
+    "bind": "unix_bind",
+    "connect": "unix_stream_connect",
+    "accept": "unix_accept",
+    "poll": "unix_poll",
+    "ioctl": "unix_ioctl",
+    "sendmsg": "unix_stream_sendmsg",
+    "recvmsg": "unix_stream_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/unix/af_unix.c:846",
+  "ops_name": "unix_stream_ops",
+  "syscall_specs": {
+    "socket$KGPT_unix": "socket$KGPT_unix(domain const[AF_UNIX], type const[SOCK_STREAM], proto const[0]) sock_unix_stream",
+    "bind$KGPT_unix_stream_ops": "bind$KGPT_unix_stream_ops(fd sock_unix_stream, addr ptr[in, sockaddr_un], addrlen len[addr])",
+    "connect$KGPT_unix_stream_ops": "connect$KGPT_unix_stream_ops(fd sock_unix_stream, addr ptr[in, sockaddr_un], addrlen len[addr])",
+    "accept4$KGPT_unix_stream_ops": "accept4$KGPT_unix_stream_ops(fd sock_unix_stream, peer ptr[out, sockaddr_un, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_unix_stream",
+    "sendto$KGPT_unix_stream_ops": "sendto$KGPT_unix_stream_ops(fd sock_unix_stream, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_un, opt], addrlen len[addr])",
+    "recvfrom$KGPT_unix_stream_ops": "recvfrom$KGPT_unix_stream_ops(fd sock_unix_stream, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_un, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCUNIXFILE": "ioctl$KGPT_SIOCUNIXFILE(fd sock_unix_stream, cmd const[SIOCUNIXFILE], arg ptr[in, array[int8]])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_unix"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/un.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_un": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/vsock_dgram_ops#net_vmw_vsock_af_vsock.c:1295.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/vsock_dgram_ops#net_vmw_vsock_af_vsock.c:1295.json
@@ -1,0 +1,45 @@
+{
+  "socket": {
+    "domain": "PF_VSOCK",
+    "type": "SOCK_DGRAM",
+    "spec": "socket$KGPT_vsock_dgram_ops(domain const[PF_VSOCK], type const[SOCK_DGRAM], proto const[0]) sock_vsock_dgram"
+  },
+  "resources": {
+    "sock_vsock_dgram": {
+      "type": "sock",
+      "spec": "resource sock_vsock_dgram[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_vm",
+  "proto_ops": {
+    "bind": "vsock_bind",
+    "connect": "vsock_dgram_connect",
+    "accept": "sock_no_accept",
+    "poll": "vsock_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "vsock_dgram_sendmsg",
+    "recvmsg": "vsock_dgram_recvmsg"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/vmw_vsock/af_vsock.c:1295",
+  "ops_name": "vsock_dgram_ops",
+  "syscall_specs": {
+    "socket$KGPT_vsock_dgram_ops": "socket$KGPT_vsock_dgram_ops(domain const[PF_VSOCK], type const[SOCK_DGRAM], proto const[0]) sock_vsock_dgram",
+    "bind$KGPT_vsock_dgram_ops": "bind$KGPT_vsock_dgram_ops(fd sock_vsock_dgram, addr ptr[in, sockaddr_vm], addrlen len[addr])",
+    "connect$KGPT_vsock_dgram_ops": "connect$KGPT_vsock_dgram_ops(fd sock_vsock_dgram, addr ptr[in, sockaddr_vm], addrlen len[addr])",
+    "accept4$KGPT_vsock_dgram_ops": "accept4$KGPT_vsock_dgram_ops(fd sock_vsock_dgram, peer ptr[out, sockaddr_vm, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_vsock_dgram",
+    "sendto$KGPT_vsock_dgram_ops": "sendto$KGPT_vsock_dgram_ops(fd sock_vsock_dgram, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_vm, opt], addrlen len[addr])",
+    "recvfrom$KGPT_vsock_dgram_ops": "recvfrom$KGPT_vsock_dgram_ops(fd sock_vsock_dgram, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_vm, opt], addrlen len[addr])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_vsock_dgram_ops"
+  ],
+  "includes": [
+    "linux/net.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_vm": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/vsock_seqpacket_ops#net_vmw_vsock_af_vsock.c:2296.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/vsock_seqpacket_ops#net_vmw_vsock_af_vsock.c:2296.json
@@ -1,0 +1,130 @@
+{
+  "socket": {
+    "domain": "AF_VSOCK",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_vsock_seqpacket_ops(domain const[AF_VSOCK], type const[SOCK_SEQPACKET], proto const[0]) sock_vsock"
+  },
+  "resources": {
+    "sock_vsock": {
+      "type": "sock",
+      "spec": "resource sock_vsock[sock]"
+    }
+  },
+  "types": {
+    "__kernel_sock_timeval": "__kernel_sock_timeval {\n\ttv_sec\tint64\n\ttv_usec\tint64\n}",
+    "__kernel_old_timeval": "__kernel_old_timeval {\n\ttv_sec\tint64\n\ttv_usec\tint64\n}"
+  },
+  "socket_addr": "sockaddr_vm",
+  "setsockopt": {
+    "SO_VM_SOCKETS_BUFFER_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[in, int64]",
+      "len": "bytesize[val]"
+    },
+    "SO_VM_SOCKETS_BUFFER_MAX_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[in, int64]",
+      "len": "bytesize[val]"
+    },
+    "SO_VM_SOCKETS_BUFFER_MIN_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[in, int64]",
+      "len": "bytesize[val]"
+    },
+    "SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW": {
+      "level": "AF_VSOCK",
+      "val": "ptr[in, __kernel_sock_timeval]",
+      "len": "bytesize[val]"
+    },
+    "SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD": {
+      "level": "AF_VSOCK",
+      "val": "ptr[in, __kernel_sock_timeval]",
+      "len": "bytesize[val]"
+    },
+    "SO_ZEROCOPY": {
+      "level": "SOL_SOCKET",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "SO_VM_SOCKETS_BUFFER_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[out, int64]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_VM_SOCKETS_BUFFER_MAX_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[out, int64]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_VM_SOCKETS_BUFFER_MIN_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[out, int64]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW": {
+      "level": "AF_VSOCK",
+      "val": "ptr[out, __kernel_sock_timeval]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD": {
+      "level": "AF_VSOCK",
+      "val": "ptr[out, __kernel_old_timeval]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "vsock_bind",
+    "connect": "vsock_connect",
+    "accept": "vsock_accept",
+    "poll": "vsock_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "vsock_connectible_sendmsg",
+    "recvmsg": "vsock_connectible_recvmsg",
+    "setsockopt": "vsock_connectible_setsockopt",
+    "getsockopt": "vsock_connectible_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/vmw_vsock/af_vsock.c:2296",
+  "ops_name": "vsock_seqpacket_ops",
+  "syscall_specs": {
+    "socket$KGPT_vsock_seqpacket_ops": "socket$KGPT_vsock_seqpacket_ops(domain const[AF_VSOCK], type const[SOCK_SEQPACKET], proto const[0]) sock_vsock",
+    "bind$KGPT_vsock_seqpacket_ops": "bind$KGPT_vsock_seqpacket_ops(fd sock_vsock, addr ptr[in, sockaddr_vm], addrlen len[addr])",
+    "connect$KGPT_vsock_seqpacket_ops": "connect$KGPT_vsock_seqpacket_ops(fd sock_vsock, addr ptr[in, sockaddr_vm], addrlen len[addr])",
+    "accept4$KGPT_vsock_seqpacket_ops": "accept4$KGPT_vsock_seqpacket_ops(fd sock_vsock, peer ptr[out, sockaddr_vm, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_vsock",
+    "sendto$KGPT_vsock_seqpacket_ops": "sendto$KGPT_vsock_seqpacket_ops(fd sock_vsock, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_vm, opt], addrlen len[addr])",
+    "recvfrom$KGPT_vsock_seqpacket_ops": "recvfrom$KGPT_vsock_seqpacket_ops(fd sock_vsock, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_vm, opt], addrlen len[addr])",
+    "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_SIZE": "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_SIZE], val ptr[out, int64], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MAX_SIZE": "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MAX_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_MAX_SIZE], val ptr[out, int64], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MIN_SIZE": "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MIN_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_MIN_SIZE], val ptr[out, int64], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW": "getsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW], val ptr[out, __kernel_sock_timeval], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD": "getsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD], val ptr[out, __kernel_old_timeval], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_SIZE": "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_SIZE], val ptr[in, int64], len bytesize[val])",
+    "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MAX_SIZE": "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MAX_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_MAX_SIZE], val ptr[in, int64], len bytesize[val])",
+    "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MIN_SIZE": "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MIN_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_MIN_SIZE], val ptr[in, int64], len bytesize[val])",
+    "setsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW": "setsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW], val ptr[in, __kernel_sock_timeval], len bytesize[val])",
+    "setsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD": "setsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD], val ptr[in, __kernel_sock_timeval], len bytesize[val])",
+    "setsockopt$KGPT_SO_ZEROCOPY": "setsockopt$KGPT_SO_ZEROCOPY(fd sock_vsock, level const[SOL_SOCKET], opt const[SO_ZEROCOPY], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_vsock_seqpacket_ops"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/vm_sockets.h",
+    "linux/socket.h",
+    "uapi/asm-generic/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_vm": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/vsock_stream_ops#net_vmw_vsock_af_vsock.c:2274.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/vsock_stream_ops#net_vmw_vsock_af_vsock.c:2274.json
@@ -1,0 +1,130 @@
+{
+  "socket": {
+    "domain": "AF_VSOCK",
+    "type": "SOCK_STREAM",
+    "spec": "socket$KGPT_vsock_stream_ops(domain const[AF_VSOCK], type const[SOCK_STREAM], proto const[0]) sock_vsock"
+  },
+  "resources": {
+    "sock_vsock": {
+      "type": "sock",
+      "spec": "resource sock_vsock[sock]"
+    }
+  },
+  "types": {
+    "__kernel_sock_timeval": "__kernel_sock_timeval {\n\ttv_sec\tint64\n\ttv_usec\tint64\n}",
+    "__kernel_old_timeval": "__kernel_old_timeval {\n\ttv_sec\tint64\n\ttv_usec\tint64\n}"
+  },
+  "socket_addr": "sockaddr_vm",
+  "setsockopt": {
+    "SO_VM_SOCKETS_BUFFER_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[in, int64]",
+      "len": "bytesize[val]"
+    },
+    "SO_VM_SOCKETS_BUFFER_MAX_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[in, int64]",
+      "len": "bytesize[val]"
+    },
+    "SO_VM_SOCKETS_BUFFER_MIN_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[in, int64]",
+      "len": "bytesize[val]"
+    },
+    "SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW": {
+      "level": "AF_VSOCK",
+      "val": "ptr[in, __kernel_sock_timeval]",
+      "len": "bytesize[val]"
+    },
+    "SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD": {
+      "level": "AF_VSOCK",
+      "val": "ptr[in, __kernel_sock_timeval]",
+      "len": "bytesize[val]"
+    },
+    "SO_ZEROCOPY": {
+      "level": "SOL_SOCKET",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "SO_VM_SOCKETS_BUFFER_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[out, int64]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_VM_SOCKETS_BUFFER_MAX_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[out, int64]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_VM_SOCKETS_BUFFER_MIN_SIZE": {
+      "level": "AF_VSOCK",
+      "val": "ptr[out, int64]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW": {
+      "level": "AF_VSOCK",
+      "val": "ptr[out, __kernel_sock_timeval]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    },
+    "SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD": {
+      "level": "AF_VSOCK",
+      "val": "ptr[out, __kernel_old_timeval]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "vsock_bind",
+    "connect": "vsock_connect",
+    "accept": "vsock_accept",
+    "poll": "vsock_poll",
+    "ioctl": "sock_no_ioctl",
+    "sendmsg": "vsock_connectible_sendmsg",
+    "recvmsg": "vsock_connectible_recvmsg",
+    "setsockopt": "vsock_connectible_setsockopt",
+    "getsockopt": "vsock_connectible_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/vmw_vsock/af_vsock.c:2274",
+  "ops_name": "vsock_stream_ops",
+  "syscall_specs": {
+    "socket$KGPT_vsock_stream_ops": "socket$KGPT_vsock_stream_ops(domain const[AF_VSOCK], type const[SOCK_STREAM], proto const[0]) sock_vsock",
+    "bind$KGPT_vsock_stream_ops": "bind$KGPT_vsock_stream_ops(fd sock_vsock, addr ptr[in, sockaddr_vm], addrlen len[addr])",
+    "connect$KGPT_vsock_stream_ops": "connect$KGPT_vsock_stream_ops(fd sock_vsock, addr ptr[in, sockaddr_vm], addrlen len[addr])",
+    "accept4$KGPT_vsock_stream_ops": "accept4$KGPT_vsock_stream_ops(fd sock_vsock, peer ptr[out, sockaddr_vm, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_vsock",
+    "sendto$KGPT_vsock_stream_ops": "sendto$KGPT_vsock_stream_ops(fd sock_vsock, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_vm, opt], addrlen len[addr])",
+    "recvfrom$KGPT_vsock_stream_ops": "recvfrom$KGPT_vsock_stream_ops(fd sock_vsock, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_vm, opt], addrlen len[addr])",
+    "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_SIZE": "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_SIZE], val ptr[out, int64], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MAX_SIZE": "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MAX_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_MAX_SIZE], val ptr[out, int64], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MIN_SIZE": "getsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MIN_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_MIN_SIZE], val ptr[out, int64], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW": "getsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW], val ptr[out, __kernel_sock_timeval], len ptr[inout, bytesize[val, int32]])",
+    "getsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD": "getsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD], val ptr[out, __kernel_old_timeval], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_SIZE": "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_SIZE], val ptr[in, int64], len bytesize[val])",
+    "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MAX_SIZE": "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MAX_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_MAX_SIZE], val ptr[in, int64], len bytesize[val])",
+    "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MIN_SIZE": "setsockopt$KGPT_SO_VM_SOCKETS_BUFFER_MIN_SIZE(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_BUFFER_MIN_SIZE], val ptr[in, int64], len bytesize[val])",
+    "setsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW": "setsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_CONNECT_TIMEOUT_NEW], val ptr[in, __kernel_sock_timeval], len bytesize[val])",
+    "setsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD": "setsockopt$KGPT_SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD(fd sock_vsock, level const[AF_VSOCK], opt const[SO_VM_SOCKETS_CONNECT_TIMEOUT_OLD], val ptr[in, __kernel_sock_timeval], len bytesize[val])",
+    "setsockopt$KGPT_SO_ZEROCOPY": "setsockopt$KGPT_SO_ZEROCOPY(fd sock_vsock, level const[SOL_SOCKET], opt const[SO_ZEROCOPY], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_vsock_stream_ops"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/vm_sockets.h",
+    "linux/socket.h",
+    "uapi/asm-generic/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_vm": "EXISTING"
+  }
+}

--- a/generated-specs/specs-6.7/correct-socket-spec/x25_proto_ops#net_x25_af_x25.c:1738.json
+++ b/generated-specs/specs-6.7/correct-socket-spec/x25_proto_ops#net_x25_af_x25.c:1738.json
@@ -1,0 +1,303 @@
+{
+  "socket": {
+    "domain": "AF_X25",
+    "type": "SOCK_SEQPACKET",
+    "spec": "socket$KGPT_X25(domain const[AF_X25], type const[SOCK_SEQPACKET], proto const[0]) sock_x25"
+  },
+  "resources": {
+    "sock_x25": {
+      "type": "sock",
+      "spec": "resource sock_x25[sock]"
+    }
+  },
+  "types": {},
+  "socket_addr": "sockaddr_x25",
+  "ioctls": {
+    "SIOCGIFMETRIC": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCSIFMETRIC": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    }
+  },
+  "existing_ioctls": {
+    "TIOCOUTQ": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "TIOCINQ": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCGIFADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCSIFADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCGIFDSTADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCSIFDSTADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCGIFBRDADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCSIFBRDADDR": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCGIFNETMASK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCSIFNETMASK": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCADDRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "argument_inference": {
+        "function": [
+          "x25_route_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "rc = x25_route_ioctl(cmd, argp);"
+        ]
+      }
+    },
+    "SIOCDELRT": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "argument_inference": {
+        "function": [
+          "x25_route_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "rc = x25_route_ioctl(cmd, argp);"
+        ]
+      }
+    },
+    "SIOCX25GSUBSCRIP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "argument_inference": {
+        "function": [
+          "x25_subscr_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "rc = x25_subscr_ioctl(cmd, argp);"
+        ]
+      }
+    },
+    "SIOCX25SSUBSCRIP": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "argument_inference": {
+        "function": [
+          "x25_subscr_ioctl"
+        ],
+        "type": [],
+        "usage": [
+          "rc = x25_subscr_ioctl(cmd, argp);"
+        ]
+      }
+    },
+    "SIOCX25GFACILITIES": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCX25SFACILITIES": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "argument_inference": {
+        "function": [],
+        "type": [
+          "x25_facilities"
+        ],
+        "usage": [
+          "if (copy_from_user(&facilities, argp, sizeof(facilities)))"
+        ]
+      }
+    },
+    "SIOCX25GDTEFACILITIES": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCX25SDTEFACILITIES": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "argument_inference": {
+        "function": [],
+        "type": [
+          "x25_dte_facilities"
+        ],
+        "usage": [
+          "if (copy_from_user(&dtefacs, argp, sizeof(dtefacs)))"
+        ]
+      }
+    },
+    "SIOCX25GCALLUSERDATA": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCX25SCALLUSERDATA": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "argument_inference": {
+        "function": [],
+        "type": [
+          "x25_calluserdata"
+        ],
+        "usage": [
+          "if (copy_from_user(&calluserdata, argp, sizeof(calluserdata)))"
+        ]
+      }
+    },
+    "SIOCX25GCAUSEDIAG": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCX25SCAUSEDIAG": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "argument_inference": {
+        "function": [],
+        "type": [
+          "x25_causediag"
+        ],
+        "usage": [
+          "if (copy_from_user(&causediag, argp, sizeof(causediag)))"
+        ]
+      }
+    },
+    "SIOCX25SCUDMATCHLEN": {
+      "arg": "UNKNOWN_ARG",
+      "arg_name_in_usage": [
+        "argp"
+      ],
+      "argument_inference": {
+        "function": [],
+        "type": [
+          "x25_subaddr"
+        ],
+        "usage": [
+          "if (copy_from_user(&sub_addr, argp, sizeof(sub_addr)))"
+        ]
+      }
+    },
+    "SIOCX25CALLACCPTAPPRV": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    },
+    "SIOCX25SENDCALLACCPT": {
+      "arg": "UNUSED_ARG",
+      "arg_name_in_usage": [],
+      "argument_inference": null
+    }
+  },
+  "unknown_cmd_ioctls": {},
+  "setsockopt": {
+    "X25_QBITINCL": {
+      "level": "SOL_X25",
+      "val": "ptr[in, int32]",
+      "len": "bytesize[val]"
+    }
+  },
+  "unknown": [],
+  "setsockopt_unknown": [],
+  "getsockopt": {
+    "X25_QBITINCL": {
+      "level": "SOL_X25",
+      "val": "ptr[out, int32]",
+      "len": "ptr[inout, bytesize[val, int32]]",
+      "val_inference": null
+    }
+  },
+  "getsockopt_unknown": [],
+  "proto_ops": {
+    "bind": "x25_bind",
+    "connect": "x25_connect",
+    "accept": "x25_accept",
+    "poll": "datagram_poll",
+    "ioctl": "x25_ioctl",
+    "sendmsg": "x25_sendmsg",
+    "recvmsg": "x25_recvmsg",
+    "setsockopt": "x25_setsockopt",
+    "getsockopt": "x25_getsockopt"
+  },
+  "path": "/scratch/xxxxxx-data/xxxxxx/linux/net/x25/af_x25.c:1738",
+  "ops_name": "x25_proto_ops",
+  "syscall_specs": {
+    "socket$KGPT_X25": "socket$KGPT_X25(domain const[AF_X25], type const[SOCK_SEQPACKET], proto const[0]) sock_x25",
+    "bind$KGPT_x25_proto_ops": "bind$KGPT_x25_proto_ops(fd sock_x25, addr ptr[in, sockaddr_x25], addrlen len[addr])",
+    "connect$KGPT_x25_proto_ops": "connect$KGPT_x25_proto_ops(fd sock_x25, addr ptr[in, sockaddr_x25], addrlen len[addr])",
+    "accept4$KGPT_x25_proto_ops": "accept4$KGPT_x25_proto_ops(fd sock_x25, peer ptr[out, sockaddr_x25, opt], peerlen ptr[inout, len[peer, int32]], flags flags[accept_flags]) sock_x25",
+    "sendto$KGPT_x25_proto_ops": "sendto$KGPT_x25_proto_ops(fd sock_x25, buf ptr[in, array[int8]], len len[buf], f flags[send_flags], addr ptr[in, sockaddr_x25, opt], addrlen len[addr])",
+    "recvfrom$KGPT_x25_proto_ops": "recvfrom$KGPT_x25_proto_ops(fd sock_x25, buf ptr[out, array[int8]], len len[buf], f flags[recv_flags], addr ptr[in, sockaddr_x25, opt], addrlen len[addr])",
+    "ioctl$KGPT_SIOCGIFMETRIC": "ioctl$KGPT_SIOCGIFMETRIC(fd sock_x25, cmd const[SIOCGIFMETRIC], arg ptr[in, array[int8]])",
+    "ioctl$KGPT_SIOCSIFMETRIC": "ioctl$KGPT_SIOCSIFMETRIC(fd sock_x25, cmd const[SIOCSIFMETRIC], arg ptr[in, array[int8]])",
+    "getsockopt$KGPT_X25_QBITINCL": "getsockopt$KGPT_X25_QBITINCL(fd sock_x25, level const[SOL_X25], opt const[X25_QBITINCL], val ptr[out, int32], len ptr[inout, bytesize[val, int32]])",
+    "setsockopt$KGPT_X25_QBITINCL": "setsockopt$KGPT_X25_QBITINCL(fd sock_x25, level const[SOL_X25], opt const[X25_QBITINCL], val ptr[in, int32], len bytesize[val])"
+  },
+  "init_syscalls": [
+    "socket$KGPT_X25"
+  ],
+  "includes": [
+    "linux/net.h",
+    "uapi/linux/sockios.h",
+    "uapi/linux/x25.h",
+    "net/x25.h",
+    "linux/socket.h"
+  ],
+  "unused_types": {},
+  "ignored_types": {
+    "sockaddr_x25": "EXISTING",
+    "x25_address": "EXISTING"
+  }
+}


### PR DESCRIPTION
Add the generated specifications for Linux 6.7 as described in the paper. Refer to `spec-eval/run-specs.py` for instructions on running these specifications with Syzkaller.







